### PR TITLE
Harden hosted PR diagnostics templates and comment fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,10 @@ jobs:
             'scripts/Invoke-CompareVIHistoryFacade.ps1',
             'scripts/Format-CompareVIHistoryModeSummary.ps1',
             'scripts/Assert-CompareVIHistoryPublishedRun.ps1',
+            'scripts/Sync-CompareVIHistoryPublishedTemplates.ps1',
             'scripts/Write-CompareVIHistorySmokeStub.ps1',
-            'scripts/Test-CompareVIHistoryBranchProtection.ps1'
+            'scripts/Test-CompareVIHistoryBranchProtection.ps1',
+            'scripts/Test-CompareVIHistoryTemplateContracts.ps1'
           )) {
             $errors = $null
             $tokens = $null
@@ -154,3 +156,4 @@ jobs:
           & "$PWD/scripts/Test-CompareVIHistoryPublishedRefs.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryModeSummary.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryPublishedRun.ps1"
+          & "$PWD/scripts/Test-CompareVIHistoryTemplateContracts.ps1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
       - scripts/Resolve-CompareVIHistoryPublishedRefs.ps1
       - scripts/Format-CompareVIHistoryModeSummary.ps1
       - scripts/Assert-CompareVIHistoryPublishedRun.ps1
+      - scripts/Sync-CompareVIHistoryPublishedTemplates.ps1
+      - scripts/Test-CompareVIHistoryTemplateContracts.ps1
+      - docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+      - docs/examples/comparevi-history-workflow-dispatch.yml
+      - docs/examples/comparevi-history-comment-gated.yml
   workflow_dispatch:
     inputs:
       backend_ref:
@@ -429,9 +434,10 @@ jobs:
           set -euo pipefail
 
           printf '%s\n' "$BACKEND_TAG" > comparevi-backend-ref.txt
+          pwsh -NoLogo -NoProfile -File scripts/Sync-CompareVIHistoryPublishedTemplates.ps1 -ImmutableTag "$IMMUTABLE_TAG" > /dev/null
 
-          if ! git diff --quiet -- comparevi-backend-ref.txt; then
-            git add comparevi-backend-ref.txt
+          if ! git diff --quiet -- comparevi-backend-ref.txt docs/examples/comparevi-history-comment-gated.yml docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md; then
+            git add comparevi-backend-ref.txt docs/examples/comparevi-history-comment-gated.yml docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
             git commit -m "Release comparevi-history $IMMUTABLE_TAG (#1)"
           fi
 
@@ -454,6 +460,7 @@ jobs:
           - Backend source SHA for that tag is \`${BACKEND_SHA}\`
           - \`${IMMUTABLE_TAG}\` is the immutable facade tag for this backend mapping
           - \`${MAJOR_TAG}\` advances only after smoke and release publication succeed
+          - Published comment-gated template now points at \`${IMMUTABLE_TAG}\`
           EOF
 
           echo "target-sha=$target_sha" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The facade forwards the underlying history outputs from `compare-vi-cli-action`,
 
 ## Trust boundaries
 
-- Treat this action as a trusted-runner workflow primitive. Real VI History diagnostics should run only on Windows runners that you control and that already satisfy the LabVIEW/LVCompare prerequisites of the backend tooling.
+- Treat this action as a trusted-runner workflow primitive. Real VI History diagnostics should run only on trusted maintainer-controlled runners, either on self-hosted Windows with the backend prerequisites already installed or through a hosted NI Linux container path wired by a repo-local adapter such as `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`.
 - The action fails closed on `pull_request` and `pull_request_target` events for forked repositories. For public repositories, use comment-gated or maintainer-dispatched workflows for PR diagnostics instead of running the facade directly on fork PR events.
 - Consumer-ready public PR diagnostics templates are published in `docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md`. The published default mode bundle is `default,attributes,front-panel,block-diagram` so public diagnostics cover more than a single broad lane.
 - Reviewer-facing consumers can use `requested-mode-list`, `executed-mode-list`, and `mode-summary-markdown` to surface
@@ -87,6 +87,7 @@ The facade forwards the underlying history outputs from `compare-vi-cli-action`,
 - `comparevi_repository`, `comparevi_ref`, and `invoke_script_path` are maintainer-only overrides. The action rejects them when the PR context is not provably repo-local and trusted, and normal consumer workflows should leave them at their defaults.
 - When `comparevi_ref` targets a published backend release tag, the action stays on the bundle path. When a maintainer points `comparevi_ref` at an unreleased branch/commit/SHA, the action falls back to a source checkout for that explicit override only.
 - Do not expose this action to untrusted fork pull requests with write-scoped tokens or secrets. `pull_request_target` against a fork is treated as unsafe by default because the facade assumes trusted refs and a trusted runner.
+- The published PR-diagnostics templates in `docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md` prefer `ubuntu-latest` plus a serial `docker pull` of `nationalinstruments/labview:2026q1-linux`, because that matches the fork-ready hosted-runner path validated in downstream consumers.
 - Hosted smoke coverage in this repo uses an LVCompare stub on `windows-latest`. That proves the facade contract and cross-repo wiring, but it is not a substitute for trusted-runner production use.
 
 ## Release mapping

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -1,7 +1,8 @@
 # Safe PR Diagnostics Templates
 
 These templates show how to use `comparevi-history` safely in public repositories without violating the facade trust
-guard, and they default to a broader mode bundle than a single `default` pass.
+guard. They default to a broader mode bundle than a single `default` pass, and they assume a GitHub-hosted Linux
+runner that pre-pulls the NI container image before invoking a repo-local hosted-runner adapter.
 
 ## Published Templates
 
@@ -34,8 +35,8 @@ keep the default bundle as the starting point for public PR diagnostics.
 - Use the comment-gated template when you want a slash command such as
   `/comparevi-history Tooling/deployment/VIP_Post-Install Custom Action.vi --modes default,attributes,front-panel,block-diagram`
   to trigger diagnostics from a trusted maintainer comment.
-- Run both patterns only on trusted Windows runners that already satisfy the backend LabVIEW and LVCompare
-  prerequisites.
+- Run both patterns on trusted maintainer-controlled workflows that pre-pull the hosted NI Linux image serially and use
+  a repo-local adapter such as `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`.
 
 ## Fork Adoption and Upstream Alignment
 
@@ -45,7 +46,7 @@ keep the default bundle as the starting point for public PR diagnostics.
   `develop` unless they intentionally diverge on diagnostics policy.
 - The published templates are repo-local by design: they resolve the pull request head repository dynamically, so the
   same workflow file can live in upstream or in a fork and still inspect fork-authored PR heads safely from a trusted
-  maintainer-controlled runner.
+  maintainer-controlled hosted runner.
 
 ## Do Not Use These Patterns
 
@@ -62,14 +63,21 @@ keep the default bundle as the starting point for public PR diagnostics.
 
 - The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
   when you want compatible updates after each reviewed facade release.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.0.3`. That is the right default when
-  you want the public PR diagnostics surface frozen to a known immutable release.
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.0.4`. That is the right default when
+  you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
+  immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
 - Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with
   `fetch-depth: 0` so the facade can traverse commit history deterministically.
 - Both templates keep maintainer-only override inputs unset. That aligns with the trust guard and keeps consumers on
   the normal released bundle path.
+- Both templates pre-pull `nationalinstruments/labview:2026q1-linux` and route execution through
+  `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1` so consumers use the hosted NI Linux contract instead of a
+  repo-specific self-hosted Windows assumption.
 - Both templates surface the mode bundle in artifacts and summaries through the facade outputs
   `requested-mode-list`, `executed-mode-list`, `mode-manifests-json`, and `mode-summary-markdown`.
+- The comment-gated template writes the diagnostics summary to the step summary first, then attempts to publish the PR
+  comment. If the repository token cannot create the comment, the workflow keeps the diagnostics job green and records
+  the fallback in the step summary instead of masking a successful compare run as infrastructure failure.
 - The published templates intentionally leave `keep_artifacts_on_no_diff` unset so they stay compatible with the
   currently pinned released backend bundle.
 - `.github/workflows/published-consumer-validation.yml` in this repo validates the published `v1` tag and latest
@@ -80,5 +88,6 @@ keep the default bundle as the starting point for public PR diagnostics.
 1. Start with the maintainer-dispatched template when your project is new to VI History diagnostics.
 2. Keep the default multi-mode bundle unless you have a documented reason to narrow it.
 3. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
-   comments on a trusted runner.
+   comments on a trusted hosted runner.
 4. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
+

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -8,20 +8,23 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
+
+concurrency:
+  group: comparevi-history-${{ github.repository }}-hosted-linux
+  cancel-in-progress: false
 
 jobs:
   comparevi-history-comment:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/comparevi-history') }}
-    runs-on:
-      - self-hosted
-      - Windows
-      - X64
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       DEFAULT_COMPARE_MODES: default,attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.0.3
+      FACADE_REF: v1.0.4
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
         id: request
@@ -89,6 +92,10 @@ jobs:
             "is-fork=$([bool]$pr.head.repo.fork)"
           ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Pre-pull NI Linux image
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
       - name: Checkout PR head repository
         uses: actions/checkout@v5
         with:
@@ -98,7 +105,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.4
         with:
           target_path: ${{ steps.request.outputs['target-path'] }}
           start_ref: ${{ steps.request.outputs['head-sha'] }}
@@ -109,6 +116,7 @@ jobs:
           detailed: true
           fail_on_diff: false
           results_dir: tests/results/pr-diagnostics/history
+          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
 
       - name: Upload diagnostics artifacts
         if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
@@ -118,13 +126,13 @@ jobs:
           path: ${{ steps.history.outputs['results-dir'] }}/**
           if-no-files-found: error
 
-      - name: Post PR comment
+      - name: Publish diagnostics summary
         if: ${{ always() }}
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.4
           TARGET_PATH: ${{ steps.request.outputs['target-path'] }}
           REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
           EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}
@@ -145,11 +153,33 @@ jobs:
           }
 
           $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $summaryLines = @(
+            '## comparevi-history comment-gated diagnostics'
+            ''
+            ('- Action ref: `{0}`' -f $env:ACTION_REF)
+            ('- Pull request: `#{0}`' -f $env:ISSUE_NUMBER)
+            ('- Target path: `{0}`' -f $env:TARGET_PATH)
+            ('- Container image: `{0}`' -f $env:COMPAREVI_NI_LINUX_IMAGE)
+            ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
+            ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
+            ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)
+            ('- Total diffs: `{0}`' -f $env:TOTAL_DIFFS)
+            ('- Step conclusion: `{0}`' -f $env:STEP_CONCLUSION)
+            ('- PR head is fork: `{0}`' -f $env:IS_FORK)
+            ('- Run URL: {0}' -f $runUrl)
+            ''
+            '### Mode coverage'
+            ''
+            $env:MODE_SUMMARY_MARKDOWN
+          )
+          $summaryLines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
           $body = @"
           comparevi-history diagnostics finished for PR #$env:ISSUE_NUMBER.
 
           - Action ref: `$env:ACTION_REF`
           - Target path: `$env:TARGET_PATH`
