### PR TITLE
#50 Fix manual exploration results-root reuse

### DIFF
--- a/.github/workflows/manual-vi-exploration.yml
+++ b/.github/workflows/manual-vi-exploration.yml
@@ -85,6 +85,7 @@ jobs:
       consumer-repository: ${{ steps.defaults.outputs.consumer_repository }}
       consumer-ref: ${{ steps.defaults.outputs.consumer_ref }}
       revision-catalog-path: ${{ steps.catalog.outputs['revision-catalog-path'] }}
+      results-root: ${{ steps.results_root.outputs['results-root'] }}
       normalized-target-path: ${{ steps.catalog.outputs['normalized-target-path'] }}
       revision-count: ${{ steps.catalog.outputs['revision-count'] }}
       catalog-complete: ${{ steps.catalog.outputs['catalog-complete'] }}
@@ -190,6 +191,16 @@ jobs:
             -GitHubOutputPath $env:GITHUB_OUTPUT `
             -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
 
+      - name: Resolve exploration results root
+        id: results_root
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $resultsRoot = Split-Path -Parent '${{ steps.catalog.outputs['revision-catalog-path'] }}'
+          "results-root=$resultsRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
       - name: Plan manual exploration chunks
         id: plan
         shell: pwsh
@@ -199,7 +210,7 @@ jobs:
 
           & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryChunkPlan.ps1" `
             -RevisionCatalogPath '${{ steps.catalog.outputs['revision-catalog-path'] }}' `
-            -ResultsDir 'tests/results/ref-compare/history-exploration' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -GitHubOutputPath $env:GITHUB_OUTPUT `
             -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
 
@@ -217,7 +228,7 @@ jobs:
           & "$env:GITHUB_WORKSPACE/platform/scripts/Invoke-CompareVIHistoryChunkExecution.ps1" `
             -ConsumerRepositoryRoot $consumerRoot `
             -ChunkPlanPath '${{ steps.plan.outputs['chunk-plan-path'] }}' `
-            -ResultsDir 'tests/results/ref-compare/history-exploration' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -Mode '${{ inputs.modes }}' `
             -NoisePolicy '${{ inputs.noise_policy }}' `
             -IncludeMergeParents:$includeMergeParents `
@@ -235,7 +246,7 @@ jobs:
           & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryExplorationRun.ps1" `
             -RevisionCatalogPath '${{ steps.catalog.outputs['revision-catalog-path'] }}' `
             -ChunkPlanPath '${{ steps.plan.outputs['chunk-plan-path'] }}' `
-            -ResultsDir 'tests/results/ref-compare/history-exploration' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -Modes '${{ inputs.modes }}' `
             -NoisePolicy '${{ inputs.noise_policy }}' `
             -IncludeMergeParents:$includeMergeParents `
@@ -252,7 +263,7 @@ jobs:
           & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryExplorationBundle.ps1" `
             -RevisionCatalogPath '${{ steps.catalog.outputs['revision-catalog-path'] }}' `
             -ChunkPlanPath '${{ steps.plan.outputs['chunk-plan-path'] }}' `
-            -ResultsDir 'tests/results/ref-compare/history-exploration' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -ExplorationRunPath '${{ steps.exploration_seed.outputs['exploration-run-path'] }}' `
             -IndexMd '${{ steps.exploration_seed.outputs['index-md'] }}' `
             -IndexHtml '${{ steps.exploration_seed.outputs['index-html'] }}' `
@@ -272,7 +283,7 @@ jobs:
           & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryExplorationRun.ps1" `
             -RevisionCatalogPath '${{ steps.catalog.outputs['revision-catalog-path'] }}' `
             -ChunkPlanPath '${{ steps.plan.outputs['chunk-plan-path'] }}' `
-            -ResultsDir 'tests/results/ref-compare/history-exploration' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -Modes '${{ inputs.modes }}' `
             -NoisePolicy '${{ inputs.noise_policy }}' `
             -IncludeMergeParents:$includeMergeParents `

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -60,6 +60,24 @@ function Assert-Equal {
   }
 }
 
+function Assert-MatchCount {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Content,
+    [Parameter(Mandatory = $true)]
+    [string]$Pattern,
+    [Parameter(Mandatory = $true)]
+    [int]$ExpectedCount,
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  $actualCount = [regex]::Matches($Content, $Pattern).Count
+  if ($actualCount -ne $ExpectedCount) {
+    throw "$Message Expected '$ExpectedCount', actual '$actualCount'."
+  }
+}
+
 $manualTemplate = Get-Content -LiteralPath $manualTemplatePath -Raw
 $commentTemplate = Get-Content -LiteralPath $commentTemplatePath -Raw
 $manualExplorationTemplate = Get-Content -LiteralPath $manualExplorationTemplatePath -Raw
@@ -100,6 +118,7 @@ Assert-Match -Content $manualExplorationWorkflow -Pattern 'Invoke-CompareVIHisto
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'Write-CompareVIHistoryExplorationBundle\.ps1' -Message 'Manual exploration workflow must write the exploration bundle.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'Write-CompareVIHistoryExplorationRun\.ps1' -Message 'Manual exploration workflow must write the exploration run receipt.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'revision-catalog-path' -Message 'Manual exploration workflow must expose the revision catalog output.'
+Assert-Match -Content $manualExplorationWorkflow -Pattern 'results-root' -Message 'Manual exploration workflow must expose the resolved exploration results root.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'chunk-plan-path' -Message 'Manual exploration workflow must expose the chunk plan output.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'execution-status' -Message 'Manual exploration workflow must expose the chunk execution status.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'bundle-status' -Message 'Manual exploration workflow must expose the bundle status.'
@@ -110,6 +129,9 @@ Assert-Match -Content $manualExplorationWorkflow -Pattern 'index-html' -Message 
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'timeline-md' -Message 'Manual exploration workflow must expose the timeline markdown output.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'timeline-html' -Message 'Manual exploration workflow must expose the timeline HTML output.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern 'platform_ref' -Message 'Manual exploration workflow must expose the platform_ref seam explicitly.'
+Assert-Match -Content $manualExplorationWorkflow -Pattern "Split-Path -Parent '\$\{\{ steps\.catalog\.outputs\['revision-catalog-path'\] \}\}'" -Message 'Manual exploration workflow must derive the resolved results root from the revision catalog output.'
+Assert-Match -Content $manualExplorationWorkflow -Pattern "\$\{\{ steps\.results_root\.outputs\['results-root'\] \}\}" -Message 'Manual exploration workflow must route the resolved results root into later stages.'
+Assert-MatchCount -Content $manualExplorationWorkflow -Pattern "'tests/results/ref-compare/history-exploration'" -ExpectedCount 1 -Message 'Manual exploration workflow must only use the relative results directory during catalog generation.'
 
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Comment-gated template must use ubuntu-latest.'
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Comment-gated template must request pull-requests: write.'


### PR DESCRIPTION
## Summary
- resolve one absolute manual-exploration results root from the revision catalog output
- reuse that resolved root for planning, execution, bundle creation, and final receipt generation
- lock the workflow contract so the relative results directory is only used during catalog generation

Closes #50.

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`
