### PR TITLE
#52 Sync published templates for v1.3.1

### DIFF
--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -81,7 +81,7 @@ Consumer repositories should not contain:
 
 - The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
   when you want compatible updates after each reviewed facade release.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.0`. That is the right default when
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.1`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
 - Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -23,7 +23,7 @@ jobs:
       DEFAULT_COMPARE_MODES: attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.3.0
+      FACADE_REF: v1.3.1
       COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
@@ -105,7 +105,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.0
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.1
         with:
           target_spec_path: .github/comparevi-history-targets.json
           target_id: ${{ steps.request.outputs['target-id'] }}
@@ -151,7 +151,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.0
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.1
           COMMENT_PATH: ${{ steps.history.outputs['public-comment-path'] }}
         run: |
           Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- sync the published comment-gated template to `v1.3.1`
- sync the safe-template guidance to the same immutable tag
- clear the `release.yml` publish-readiness gate for `v1.3.1`

Closes #52.

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1 -BackendTag v0.6.3-tools.8 -ImmutableTag v1.3.1`
- `git diff --check`