+          - Container image: `$env:COMPAREVI_NI_LINUX_IMAGE`
           - Requested modes: `$env:REQUESTED_MODES`
           - Executed modes: `$env:EXECUTED_MODES`
           - Total processed: `$env:TOTAL_PROCESSED`
@@ -165,4 +195,29 @@ jobs:
 
           $payload = @{ body = $body } | ConvertTo-Json -Depth 5
           $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER/comments"
-          Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $payload -ContentType 'application/json'
+
+          try {
+            Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $payload -ContentType 'application/json' | Out-Null
+            @(
+              ''
+              '- PR comment publication: `posted`'
+            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          } catch {
+            $statusCode = $null
+            if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+              $statusCode = [int]$_.Exception.Response.StatusCode
+            }
+
+            $permissionDenied = $statusCode -eq 403 -or $_.Exception.Message -match 'Resource not accessible by integration'
+            if (-not $permissionDenied) {
+              throw
+            }
+
+            $warning = 'PR comment publication was denied by the repository token; keeping diagnostics green and relying on the workflow summary and uploaded artifacts.'
+            Write-Warning $warning
+            @(
+              ''
+              ('- PR comment publication: `skipped` ({0})' -f $warning)
+            ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          }
+

--- a/docs/examples/comparevi-history-workflow-dispatch.yml
+++ b/docs/examples/comparevi-history-workflow-dispatch.yml
@@ -29,13 +29,18 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: comparevi-history-${{ github.repository }}-hosted-linux
+  cancel-in-progress: false
 
 jobs:
   comparevi-history-manual:
-    runs-on:
-      - self-hosted
-      - Windows
-      - X64
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Resolve pull request head
         id: pr
@@ -67,6 +72,10 @@ jobs:
             "is-fork=$([bool]$pr.head.repo.fork)"
           ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Pre-pull NI Linux image
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
       - name: Checkout PR head repository
         uses: actions/checkout@v5
         with:
@@ -87,6 +96,7 @@ jobs:
           detailed: true
           fail_on_diff: false
           results_dir: tests/results/pr-diagnostics/history
+          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
 
       - name: Upload diagnostics artifacts
         if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
@@ -121,6 +131,7 @@ jobs:
             ('- Action ref: `{0}`' -f $env:ACTION_REF)
             ('- Pull request: `#{0}`' -f $env:PR_NUMBER)
             ('- Target path: `{0}`' -f $env:TARGET_PATH)
+            ('- Container image: `{0}`' -f $env:COMPAREVI_NI_LINUX_IMAGE)
             ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
             ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
             ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)

