### PR TITLE
#34 Prepare published templates for v1.2.0

### DIFF
--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -81,7 +81,7 @@ Consumer repositories should not contain:
 
 - The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
   when you want compatible updates after each reviewed facade release.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.1.0`. That is the right default when
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.2.0`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
 - Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with
@@ -110,4 +110,5 @@ Consumer repositories should not contain:
 4. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
    comments on a trusted hosted runner.
 5. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
+
 

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -23,7 +23,7 @@ jobs:
       DEFAULT_COMPARE_MODES: attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.1.0
+      FACADE_REF: v1.2.0
       COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.1.0
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.2.0
         with:
           target_spec_path: .github/comparevi-history-targets.json
           target_id: ${{ steps.request.outputs['target-id'] }}
@@ -151,7 +151,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.1.0
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.2.0
           COMMENT_PATH: ${{ steps.history.outputs['public-comment-path'] }}
         run: |
           Set-StrictMode -Version Latest
@@ -192,4 +192,5 @@ jobs:
               ('- PR comment publication: `skipped` ({0})' -f $warning)
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
+
 


### PR DESCRIPTION
## Summary
- prepare the published template refs for `comparevi-history` release `v1.2.0`
- sync the published comment-gated template to the new immutable tag
- sync the safe template docs to the new immutable tag

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `.\scripts\Resolve-CompareVIHistoryReleasePublishReadiness.ps1 -BackendTag 'v0.6.3-tools.8' -ImmutableTag 'v1.2.0' -OutputPath release-readiness-v1.2.0.json -FailIfPreparationRequired`

## Issue
- closes #34

## Agent Metadata
- agent: Codex
- repo: LabVIEW-Community-CI-CD/comparevi-history
- issue: #34
- scope: release prep for v1.2.0
