### PR TITLE
#22 Publish comparevi-history releases without pushing to protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
             'scripts/Resolve-CompareVIHistoryBackend.ps1',
             'scripts/Acquire-CompareVIToolsBundle.ps1',
             'scripts/Resolve-CompareVIHistoryPublishedRefs.ps1',
+            'scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1',
             'scripts/Resolve-CompareVIHistoryRequest.ps1',
             'scripts/Invoke-CompareVIHistoryFacade.ps1',
             'scripts/Format-CompareVIHistoryModeSummary.ps1',
@@ -109,6 +110,7 @@ jobs:
             'scripts/Sync-CompareVIHistoryPublishedTemplates.ps1',
             'scripts/Write-CompareVIHistorySmokeStub.ps1',
             'scripts/Test-CompareVIHistoryBranchProtection.ps1',
+            'scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1',
             'scripts/Test-CompareVIHistoryTemplateContracts.ps1'
           )) {
             $errors = $null
@@ -157,6 +159,7 @@ jobs:
           $ErrorActionPreference = 'Stop'
           & "$PWD/scripts/Test-CompareVIHistoryTrust.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryPublishedRefs.ps1"
+          & "$PWD/scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryRequest.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryModeSummary.ps1"
           & "$PWD/scripts/Test-CompareVIHistoryPublicRun.ps1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
       - scripts/Resolve-CompareVIHistoryPublishedRefs.ps1
       - scripts/Format-CompareVIHistoryModeSummary.ps1
       - scripts/Assert-CompareVIHistoryPublishedRun.ps1
+      - scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1
+      - scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1
       - scripts/Sync-CompareVIHistoryPublishedTemplates.ps1
       - scripts/Test-CompareVIHistoryTemplateContracts.ps1
       - docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -75,6 +77,9 @@ jobs:
       consumer_repository: ${{ steps.plan.outputs.consumer_repository }}
       consumer_ref: ${{ steps.plan.outputs.consumer_ref }}
       current_backend_ref: ${{ steps.plan.outputs.current_backend_ref }}
+      release_content_ready: ${{ steps.readiness.outputs.release-content-ready }}
+      preparation_required: ${{ steps.readiness.outputs.preparation-required }}
+      changed_file_count: ${{ steps.readiness.outputs.changed-file-count }}
     steps:
       - name: Checkout facade repo
         uses: actions/checkout@v5
@@ -194,11 +199,30 @@ jobs:
             "current_backend_ref=$currentBackendRef"
           ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Check release publish readiness
+        id: readiness
+        shell: pwsh
+        env:
+          BACKEND_TAG: ${{ steps.plan.outputs.backend_tag }}
+          IMMUTABLE_TAG: ${{ steps.plan.outputs.immutable_tag }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          & "$PWD/scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1" `
+            -BackendTag $env:BACKEND_TAG `
+            -ImmutableTag $env:IMMUTABLE_TAG `
+            -OutputPath 'release-readiness.json' `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
       - name: Upload release plan artifact
         uses: actions/upload-artifact@v5
         with:
           name: comparevi-history-release-plan-${{ github.run_id }}
-          path: release-plan.json
+          path: |
+            release-plan.json
+            release-readiness.json
           if-no-files-found: error
 
       - name: Summarize release plan
@@ -216,6 +240,9 @@ jobs:
             echo "- Major tag: \`${{ steps.plan.outputs.major_tag }}\`"
             echo "- External consumer: \`${{ steps.plan.outputs.consumer_repository }}@${{ steps.plan.outputs.consumer_ref }}\`"
             echo "- Publish: \`${{ steps.plan.outputs.publish }}\`"
+            echo "- Release content ready on \`main\`: \`${{ steps.readiness.outputs.release-content-ready }}\`"
+            echo "- Publish prep required: \`${{ steps.readiness.outputs.preparation-required }}\`"
+            echo "- Changed file count: \`${{ steps.readiness.outputs.changed-file-count }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   smoke-local:
@@ -414,14 +441,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure git identity
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-      - name: Update backend pin and create release notes
+      - name: Verify publish content and create release notes
         id: prepare
         shell: bash
         env:
@@ -433,13 +453,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          printf '%s\n' "$BACKEND_TAG" > comparevi-backend-ref.txt
-          pwsh -NoLogo -NoProfile -File scripts/Sync-CompareVIHistoryPublishedTemplates.ps1 -ImmutableTag "$IMMUTABLE_TAG" > /dev/null
-
-          if ! git diff --quiet -- comparevi-backend-ref.txt docs/examples/comparevi-history-comment-gated.yml docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md; then
-            git add comparevi-backend-ref.txt docs/examples/comparevi-history-comment-gated.yml docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
-            git commit -m "Release comparevi-history $IMMUTABLE_TAG (#1)"
+          git fetch origin main --tags --force
+          current_main_sha="$(git rev-parse refs/remotes/origin/main)"
+          current_head_sha="$(git rev-parse HEAD)"
+          if [ "$current_head_sha" != "$current_main_sha" ]; then
+            echo "Release publish must run from the current origin/main tip. HEAD=$current_head_sha origin/main=$current_main_sha. Rerun release.yml after main stabilizes." >&2
+            exit 1
           fi
+
+          pwsh -NoLogo -NoProfile -File scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1 \
+            -BackendTag "$BACKEND_TAG" \
+            -ImmutableTag "$IMMUTABLE_TAG" \
+            -OutputPath release-readiness.json \
+            -FailIfPreparationRequired \
+            -StepSummaryPath "$GITHUB_STEP_SUMMARY" > /dev/null
 
           target_sha="$(git rev-parse HEAD)"
 
@@ -456,23 +483,23 @@ jobs:
 
           ### Published contract
 
-          - \`comparevi-backend-ref.txt\` now pins backend release tag \`${BACKEND_TAG}\`
+          - \`comparevi-backend-ref.txt\` already pins backend release tag \`${BACKEND_TAG}\`
           - Backend source SHA for that tag is \`${BACKEND_SHA}\`
-          - \`${IMMUTABLE_TAG}\` is the immutable facade tag for this backend mapping
+          - \`${IMMUTABLE_TAG}\` is the immutable facade tag for this already-reviewed backend mapping
           - \`${MAJOR_TAG}\` advances only after smoke and release publication succeed
-          - Published comment-gated template now points at \`${IMMUTABLE_TAG}\`
+          - Published comment-gated template already points at \`${IMMUTABLE_TAG}\`
           EOF
 
           echo "target-sha=$target_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Push release commit and immutable tag
+      - name: Push immutable tag
         shell: bash
         env:
           IMMUTABLE_TAG: ${{ needs.validate.outputs.immutable_tag }}
         run: |
           set -euo pipefail
           git tag "$IMMUTABLE_TAG" "${{ steps.prepare.outputs.target-sha }}"
-          git push --atomic origin HEAD:main "refs/tags/$IMMUTABLE_TAG"
+          git push origin "refs/tags/$IMMUTABLE_TAG"
 
       - name: Create GitHub release
         shell: bash

--- a/README.md
+++ b/README.md
@@ -191,8 +191,13 @@ Do not copy backend renderers or repo-local history execution logic into consume
   - `publish`: `false` for smoke-only rehearsal, `true` for a real release from `main`
 - The workflow resolves `backend_ref` to a backend release tag plus source SHA, runs both local and external smoke
   against that candidate bundle-backed backend, and uploads a release-plan artifact before any publish step runs.
-- When `publish: true`, the workflow then updates `comparevi-backend-ref.txt`, creates the immutable tag, publishes
-  GitHub Release notes with the mapped backend release tag and source SHA, and finally moves `v1`.
+- When `publish: true`, the workflow now verifies that `main` already contains the required `comparevi-backend-ref.txt`
+  and published-template changes for the requested release. If readiness says preparation is still required, merge a
+  prep PR first and rerun the workflow from `main`.
+- Publish also requires the current `main` tip to stay unchanged through smoke. If `main` advances before the publish
+  job runs, rerun the release workflow so the immutable tag maps to the exact `main` commit that passed smoke.
+- Once `main` is already aligned, the workflow creates the immutable tag, publishes GitHub Release notes with the
+  mapped backend release tag and source SHA, and finally moves `v1`.
 - Failure before the final major-tag step leaves `v1` unchanged.
 
 ## Repository policy
@@ -224,7 +229,8 @@ gh api repos/LabVIEW-Community-CI-CD/comparevi-history/branches/main/protection 
 ```
 
 - The policy intentionally relies on required status checks instead of required reviewer gates so the manual release
-  workflow can update `comparevi-backend-ref.txt` and tags after smoke passes.
+  workflow can publish tags from already-reviewed `main` after smoke passes, while repo-content updates still flow
+  through normal pull requests.
 
 ## Notes
 

--- a/scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1
+++ b/scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1
@@ -1,0 +1,183 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BackendTag,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ImmutableTag,
+
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+
+  [string]$OutputPath,
+
+  [string]$GitHubOutputPath,
+
+  [string]$StepSummaryPath,
+
+  [switch]$FailIfPreparationRequired
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($BackendTag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$') {
+  throw "BackendTag must resolve to an immutable release tag. Actual: '$BackendTag'."
+}
+
+if ($ImmutableTag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+  throw "ImmutableTag must match v<major>.<minor>.<patch>. Actual: '$ImmutableTag'."
+}
+
+$repoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+$trackedRelativePaths = @(
+  'comparevi-backend-ref.txt',
+  'docs/examples/comparevi-history-comment-gated.yml',
+  'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
+)
+
+function Get-NormalizedTextContent {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $content = Get-Content -LiteralPath $Path -Raw
+  $content = $content -replace "`r`n", "`n"
+  $content = $content -replace "`r", "`n"
+  return $content.TrimEnd("`n")
+}
+
+function Assert-Match {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Content,
+    [Parameter(Mandatory = $true)]
+    [string]$Pattern,
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if ($Content -notmatch $Pattern) {
+    throw $Message
+  }
+}
+
+foreach ($relativePath in $trackedRelativePaths) {
+  $absolutePath = Join-Path $repoRoot $relativePath
+  if (-not (Test-Path -LiteralPath $absolutePath -PathType Leaf)) {
+    throw "Release publish readiness input not found: $absolutePath"
+  }
+}
+
+$stagingRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("comparevi-history-release-readiness-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+
+try {
+  foreach ($relativePath in $trackedRelativePaths) {
+    $sourcePath = Join-Path $repoRoot $relativePath
+    $destinationPath = Join-Path $stagingRoot $relativePath
+    $destinationDirectory = Split-Path -Parent $destinationPath
+    if (-not (Test-Path -LiteralPath $destinationDirectory -PathType Container)) {
+      New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+    }
+    Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+  }
+
+  $stagedBackendRefPath = Join-Path $stagingRoot 'comparevi-backend-ref.txt'
+  Set-Content -LiteralPath $stagedBackendRefPath -Encoding utf8 -Value $BackendTag
+  & (Join-Path $PSScriptRoot 'Sync-CompareVIHistoryPublishedTemplates.ps1') -ImmutableTag $ImmutableTag -RepoRoot $stagingRoot | Out-Null
+
+  $stagedCommentTemplate = Get-Content -LiteralPath (Join-Path $stagingRoot 'docs/examples/comparevi-history-comment-gated.yml') -Raw
+  $stagedSafeTemplates = Get-Content -LiteralPath (Join-Path $stagingRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md') -Raw
+  $escapedImmutableTag = [regex]::Escape($ImmutableTag)
+  Assert-Match -Content $stagedCommentTemplate -Pattern "(?m)^\s*FACADE_REF:\s*$escapedImmutableTag\s*$" -Message 'Published comment-gated template sync did not stamp the requested immutable FACADE_REF.'
+  Assert-Match -Content $stagedCommentTemplate -Pattern "(?m)^\s*uses:\s+LabVIEW-Community-CI-CD/comparevi-history@$escapedImmutableTag\s*$" -Message 'Published comment-gated template sync did not stamp the requested immutable uses: ref.'
+  Assert-Match -Content $stagedCommentTemplate -Pattern "(?m)^\s*ACTION_REF:\s+LabVIEW-Community-CI-CD/comparevi-history@$escapedImmutableTag\s*$" -Message 'Published comment-gated template sync did not stamp the requested immutable ACTION_REF.'
+  Assert-Match -Content $stagedSafeTemplates -Pattern "LabVIEW-Community-CI-CD/comparevi-history@$escapedImmutableTag" -Message 'Published safe-template docs did not stamp the requested immutable comparevi-history ref.'
+
+  $changedFiles = New-Object System.Collections.Generic.List[string]
+  foreach ($relativePath in $trackedRelativePaths) {
+    $currentPath = Join-Path $repoRoot $relativePath
+    $stagedPath = Join-Path $stagingRoot $relativePath
+    $currentContent = Get-NormalizedTextContent -Path $currentPath
+    $stagedContent = Get-NormalizedTextContent -Path $stagedPath
+    if ($currentContent -ne $stagedContent) {
+      $changedFiles.Add($relativePath)
+    }
+  }
+
+  $currentBackendRef = (Get-Content -LiteralPath (Join-Path $repoRoot 'comparevi-backend-ref.txt') -Raw).Trim()
+  $releaseContentReady = ($changedFiles.Count -eq 0)
+  $preparationHint = if ($releaseContentReady) {
+    $null
+  } else {
+    "Merge a prep PR to main that updates $($changedFiles -join ', '), then rerun release.yml with publish=true."
+  }
+
+  $receipt = [ordered]@{
+    schema                 = 'comparevi-history/release-publish-readiness@v1'
+    generatedAtUtc         = [DateTime]::UtcNow.ToString('o')
+    repoRoot               = $repoRoot
+    backendTag             = $BackendTag
+    immutableTag           = $ImmutableTag
+    currentBackendRef      = $currentBackendRef
+    releaseContentReady    = $releaseContentReady
+    preparationRequired    = (-not $releaseContentReady)
+    changedFileCount       = $changedFiles.Count
+    changedFiles           = @($changedFiles)
+    preparationHint        = $preparationHint
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $outputDirectory = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($outputDirectory) -and -not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+      New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+    }
+    $receipt | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    @(
+      ("release-content-ready={0}" -f $receipt.releaseContentReady.ToString().ToLowerInvariant())
+      ("preparation-required={0}" -f $receipt.preparationRequired.ToString().ToLowerInvariant())
+      ("changed-file-count={0}" -f $receipt.changedFileCount)
+      ("changed-files-json={0}" -f (($receipt.changedFiles | ConvertTo-Json -Compress)))
+    ) | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+      ("readiness-report-path={0}" -f $OutputPath) | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+    }
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+    $summaryLines = @(
+      '## comparevi-history release publish readiness'
+      ''
+      ('- Backend tag: `{0}`' -f $BackendTag)
+      ('- Immutable tag: `{0}`' -f $ImmutableTag)
+      ('- Current backend ref: `{0}`' -f $currentBackendRef)
+      ('- Release content ready on `main`: `{0}`' -f $receipt.releaseContentReady.ToString().ToLowerInvariant())
+      ('- Changed file count: `{0}`' -f $receipt.changedFileCount)
+    )
+
+    if ($changedFiles.Count -gt 0) {
+      $summaryLines += ''
+      $summaryLines += 'Preparation required before publish:'
+      foreach ($relativePath in $changedFiles) {
+        $summaryLines += ('- `{0}`' -f $relativePath)
+      }
+      $summaryLines += ''
+      $summaryLines += $preparationHint
+    }
+
+    $summaryLines | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+  }
+
+  if ($FailIfPreparationRequired -and -not $releaseContentReady) {
+    throw ("Release publish requires already-reviewed main content. Merge a prep PR that updates {0}, then rerun release.yml with publish=true." -f ($changedFiles -join ', '))
+  }
+
+  $receipt | ConvertTo-Json -Depth 10
+} finally {
+  Remove-Item -LiteralPath $stagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1
+++ b/scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1
@@ -1,0 +1,109 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Resolve-CompareVIHistoryReleasePublishReadiness.ps1'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("comparevi-history-release-publish-ready-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Actual,
+    [Parameter(Mandatory = $true)]
+    [object]$Expected,
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  if ($Actual -ne $Expected) {
+    throw "$Message Expected '$Expected', actual '$Actual'."
+  }
+}
+
+try {
+  $trackedRelativePaths = @(
+    'comparevi-backend-ref.txt',
+    'docs/examples/comparevi-history-comment-gated.yml',
+    'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
+  )
+  foreach ($relativePath in $trackedRelativePaths) {
+    $sourcePath = Join-Path $repoRoot $relativePath
+    $destinationPath = Join-Path $tempRoot $relativePath
+    $destinationDirectory = Split-Path -Parent $destinationPath
+    if (-not (Test-Path -LiteralPath $destinationDirectory -PathType Container)) {
+      New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+    }
+    Copy-Item -LiteralPath $sourcePath -Destination $destinationPath -Force
+  }
+
+  $currentBackendRef = (Get-Content -LiteralPath (Join-Path $repoRoot 'comparevi-backend-ref.txt') -Raw).Trim()
+  $commentTemplate = Get-Content -LiteralPath (Join-Path $repoRoot 'docs/examples/comparevi-history-comment-gated.yml') -Raw
+  $immutableTagMatch = [regex]::Match($commentTemplate, '(?m)^\s*FACADE_REF:\s*(v[0-9]+\.[0-9]+\.[0-9]+)\s*$')
+  if (-not $immutableTagMatch.Success) {
+    throw 'Failed to resolve the current immutable tag from the published comment-gated template.'
+  }
+  $currentImmutableTag = $immutableTagMatch.Groups[1].Value
+  $readinessOutputPath = Join-Path $tempRoot 'release-readiness.json'
+  $githubOutputPath = Join-Path $tempRoot 'github-output.txt'
+
+  $readyReceiptJson = & $scriptPath `
+    -BackendTag $currentBackendRef `
+    -ImmutableTag $currentImmutableTag `
+    -RepoRoot $tempRoot `
+    -OutputPath $readinessOutputPath `
+    -GitHubOutputPath $githubOutputPath
+
+  $readyReceipt = $readyReceiptJson | ConvertFrom-Json
+  Assert-Equal -Actual $readyReceipt.schema -Expected 'comparevi-history/release-publish-readiness@v1' -Message 'Readiness schema mismatch.'
+  Assert-Equal -Actual $readyReceipt.releaseContentReady -Expected $true -Message 'Expected repo copy to already be publish-ready.'
+  Assert-Equal -Actual $readyReceipt.preparationRequired -Expected $false -Message 'Preparation should not be required for current repo state.'
+  Assert-Equal -Actual $readyReceipt.changedFileCount -Expected 0 -Message 'Current repo state should not need content changes.'
+
+  $writtenReceipt = Get-Content -LiteralPath $readinessOutputPath -Raw | ConvertFrom-Json
+  Assert-Equal -Actual $writtenReceipt.releaseContentReady -Expected $true -Message 'Written readiness receipt mismatch.'
+
+  $githubOutput = Get-Content -LiteralPath $githubOutputPath
+  if (-not ($githubOutput -contains 'release-content-ready=true')) {
+    throw 'GitHub output did not include release-content-ready=true.'
+  }
+  if (-not ($githubOutput -contains 'preparation-required=false')) {
+    throw 'GitHub output did not include preparation-required=false.'
+  }
+
+  $driftReceipt = (& $scriptPath -BackendTag 'v9.9.9' -ImmutableTag 'v9.9.9' -RepoRoot $tempRoot) | ConvertFrom-Json
+  Assert-Equal -Actual $driftReceipt.releaseContentReady -Expected $false -Message 'Expected synthetic drift to require prep.'
+  Assert-Equal -Actual $driftReceipt.preparationRequired -Expected $true -Message 'PreparationRequired mismatch for synthetic drift.'
+  if ($driftReceipt.changedFiles.Count -lt 3) {
+    throw 'Expected synthetic drift to touch the backend pin and published template files.'
+  }
+
+  $failed = $false
+  try {
+    & $scriptPath -BackendTag 'v9.9.9' -ImmutableTag 'v9.9.9' -RepoRoot $tempRoot -FailIfPreparationRequired | Out-Null
+  } catch {
+    $failed = $_.Exception.Message -match 'already-reviewed main content'
+  }
+
+  if (-not $failed) {
+    throw 'Expected -FailIfPreparationRequired to throw for synthetic drift.'
+  }
+
+  $corruptTemplatePath = Join-Path $tempRoot 'docs/examples/comparevi-history-comment-gated.yml'
+  $corruptTemplate = Get-Content -LiteralPath $corruptTemplatePath -Raw
+  $corruptTemplate = $corruptTemplate -replace '(?m)^\s*FACADE_REF:\s*v[0-9]+\.[0-9]+\.[0-9]+\s*$', '      # FACADE_REF removed for readiness failure coverage'
+  $corruptTemplate | Set-Content -LiteralPath $corruptTemplatePath -Encoding utf8
+
+  $syncValidationFailed = $false
+  try {
+    & $scriptPath -BackendTag $currentBackendRef -ImmutableTag $currentImmutableTag -RepoRoot $tempRoot | Out-Null
+  } catch {
+    $syncValidationFailed = $_.Exception.Message -match 'did not stamp the requested immutable'
+  }
+
+  if (-not $syncValidationFailed) {
+    throw 'Expected readiness helper to fail when template sync cannot stamp the requested immutable tag.'
+  }
+} finally {
+  Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -8,6 +8,7 @@ $safeTemplatesPath = Join-Path $repoRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
 $publishedValidationWorkflowPath = Join-Path $repoRoot '.github/workflows/published-consumer-validation.yml'
 $smokeWorkflowPath = Join-Path $repoRoot '.github/workflows/smoke.yml'
 $releaseWorkflowPath = Join-Path $repoRoot '.github/workflows/release.yml'
+$releaseReadinessScriptPath = Join-Path $repoRoot 'scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1'
 $readmePath = Join-Path $repoRoot 'README.md'
 $exampleTargetsPath = Join-Path $repoRoot 'docs/examples/comparevi-history-consumer-targets.json'
 
@@ -62,6 +63,7 @@ $safeTemplates = Get-Content -LiteralPath $safeTemplatesPath -Raw
 $publishedValidationWorkflow = Get-Content -LiteralPath $publishedValidationWorkflowPath -Raw
 $smokeWorkflow = Get-Content -LiteralPath $smokeWorkflowPath -Raw
 $releaseWorkflow = Get-Content -LiteralPath $releaseWorkflowPath -Raw
+$releaseReadinessScript = Get-Content -LiteralPath $releaseReadinessScriptPath -Raw
 $readme = Get-Content -LiteralPath $readmePath -Raw
 $exampleTargets = Get-Content -LiteralPath $exampleTargetsPath -Raw
 
@@ -107,14 +109,19 @@ Assert-Match -Content $publishedValidationWorkflow -Pattern 'public-step-summary
 Assert-Match -Content $smokeWorkflow -Pattern 'comparevi-backend-ref\.txt' -Message 'Smoke workflow must resolve the repo-pinned backend release tag.'
 Assert-Match -Content $releaseWorkflow -Pattern 'comparevi-backend-ref\.txt' -Message 'Release workflow must read comparevi-backend-ref.txt.'
 Assert-Match -Content $releaseWorkflow -Pattern "tooling-source'\] -ne 'bundle'" -Message 'Release workflow must fail closed when the resolved backend is not a bundle release.'
-Assert-Match -Content $releaseWorkflow -Pattern 'scripts/Sync-CompareVIHistoryPublishedTemplates\.ps1' -Message 'Release workflow must include the published template sync script.'
-Assert-Match -Content $releaseWorkflow -Pattern 'Published comment-gated template now points at' -Message 'Release notes must mention the published comment-gated template pin.'
+Assert-Match -Content $releaseWorkflow -Pattern 'scripts/Resolve-CompareVIHistoryReleasePublishReadiness\.ps1' -Message 'Release workflow must check publish readiness against already-reviewed main content.'
+Assert-Match -Content $releaseWorkflow -Pattern 'if \[ "\$current_head_sha" != "\$current_main_sha" \]; then' -Message 'Release workflow must verify publish still targets the current origin/main tip before tagging.'
+Assert-Match -Content $releaseWorkflow -Pattern 'Published comment-gated template already points at' -Message 'Release notes must mention the published comment-gated template pin.'
+Assert-Match -Content $releaseWorkflow -Pattern 'git push origin "refs/tags/\$IMMUTABLE_TAG"' -Message 'Release workflow must push only the immutable tag during publish.'
+Assert-NotMatch -Content $releaseWorkflow -Pattern 'git push --atomic origin HEAD:main' -Message 'Release workflow must not push a fresh commit directly to protected main during publish.'
+Assert-Match -Content $releaseReadinessScript -Pattern 'Sync-CompareVIHistoryPublishedTemplates\.ps1' -Message 'Release readiness helper must derive desired publish content through the published template sync script.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/consumer-targets@v1' -Message 'README must document the target catalog contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/public-run@v1' -Message 'README must document the public run contract.'
 Assert-Match -Content $readme -Pattern 'hosted NI Linux container path wired by a repo-local adapter' -Message 'README must document the hosted NI Linux adapter path.'
 Assert-Match -Content $readme -Pattern 'public-comment-path' -Message 'README must document the action-owned public comment output.'
 Assert-Match -Content $readme -Pattern 'attributes`, `front-panel`, and `block-diagram' -Message 'README must document explicit public modes only.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/issues/24' -Message 'README must point at the comparevi-history platform-boundary epic.'
+Assert-Match -Content $readme -Pattern 'merge a\s+prep PR first' -Message 'README must explain the protected-main release prep requirement.'
 Assert-NotMatch -Content $readme -Pattern 'compare-vi-cli-action/issues/841' -Message 'README must not point at the legacy compare-vi-cli-action tracking epic.'
 
 $facadeRefMatch = [regex]::Match($commentTemplate, '(?m)^\s*FACADE_REF:\s*(v[0-9]+\.[0-9]+\.[0-9]+)\s*$')


### PR DESCRIPTION
## Summary
- stop `release.yml` from trying to push a new release commit directly to protected `main`
- add a release publish readiness helper that proves `main` already contains the backend pin and published-template content for the requested release
- keep publish on the exact current `origin/main` tip that passed smoke, and fail closed with a rerun message if `main` advances

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPublishedRefs.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTrust.ps1`
- `C:\dev\compare-vi-cli-action\compare-vi-cli-action\bin\actionlint.exe .github/workflows/release.yml .github/workflows/ci.yml`
- direct Copilot CLI review: `No actionable findings.`

Closes #22.