### PR TITLE
docs(pr): publish safe multi-mode diagnostics templates (#9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,12 @@ jobs:
 
       - name: Lint workflows
         shell: bash
-        run: ./actionlint -color
+        run: |
+          set -euo pipefail
+          ./actionlint -color
+          ./actionlint -color \
+            docs/examples/comparevi-history-workflow-dispatch.yml \
+            docs/examples/comparevi-history-comment-gated.yml
 
       - name: Validate backend pin and facade scripts
         shell: pwsh
@@ -100,6 +105,7 @@ jobs:
               ('- Backend bundle asset: `{0}`' -f $bundleAsset.name)
               '- PowerShell facade scripts parsed successfully'
               '- Branch-protection drift script parsed successfully'
+              '- Consumer PR-diagnostics example workflows linted successfully'
               '- Generated smoke stub parsed successfully'
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The facade forwards the underlying history outputs from `compare-vi-cli-action`,
 
 - Treat this action as a trusted-runner workflow primitive. Real VI History diagnostics should run only on Windows runners that you control and that already satisfy the LabVIEW/LVCompare prerequisites of the backend tooling.
 - The action fails closed on `pull_request` and `pull_request_target` events for forked repositories. For public repositories, use comment-gated or maintainer-dispatched workflows for PR diagnostics instead of running the facade directly on fork PR events.
+- Consumer-ready public PR diagnostics templates are published in `docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md`. The published default mode bundle is `default,attributes,front-panel,block-diagram` so public diagnostics cover more than a single broad lane.
 - `comparevi_repository`, `comparevi_ref`, and `invoke_script_path` are maintainer-only overrides. The action rejects them when the PR context is not provably repo-local and trusted, and normal consumer workflows should leave them at their defaults.
 - When `comparevi_ref` targets a published backend release tag, the action stays on the bundle path. When a maintainer points `comparevi_ref` at an unreleased branch/commit/SHA, the action falls back to a source checkout for that explicit override only.
 - Do not expose this action to untrusted fork pull requests with write-scoped tokens or secrets. `pull_request_target` against a fork is treated as unsafe by default because the facade assumes trusted refs and a trusted runner.

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -1,0 +1,69 @@
+# Safe PR Diagnostics Templates
+
+These templates show how to use `comparevi-history` safely in public repositories without violating the facade trust
+guard, and they default to a broader mode bundle than a single `default` pass.
+
+## Published Templates
+
+- Maintainer-dispatched template:
+  [comparevi-history-workflow-dispatch.yml](examples/comparevi-history-workflow-dispatch.yml)
+- Comment-gated template:
+  [comparevi-history-comment-gated.yml](examples/comparevi-history-comment-gated.yml)
+
+## Recommended Mode Coverage
+
+The published examples default to:
+
+```text
+default,attributes,front-panel,block-diagram
+```
+
+That bundle is intentional:
+
+- `default` keeps the broad baseline compare lane.
+- `attributes` surfaces VI attribute drift explicitly.
+- `front-panel` isolates front-panel changes that often matter in UI-facing PRs.
+- `block-diagram` adds functional and cosmetic block-diagram coverage that a narrow single-mode demo would miss.
+
+If your consumer repository needs a narrower or broader set, adjust the `compare_modes` input or command override, but
+keep the default bundle as the starting point for public PR diagnostics.
+
+## Use These Patterns
+
+- Use the maintainer-dispatched template when a maintainer wants to inspect a specific pull request on demand.
+- Use the comment-gated template when you want a slash command such as
+  `/comparevi-history Tooling/deployment/VIP_Post-Install Custom Action.vi --modes default,attributes,front-panel,block-diagram`
+  to trigger diagnostics from a trusted maintainer comment.
+- Run both patterns only on trusted Windows runners that already satisfy the backend LabVIEW and LVCompare
+  prerequisites.
+
+## Do Not Use These Patterns
+
+- Do not run `comparevi-history` directly from `pull_request` on public fork PRs. The facade intentionally fails closed
+  there because the event does not prove a trusted runner or trusted refs.
+- Do not use `pull_request_target` to run the facade automatically against fork content with write-scoped tokens or
+  secrets. That pattern crosses the trust boundary the guard is designed to enforce.
+- Do not pin consumer workflows to branch refs such as `@main`, `@develop`, or unpublished SHAs. Use released facade
+  refs only.
+- Do not hide the mode list inside local wrapper scripts. Public PR diagnostics should make the executed mode bundle
+  obvious in the workflow file, summary, and PR comment so reviewers know what coverage they received.
+
+## Template Notes
+
+- The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
+  when you want compatible updates after each reviewed facade release.
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.0.2`. That is the right default when
+  you want the public PR diagnostics surface frozen to a known immutable release.
+- Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with
+  `fetch-depth: 0` so the facade can traverse commit history deterministically.
+- Both templates keep maintainer-only override inputs unset. That aligns with the trust guard and keeps consumers on
+  the normal released bundle path.
+- Both templates surface the mode bundle in artifacts and summaries so maintainers can see the exact coverage that ran.
+
+## Recommended Adoption
+
+1. Start with the maintainer-dispatched template when your project is new to VI History diagnostics.
+2. Keep the default multi-mode bundle unless you have a documented reason to narrow it.
+3. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
+   comments on a trusted runner.
+4. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -1,0 +1,164 @@
+name: CompareVI History Comment-Gated Diagnostics
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  comparevi-history-comment:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/comparevi-history') }}
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+    env:
+      DEFAULT_COMPARE_MODES: default,attributes,front-panel,block-diagram
+      DEFAULT_MAX_PAIRS: '5'
+      DEFAULT_MAX_SIGNAL_PAIRS: '5'
+      FACADE_REF: v1.0.2
+    steps:
+      - name: Validate maintainer command and resolve PR head
+        id: request
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $allowedAssociations = @('OWNER', 'MEMBER', 'COLLABORATOR')
+          if ($env:AUTHOR_ASSOCIATION -notin $allowedAssociations) {
+            throw "Only trusted maintainers may invoke /comparevi-history. Current author_association is '$($env:AUTHOR_ASSOCIATION)'."
+          }
+
+          $command = $env:COMMENT_BODY.Trim()
+          $prefix = '/comparevi-history'
+          if (-not $command.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Unsupported command.'
+          }
+
+          $remainder = $command.Substring($prefix.Length).Trim()
+          if ([string]::IsNullOrWhiteSpace($remainder)) {
+            throw 'Usage: /comparevi-history <repository-relative-vi-path> [--modes comma,list]'
+          }
+
+          $targetPath = $remainder
+          $compareModes = $env:DEFAULT_COMPARE_MODES
+          $modeMarker = ' --modes '
+          $modeIndex = $remainder.IndexOf($modeMarker, [System.StringComparison]::OrdinalIgnoreCase)
+          if ($modeIndex -ge 0) {
+            $targetPath = $remainder.Substring(0, $modeIndex).Trim()
+            $compareModes = $remainder.Substring($modeIndex + $modeMarker.Length).Trim()
+          }
+
+          if ([string]::IsNullOrWhiteSpace($targetPath)) {
+            throw 'The slash command must include a repository-relative VI path.'
+          }
+          if ([string]::IsNullOrWhiteSpace($compareModes)) {
+            $compareModes = $env:DEFAULT_COMPARE_MODES
+          }
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'comparevi-history-template'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/pulls/$env:ISSUE_NUMBER"
+          $pr = Invoke-RestMethod -Uri $uri -Headers $headers
+          if ($pr.state -ne 'open') {
+            throw "Pull request #$($env:ISSUE_NUMBER) is not open."
+          }
+
+          @(
+            "target-path=$targetPath"
+            "compare-modes=$compareModes"
+            "head-repo=$($pr.head.repo.full_name)"
+            "head-sha=$($pr.head.sha)"
+            "head-ref=$($pr.head.ref)"
+            "is-fork=$([bool]$pr.head.repo.fork)"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout PR head repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.request.outputs['head-repo'] }}
+          ref: ${{ steps.request.outputs['head-sha'] }}
+          fetch-depth: 0
+
+      - name: Run comparevi-history
+        id: history
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.2
+        with:
+          target_path: ${{ steps.request.outputs['target-path'] }}
+          start_ref: ${{ steps.request.outputs['head-sha'] }}
+          mode: ${{ steps.request.outputs['compare-modes'] }}
+          max_pairs: ${{ env.DEFAULT_MAX_PAIRS }}
+          max_signal_pairs: ${{ env.DEFAULT_MAX_SIGNAL_PAIRS }}
+          render_report: true
+          detailed: true
+          fail_on_diff: false
+          keep_artifacts_on_no_diff: true
+          results_dir: tests/results/pr-diagnostics/history
+
+      - name: Upload diagnostics artifacts
+        if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-${{ github.event.issue.number }}
+          path: ${{ steps.history.outputs['results-dir'] }}/**
+          if-no-files-found: error
+
+      - name: Post PR comment
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.2
+          TARGET_PATH: ${{ steps.request.outputs['target-path'] }}
+          REQUESTED_MODES: ${{ steps.request.outputs['compare-modes'] }}
+          EXECUTED_MODES: ${{ steps.history.outputs['mode-list'] }}
+          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
+          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
+          STEP_CONCLUSION: ${{ steps.history.conclusion }}
+          IS_FORK: ${{ steps.request.outputs['is-fork'] }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'comparevi-history-template'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $body = @"
+          comparevi-history diagnostics finished for PR #$env:ISSUE_NUMBER.
+
+          - Action ref: `$env:ACTION_REF`
+          - Target path: `$env:TARGET_PATH`
+          - Requested modes: `$env:REQUESTED_MODES`
+          - Executed modes: `$env:EXECUTED_MODES`
+          - Total processed: `$env:TOTAL_PROCESSED`
+          - Total diffs: `$env:TOTAL_DIFFS`
+          - Step conclusion: `$env:STEP_CONCLUSION`
+          - PR head is fork: `$env:IS_FORK`
+          - Run: $runUrl
+          "@.Trim()
+
+          $payload = @{ body = $body } | ConvertTo-Json -Depth 5
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER/comments"
+          Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $payload -ContentType 'application/json'

--- a/docs/examples/comparevi-history-workflow-dispatch.yml
+++ b/docs/examples/comparevi-history-workflow-dispatch.yml
@@ -1,0 +1,131 @@
+name: CompareVI History Manual PR Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to inspect
+        required: true
+        type: string
+      target_path:
+        description: Repository-relative VI path to inspect
+        required: true
+        type: string
+      compare_modes:
+        description: Comma-separated compare mode bundle
+        required: false
+        default: default,attributes,front-panel,block-diagram
+        type: string
+      max_pairs:
+        description: Maximum adjacent commit pairs to process
+        required: false
+        default: '5'
+        type: string
+      max_signal_pairs:
+        description: Maximum surfaced signal pairs
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  comparevi-history-manual:
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+    steps:
+      - name: Resolve pull request head
+        id: pr
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'comparevi-history-template'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/pulls/$env:PULL_REQUEST_NUMBER"
+          $pr = Invoke-RestMethod -Uri $uri -Headers $headers
+          if ($pr.state -ne 'open') {
+            throw "Pull request #$($env:PULL_REQUEST_NUMBER) is not open."
+          }
+
+          @(
+            "head-repo=$($pr.head.repo.full_name)"
+            "head-sha=$($pr.head.sha)"
+            "head-ref=$($pr.head.ref)"
+            "is-fork=$([bool]$pr.head.repo.fork)"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout PR head repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.pr.outputs['head-repo'] }}
+          ref: ${{ steps.pr.outputs['head-sha'] }}
+          fetch-depth: 0
+
+      - name: Run comparevi-history
+        id: history
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1
+        with:
+          target_path: ${{ inputs.target_path }}
+          start_ref: ${{ steps.pr.outputs['head-sha'] }}
+          mode: ${{ inputs.compare_modes }}
+          max_pairs: ${{ inputs.max_pairs }}
+          max_signal_pairs: ${{ inputs.max_signal_pairs }}
+          render_report: true
+          detailed: true
+          fail_on_diff: false
+          keep_artifacts_on_no_diff: true
+          results_dir: tests/results/pr-diagnostics/history
+
+      - name: Upload diagnostics artifacts
+        if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-${{ inputs.pull_request_number }}
+          path: ${{ steps.history.outputs['results-dir'] }}/**
+          if-no-files-found: error
+
+      - name: Summarize diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1
+          PR_NUMBER: ${{ inputs.pull_request_number }}
+          TARGET_PATH: ${{ inputs.target_path }}
+          REQUESTED_MODES: ${{ inputs.compare_modes }}
+          EXECUTED_MODES: ${{ steps.history.outputs['mode-list'] }}
+          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
+          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
+          RESULTS_DIR: ${{ steps.history.outputs['results-dir'] }}
+          IS_FORK: ${{ steps.pr.outputs['is-fork'] }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          @(
+            '## comparevi-history manual PR diagnostics'
+            ''
+            ('- Action ref: `{0}`' -f $env:ACTION_REF)
+            ('- Pull request: `#{0}`' -f $env:PR_NUMBER)
+            ('- Target path: `{0}`' -f $env:TARGET_PATH)
+            ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
+            ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
+            ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)
+            ('- Total diffs: `{0}`' -f $env:TOTAL_DIFFS)
+            ('- Results dir: `{0}`' -f $env:RESULTS_DIR)
+            ('- PR head is fork: `{0}`' -f $env:IS_FORK)
+            ('- Run URL: {0}' -f $runUrl)
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append


### PR DESCRIPTION
## Summary

- publish safe public PR-diagnostics templates for `comparevi-history`
- widen the published default mode coverage to `default,attributes,front-panel,block-diagram`
- lint the example workflow files in CI so the template surface stays executable

## Validation

- `actionlint` on `.github/workflows/ci.yml`, `.github/workflows/branch-protection-drift.yml`, and both example workflow files
- local review of the trust-boundary docs and released-ref pinning

Closes #9