--- a/scripts/Sync-CompareVIHistoryPublishedTemplates.ps1
+++ b/scripts/Sync-CompareVIHistoryPublishedTemplates.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ImmutableTag,
+
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($ImmutableTag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+  throw "ImmutableTag must match v<major>.<minor>.<patch>. Actual: '$ImmutableTag'."
+}
+
+$commentTemplatePath = Join-Path $RepoRoot 'docs/examples/comparevi-history-comment-gated.yml'
+$safeTemplatesPath = Join-Path $RepoRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
+
+foreach ($path in @($commentTemplatePath, $safeTemplatesPath)) {
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    throw "Template sync input not found: $path"
+  }
+}
+
+$commentTemplate = Get-Content -LiteralPath $commentTemplatePath -Raw
+$commentTemplate = [regex]::Replace(
+  $commentTemplate,
+  '(?m)(^\s*FACADE_REF:\s*)v[0-9]+\.[0-9]+\.[0-9]+\s*$',
+  ("`$1{0}" -f $ImmutableTag)
+)
+$commentTemplate = [regex]::Replace(
+  $commentTemplate,
+  '(?m)(^\s*uses:\s+LabVIEW-Community-CI-CD/comparevi-history@)v[0-9]+\.[0-9]+\.[0-9]+\s*$',
+  ("`$1{0}" -f $ImmutableTag)
+)
+$commentTemplate = [regex]::Replace(
+  $commentTemplate,
+  '(?m)(^\s*ACTION_REF:\s+LabVIEW-Community-CI-CD/comparevi-history@)v[0-9]+\.[0-9]+\.[0-9]+\s*$',
+  ("`$1{0}" -f $ImmutableTag)
+)
+$commentTemplate | Set-Content -LiteralPath $commentTemplatePath -Encoding utf8
+
+$safeTemplates = Get-Content -LiteralPath $safeTemplatesPath -Raw
+$safeTemplates = [regex]::Replace(
+  $safeTemplates,
+  'LabVIEW-Community-CI-CD/comparevi-history@v[0-9]+\.[0-9]+\.[0-9]+',
+  ('LabVIEW-Community-CI-CD/comparevi-history@{0}' -f $ImmutableTag)
+)
+$safeTemplates | Set-Content -LiteralPath $safeTemplatesPath -Encoding utf8
+
+[ordered]@{
+  immutableTag = $ImmutableTag
+  commentTemplatePath = $commentTemplatePath
+  safeTemplatesPath = $safeTemplatesPath
+} | ConvertTo-Json -Depth 5

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -1,0 +1,80 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$manualTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-workflow-dispatch.yml'
+$commentTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-comment-gated.yml'
+$safeTemplatesPath = Join-Path $repoRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
+$releaseWorkflowPath = Join-Path $repoRoot '.github/workflows/release.yml'
+$readmePath = Join-Path $repoRoot 'README.md'
+
+function Assert-Match {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Content,
+    [Parameter(Mandatory = $true)]
+    [string]$Pattern,
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if ($Content -notmatch $Pattern) {
+    throw $Message
+  }
+}
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Actual,
+    [Parameter(Mandatory = $true)]
+    [string]$Expected,
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if ($Actual -ne $Expected) {
+    throw "$Message Expected '$Expected', actual '$Actual'."
+  }
+}
+
+$manualTemplate = Get-Content -LiteralPath $manualTemplatePath -Raw
+$commentTemplate = Get-Content -LiteralPath $commentTemplatePath -Raw
+$safeTemplates = Get-Content -LiteralPath $safeTemplatesPath -Raw
+$releaseWorkflow = Get-Content -LiteralPath $releaseWorkflowPath -Raw
+$readme = Get-Content -LiteralPath $readmePath -Raw
+
+Assert-Match -Content $manualTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Manual template must use ubuntu-latest.'
+Assert-Match -Content $manualTemplate -Pattern '(?m)^\s*COMPAREVI_NI_LINUX_IMAGE:\s+nationalinstruments/labview:2026q1-linux\s*$' -Message 'Manual template must pin the NI Linux image.'
+Assert-Match -Content $manualTemplate -Pattern 'docker pull "\$COMPAREVI_NI_LINUX_IMAGE"' -Message 'Manual template must pre-pull the NI Linux image.'
+Assert-Match -Content $manualTemplate -Pattern 'invoke_script_path:\s+Tooling/Invoke-CompareVIHistoryHostedNILinux\.ps1' -Message 'Manual template must use the hosted NI Linux invoke adapter.'
+Assert-Match -Content $manualTemplate -Pattern 'Container image' -Message 'Manual template summary must surface the container image.'
+
+Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Comment-gated template must use ubuntu-latest.'
+Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Comment-gated template must request pull-requests: write.'
+Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*COMPAREVI_NI_LINUX_IMAGE:\s+nationalinstruments/labview:2026q1-linux\s*$' -Message 'Comment-gated template must pin the NI Linux image.'
+Assert-Match -Content $commentTemplate -Pattern 'docker pull "\$COMPAREVI_NI_LINUX_IMAGE"' -Message 'Comment-gated template must pre-pull the NI Linux image.'
+Assert-Match -Content $commentTemplate -Pattern 'invoke_script_path:\s+Tooling/Invoke-CompareVIHistoryHostedNILinux\.ps1' -Message 'Comment-gated template must use the hosted NI Linux invoke adapter.'
+Assert-Match -Content $commentTemplate -Pattern 'Resource not accessible by integration' -Message 'Comment-gated template must recognize permission-denied PR comment failures.'
+Assert-Match -Content $commentTemplate -Pattern 'PR comment publication was denied by the repository token' -Message 'Comment-gated template must warn on denied PR comment publication.'
+Assert-Match -Content $commentTemplate -Pattern 'PR comment publication: `skipped`' -Message 'Comment-gated template must record skipped PR comment publication in the step summary.'
+Assert-Match -Content $releaseWorkflow -Pattern 'scripts/Sync-CompareVIHistoryPublishedTemplates\.ps1' -Message 'Release workflow must include the published template sync script.'
+Assert-Match -Content $releaseWorkflow -Pattern 'Published comment-gated template now points at' -Message 'Release notes must mention the published comment-gated template pin.'
+Assert-Match -Content $readme -Pattern 'hosted NI Linux container path wired by a repo-local adapter' -Message 'README must document the hosted NI Linux adapter path.'
+Assert-Match -Content $readme -Pattern 'nationalinstruments/labview:2026q1-linux' -Message 'README must mention the published hosted NI Linux image path.'
+
+$facadeRefMatch = [regex]::Match($commentTemplate, '(?m)^\s*FACADE_REF:\s*(v[0-9]+\.[0-9]+\.[0-9]+)\s*$')
+$usesRefMatch = [regex]::Match($commentTemplate, '(?m)^\s*uses:\s+LabVIEW-Community-CI-CD/comparevi-history@(v[0-9]+\.[0-9]+\.[0-9]+)\s*$')
+$actionRefMatch = [regex]::Match($commentTemplate, '(?m)^\s*ACTION_REF:\s+LabVIEW-Community-CI-CD/comparevi-history@(v[0-9]+\.[0-9]+\.[0-9]+)\s*$')
+$docsRefMatch = [regex]::Match($safeTemplates, 'LabVIEW-Community-CI-CD/comparevi-history@(v[0-9]+\.[0-9]+\.[0-9]+)')
+
+foreach ($match in @($facadeRefMatch, $usesRefMatch, $actionRefMatch, $docsRefMatch)) {
+  if (-not $match.Success) {
+    throw 'Failed to resolve the published immutable tag across the comment-gated template contract.'
+  }
+}
+
+$immutableTag = $facadeRefMatch.Groups[1].Value
+Assert-Equal -Actual $usesRefMatch.Groups[1].Value -Expected $immutableTag -Message 'Comment-gated template uses: pin mismatch.'
+Assert-Equal -Actual $actionRefMatch.Groups[1].Value -Expected $immutableTag -Message 'Comment-gated template ACTION_REF mismatch.'
+Assert-Equal -Actual $docsRefMatch.Groups[1].Value -Expected $immutableTag -Message 'Safe template docs immutable tag mismatch.'


