### PR TITLE
Refresh published template release refs (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The facade forwards the underlying history outputs from `compare-vi-cli-action`,
 - Use `.github/workflows/release.yml` to automate backend pin bumps and facade publication.
 - Dispatch it with:
   - `backend_ref`: backend release tag to pin, or another backend ref that already resolves to a published `CompareVI.Tools` bundle
-  - `immutable_tag`: new immutable facade tag such as `v1.0.2`
+  - `immutable_tag`: new immutable facade tag such as `v1.2.3`
   - `major_tag`: moving compatibility tag, normally `v1`
   - `publish`: `false` for smoke-only rehearsal, `true` for a real release from `main`
 - The workflow resolves `backend_ref` to a backend release tag plus source SHA, runs both local and external smoke against that candidate bundle-backed backend, and uploads a release-plan artifact before any publish step runs.

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -62,7 +62,7 @@ keep the default bundle as the starting point for public PR diagnostics.
 
 - The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
   when you want compatible updates after each reviewed facade release.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.0.2`. That is the right default when
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.0.3`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release.
 - Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with
   `fetch-depth: 0` so the facade can traverse commit history deterministically.

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -21,7 +21,7 @@ jobs:
       DEFAULT_COMPARE_MODES: default,attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.0.2
+      FACADE_REF: v1.0.3
     steps:
       - name: Validate maintainer command and resolve PR head
         id: request
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.2
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
         with:
           target_path: ${{ steps.request.outputs['target-path'] }}
           start_ref: ${{ steps.request.outputs['head-sha'] }}
@@ -124,7 +124,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.2
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
           TARGET_PATH: ${{ steps.request.outputs['target-path'] }}
           REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
           EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}


### PR DESCRIPTION
## Summary
Updates the public immutable diagnostics template to point at the newly published `comparevi-history@v1.0.3` release instead of the older `v1.0.2` tag, which predates the new per-mode reviewer-facing outputs. This closes the last public-consumer gap after the `v1.0.3` release and keeps the docs/examples aligned with the released surface that upstream-aligned forks can actually consume.

## Change Surface
- bump the comment-gated example workflow from `@v1.0.2` to `@v1.0.3`
- update the safe diagnostics template guide to reference the new immutable tag
- normalize the README release-input example to a generic immutable-tag example instead of a stale patch number

## Validation
- `actionlint docs/examples/comparevi-history-comment-gated.yml docs/examples/comparevi-history-workflow-dispatch.yml .github/workflows/published-consumer-validation.yml`
- verified published release `v1.0.3` exists and release workflow run `22837095924` passed, including published-consumer validation against `ni/labview-icon-editor`
