### PR TITLE
#62 Handle empty mode summaries in manual exploration

### DIFF
--- a/scripts/Format-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Format-CompareVIHistoryModeSummary.ps1
@@ -184,6 +184,32 @@ function Format-CountMap {
   return (($normalized.Keys | ForEach-Object { '{0} ({1})' -f $_, [int]$normalized[$_] }) -join ', ')
 }
 
+function Get-ModeSummaryTotal {
+  param(
+    [AllowNull()]
+    $ModeSummaries,
+    [Parameter(Mandatory = $true)]
+    [string]$PropertyName
+  )
+
+  $total = 0
+  foreach ($modeSummary in @(ConvertTo-ObjectArray -Value $ModeSummaries)) {
+    $value = Get-EntryValue -Entry $modeSummary -Name $PropertyName -DefaultValue 0
+    if ($null -eq $value) {
+      continue
+    }
+
+    $renderedValue = [string]$value
+    if ([string]::IsNullOrWhiteSpace($renderedValue)) {
+      continue
+    }
+
+    $total += [int]$value
+  }
+
+  return $total
+}
+
 function Get-SuppressionProfile {
   param(
     [AllowNull()]
@@ -407,12 +433,12 @@ $suppressionProfile = if ($aggregateProfiles.Count -eq 0) {
 }
 
 $effectiveTotalProcessed = if ([string]::IsNullOrWhiteSpace($TotalProcessed)) {
-  [string](($modeSummaries | Measure-Object -Property processed -Sum).Sum)
+  [string](Get-ModeSummaryTotal -ModeSummaries $modeSummaries -PropertyName 'processed')
 } else {
   $TotalProcessed
 }
 $effectiveTotalDiffs = if ([string]::IsNullOrWhiteSpace($TotalDiffs)) {
-  [string](($modeSummaries | Measure-Object -Property diffs -Sum).Sum)
+  [string](Get-ModeSummaryTotal -ModeSummaries $modeSummaries -PropertyName 'diffs')
 } else {
   $TotalDiffs
 }

--- a/scripts/Test-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Test-CompareVIHistoryModeSummary.ps1
@@ -179,6 +179,47 @@ try {
   if ($legacySummary -notmatch '\| default \| unsuppressed \| none \| 1 \| 1 \| 0 \| 0 \| captures=0; images=0 \| ok \|') {
     throw 'Legacy summary did not fall back missing per-mode fields to zero.'
   }
+
+  $emptyJsonOutputPath = Join-Path $tempRoot 'empty-mode-summary.json'
+  $emptySummary = & $scriptPath `
+    -RequestedModeList 'full' `
+    -ExecutedModeList '' `
+    -ModeManifestsJson '' `
+    -TotalProcessed '' `
+    -TotalDiffs '' `
+    -StopReason 'facade-step-failed' `
+    -NoisePolicy 'include' `
+    -JsonOutputPath $emptyJsonOutputPath
+
+  if ($emptySummary -notmatch 'Requested modes: `full`') {
+    throw 'Empty mode summary did not preserve the requested mode list.'
+  }
+  if ($emptySummary -notmatch 'Executed modes: `n/a`') {
+    throw 'Empty mode summary did not keep executed modes empty.'
+  }
+  if ($emptySummary -notmatch 'Suppression profile: `unknown`') {
+    throw 'Empty mode summary did not degrade suppression profile to unknown.'
+  }
+  if ($emptySummary -notmatch 'Total processed: `0`') {
+    throw 'Empty mode summary did not fall back total processed to zero.'
+  }
+  if ($emptySummary -notmatch 'Total diffs: `0`') {
+    throw 'Empty mode summary did not fall back total diffs to zero.'
+  }
+  if ($emptySummary -notmatch 'Stop reason: `facade-step-failed`') {
+    throw 'Empty mode summary did not preserve the stop reason.'
+  }
+
+  $emptySummaryJson = Get-Content -LiteralPath $emptyJsonOutputPath -Raw | ConvertFrom-Json -Depth 64
+  if ($emptySummaryJson.suppressionProfile -ne 'unknown') {
+    throw 'Empty mode summary JSON suppression profile mismatch.'
+  }
+  if ($emptySummaryJson.totalProcessed -ne 0 -or $emptySummaryJson.totalDiffs -ne 0) {
+    throw 'Empty mode summary JSON totals mismatch.'
+  }
+  if ($emptySummaryJson.metadata.captureCount -ne 0 -or $emptySummaryJson.metadata.imageArtifactCount -ne 0) {
+    throw 'Empty mode summary JSON metadata counts mismatch.'
+  }
 } finally {
   Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
## Summary
- handle empty mode-summary collections without dereferencing `.Sum` unsafely
- keep chunk execution on the fail-closed path when execution stops before mode manifests are emitted
- add a direct regression for the empty-mode-summary hosted failure shape

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryModeSummary.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryChunkExecution.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryManualExplorationFastLoop.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #62.