### PR DESCRIPTION
## Summary
Modernize the published comparevi-history PR diagnostics templates around the hosted NI Linux runner contract and stop treating PR-comment publication denial as a hard workflow failure.
This updates the shipped manual/comment-gated examples, adds a release-time sync seam for the immutable example pin, and adds a repo-local template contract test so future releases do not drift back to stale or brittle consumer guidance.

## Change Surface
- move the published manual and comment-gated templates to `ubuntu-latest` plus serial `docker pull` of `nationalinstruments/labview:2026q1-linux`
- route both templates through `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`
- add step-summary-first PR diagnostics reporting and permission-denied fallback in the comment-gated template
- add `Sync-CompareVIHistoryPublishedTemplates.ps1` and `Test-CompareVIHistoryTemplateContracts.ps1`
- teach `release.yml` to refresh the published immutable comment-gated pin during publish
- refresh README/template docs to match the hosted runner contract

## Validation
- `D:\workspace\compare-vi-cli-action\compare-vi-cli-action\bin\actionlint.exe -color .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/published-consumer-validation.yml docs/examples/comparevi-history-workflow-dispatch.yml docs/examples/comparevi-history-comment-gated.yml`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTrust.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPublishedRefs.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryModeSummary.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPublishedRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Sync-CompareVIHistoryPublishedTemplates.ps1 -ImmutableTag v1.0.4`

## Tracking
- #20
