### PR TITLE
#70 Normalize manual exploration comparison pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ The current execution slice stays additive on top of the discovery-first baselin
 - the platform keeps unsuppressed LVCompare output in-band and surfaces deterministic metadata summaries for capture
   artifacts such as images instead of collapsing them into generic noise counts
 - the platform emits `exploration-run.json` as the top-level execution and aggregation receipt
+- the platform keeps `categoryCounts` semantic and emits structured `comparisonPairs` separately so HTML-rendered
+  compare identity fragments remain machine-readable instead of leaking into category keys
 - the platform writes `index.md` and `index.html` as the first operator-facing navigation surfaces
 - the platform also writes `timeline.md` and `timeline.html` for the deeper chunk-by-chunk timeline view
 - the platform packages the timeline, receipts, and per-chunk reports into one deterministic bundle

--- a/docs/schemas/comparevi-history-exploration-run-v1.schema.json
+++ b/docs/schemas/comparevi-history-exploration-run-v1.schema.json
@@ -95,6 +95,7 @@
         "imageMimeTypes",
         "chunkCountWithMetadata",
         "categoryCounts",
+        "comparisonPairs",
         "bucketCounts"
       ],
       "properties": {
@@ -134,6 +135,30 @@
           "additionalProperties": {
             "type": "integer",
             "minimum": 0
+          }
+        },
+        "comparisonPairs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "firstPath",
+              "secondPath",
+              "count"
+            ],
+            "properties": {
+              "firstPath": {
+                "type": "string"
+              },
+              "secondPath": {
+                "type": "string"
+              },
+              "count": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
           }
         },
         "bucketCounts": {

--- a/scripts/Format-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Format-CompareVIHistoryModeSummary.ps1
@@ -119,6 +119,14 @@ function Get-EntryValue {
     $DefaultValue = $null
   )
 
+  if ($Entry -is [System.Collections.IDictionary]) {
+    if ($Entry.Contains($Name)) {
+      return $Entry[$Name]
+    }
+
+    return $DefaultValue
+  }
+
   $property = $Entry.PSObject.Properties[$Name]
   if ($null -eq $property) {
     return $DefaultValue
@@ -182,6 +190,176 @@ function Format-CountMap {
   }
 
   return (($normalized.Keys | ForEach-Object { '{0} ({1})' -f $_, [int]$normalized[$_] }) -join ', ')
+}
+
+function Normalize-CategoryLabel {
+  param(
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return ''
+  }
+
+  $decoded = [System.Net.WebUtility]::HtmlDecode($Value)
+  $withoutTags = [regex]::Replace($decoded, '<[^>]+>', ' ')
+  return ([regex]::Replace($withoutTags, '\s+', ' ')).Trim()
+}
+
+function Try-ParseComparisonPairLabel {
+  param(
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$Label
+  )
+
+  $normalizedLabel = Normalize-CategoryLabel -Value $Label
+  if ([string]::IsNullOrWhiteSpace($normalizedLabel)) {
+    return $null
+  }
+
+  $pattern = '^\s*First\s+VI:\s*(?<first>.+?)\s+Second\s+VI:\s*(?<second>.+?)\s*$'
+  if ($normalizedLabel -notmatch $pattern) {
+    return $null
+  }
+
+  return [ordered]@{
+    firstPath = $Matches['first'].Trim()
+    secondPath = $Matches['second'].Trim()
+  }
+}
+
+function Add-ComparisonPairAggregate {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Target,
+    [Parameter(Mandatory = $true)]
+    [string]$FirstPath,
+    [Parameter(Mandatory = $true)]
+    [string]$SecondPath,
+    [int]$Count = 1
+  )
+
+  $key = '{0}`n{1}' -f $FirstPath, $SecondPath
+  if (-not $Target.Contains($key)) {
+    $Target[$key] = [ordered]@{
+      firstPath = $FirstPath
+      secondPath = $SecondPath
+      count = 0
+    }
+  }
+
+  $Target[$key].count = [int]$Target[$key].count + [int]$Count
+}
+
+function ConvertTo-ComparisonPairArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [System.Collections.IDictionary]) {
+    return @(
+      $Value.GetEnumerator() |
+        Sort-Object { [string]$_.Value.firstPath }, { [string]$_.Value.secondPath } |
+        ForEach-Object {
+          [ordered]@{
+            firstPath = [string]$_.Value.firstPath
+            secondPath = [string]$_.Value.secondPath
+            count = [int]$_.Value.count
+          }
+        }
+    )
+  }
+
+  $pairs = New-Object System.Collections.Generic.List[object]
+  foreach ($pair in @(ConvertTo-ObjectArray -Value $Value)) {
+    $firstPath = [string](Get-EntryValue -Entry $pair -Name 'firstPath' -DefaultValue '')
+    $secondPath = [string](Get-EntryValue -Entry $pair -Name 'secondPath' -DefaultValue '')
+    if ([string]::IsNullOrWhiteSpace($firstPath) -or [string]::IsNullOrWhiteSpace($secondPath)) {
+      continue
+    }
+
+    $pairs.Add([ordered]@{
+        firstPath = $firstPath.Trim()
+        secondPath = $secondPath.Trim()
+        count = [int](Get-EntryValue -Entry $pair -Name 'count' -DefaultValue 0)
+      }) | Out-Null
+  }
+
+  return @(
+    $pairs |
+      Sort-Object { [string]$_.firstPath }, { [string]$_.secondPath } |
+      ForEach-Object { $_ }
+  )
+}
+
+function Merge-ComparisonPairCollection {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Target,
+    [AllowNull()]
+    $Source
+  )
+
+  foreach ($pair in @(ConvertTo-ComparisonPairArray -Value $Source)) {
+    Add-ComparisonPairAggregate -Target $Target -FirstPath ([string]$pair.firstPath) -SecondPath ([string]$pair.secondPath) -Count ([int]$pair.count)
+  }
+}
+
+function ConvertTo-NormalizedCategorySurface {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  $normalizedSource = ConvertTo-OrderedCountMap -Value $Value
+  $categoryCounts = @{}
+  $comparisonPairs = @{}
+
+  foreach ($rawKey in @($normalizedSource.Keys | Sort-Object)) {
+    $count = [int]$normalizedSource[$rawKey]
+    $comparisonPair = Try-ParseComparisonPairLabel -Label ([string]$rawKey)
+    if ($null -ne $comparisonPair) {
+      Add-ComparisonPairAggregate -Target $comparisonPairs -FirstPath ([string]$comparisonPair.firstPath) -SecondPath ([string]$comparisonPair.secondPath) -Count $count
+      continue
+    }
+
+    $normalizedKey = Normalize-CategoryLabel -Value ([string]$rawKey)
+    if ([string]::IsNullOrWhiteSpace($normalizedKey)) {
+      continue
+    }
+
+    if (-not $categoryCounts.Contains($normalizedKey)) {
+      $categoryCounts[$normalizedKey] = 0
+    }
+    $categoryCounts[$normalizedKey] = [int]$categoryCounts[$normalizedKey] + $count
+  }
+
+  return [pscustomobject]@{
+    categoryCounts = ConvertTo-OrderedCountMap -Value $categoryCounts
+    comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $comparisonPairs)
+  }
+}
+
+function Format-ComparisonPairList {
+  param(
+    [AllowNull()]
+    $Pairs
+  )
+
+  $pairArray = @(ConvertTo-ComparisonPairArray -Value $Pairs)
+  if ($pairArray.Count -eq 0) {
+    return 'none'
+  }
+
+  return (($pairArray | ForEach-Object { '{0} -> {1} ({2})' -f [string]$_.firstPath, [string]$_.secondPath, [int]$_.count }) -join ', ')
 }
 
 function Get-ModeSummaryTotal {
@@ -318,7 +496,9 @@ function Get-ModeSurfaceSummary {
   }
 
   $stats = if ($manifest) { Get-EntryValue -Entry $manifest -Name 'stats' -DefaultValue $null } else { $null }
-  $categoryCounts = ConvertTo-OrderedCountMap -Value $(if ($stats) { Get-EntryValue -Entry $stats -Name 'categoryCounts' -DefaultValue $null } else { Get-EntryValue -Entry $Entry -Name 'categoryCounts' -DefaultValue $null })
+  $categorySurface = ConvertTo-NormalizedCategorySurface -Value $(if ($stats) { Get-EntryValue -Entry $stats -Name 'categoryCounts' -DefaultValue $null } else { Get-EntryValue -Entry $Entry -Name 'categoryCounts' -DefaultValue $null })
+  $categoryCounts = $categorySurface.categoryCounts
+  $comparisonPairs = @($categorySurface.comparisonPairs)
   $bucketCounts = ConvertTo-OrderedCountMap -Value $(if ($stats) { Get-EntryValue -Entry $stats -Name 'bucketCounts' -DefaultValue $null } else { Get-EntryValue -Entry $Entry -Name 'bucketCounts' -DefaultValue $null })
 
   $artifactDirSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
@@ -361,6 +541,7 @@ function Get-ModeSurfaceSummary {
     flags = @($flags | Sort-Object -Unique)
     suppressionProfile = Get-SuppressionProfile -Flags $flags
     categoryCounts = $categoryCounts
+    comparisonPairs = $comparisonPairs
     bucketCounts = $bucketCounts
     metadata = [ordered]@{
       comparisonArtifactCount = $comparisonArtifactCount
@@ -400,6 +581,7 @@ if ($executedModes.Count -eq 0 -and $modeEntries.Count -gt 0) {
 $modeSummaries = @($modeEntries | ForEach-Object { Get-ModeSurfaceSummary -Entry $_ })
 $aggregateCategoryCounts = @{}
 $aggregateBucketCounts = @{}
+$aggregateComparisonPairs = @{}
 $aggregateCaptureCount = 0
 $aggregateImageArtifactCount = 0
 $aggregateComparisonArtifactCount = 0
@@ -415,6 +597,7 @@ foreach ($modeSummary in $modeSummaries) {
     [void]$aggregateProfiles.Add($profile)
   }
   Merge-CountMap -Target $aggregateCategoryCounts -Source $modeSummary.categoryCounts
+  Merge-ComparisonPairCollection -Target $aggregateComparisonPairs -Source $modeSummary.comparisonPairs
   Merge-CountMap -Target $aggregateBucketCounts -Source $modeSummary.bucketCounts
   $aggregateCaptureCount += [int]$modeSummary.metadata.captureCount
   $aggregateImageArtifactCount += [int]$modeSummary.metadata.imageArtifactCount
@@ -453,6 +636,7 @@ $modeSummaryObject = [ordered]@{
   noisePolicy = if ([string]::IsNullOrWhiteSpace($NoisePolicy)) { $null } else { $NoisePolicy }
   suppressionProfile = $suppressionProfile
   categoryCounts = [ordered]@{}
+  comparisonPairs = @()
   bucketCounts = [ordered]@{}
   metadata = [ordered]@{
     comparisonArtifactCount = $aggregateComparisonArtifactCount
@@ -466,6 +650,7 @@ $modeSummaryObject = [ordered]@{
 foreach ($key in @($aggregateCategoryCounts.Keys | Sort-Object)) {
   $modeSummaryObject.categoryCounts[$key] = [int]$aggregateCategoryCounts[$key]
 }
+$modeSummaryObject.comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $aggregateComparisonPairs)
 foreach ($key in @($aggregateBucketCounts.Keys | Sort-Object)) {
   $modeSummaryObject.bucketCounts[$key] = [int]$aggregateBucketCounts[$key]
 }
@@ -488,6 +673,9 @@ if ($aggregateCaptureCount -gt 0 -or $aggregateImageArtifactCount -gt 0 -or $agg
 }
 if ($modeSummaryObject.categoryCounts.Count -gt 0) {
   $summaryLines.Add(('Category counts: `{0}`' -f (Format-CountMap -Map $modeSummaryObject.categoryCounts)))
+}
+if ($modeSummaryObject.comparisonPairs.Count -gt 0) {
+  $summaryLines.Add(('Comparison pairs: `{0}`' -f (Format-ComparisonPairList -Pairs $modeSummaryObject.comparisonPairs)))
 }
 if ($modeSummaryObject.bucketCounts.Count -gt 0) {
   $summaryLines.Add(('Bucket counts: `{0}`' -f (Format-CountMap -Map $modeSummaryObject.bucketCounts)))
@@ -529,6 +717,9 @@ if ($modeSummaries.Count -gt 0) {
     $detailParts = New-Object System.Collections.Generic.List[string]
     if ($entry.categoryCounts.Count -gt 0) {
       $detailParts.Add(('categories={0}' -f (Format-CountMap -Map $entry.categoryCounts))) | Out-Null
+    }
+    if (@($entry.comparisonPairs).Count -gt 0) {
+      $detailParts.Add(('comparison-pairs={0}' -f (Format-ComparisonPairList -Pairs $entry.comparisonPairs))) | Out-Null
     }
     if ($entry.bucketCounts.Count -gt 0) {
       $detailParts.Add(('buckets={0}' -f (Format-CountMap -Map $entry.bucketCounts))) | Out-Null

--- a/scripts/Test-CompareVIHistoryExplorationRun.ps1
+++ b/scripts/Test-CompareVIHistoryExplorationRun.ps1
@@ -211,7 +211,10 @@ try {
       imageArtifactCount = 1
       imageMimeTypes = @('image/png')
       chunkCountWithMetadata = 1
-      categoryCounts = [ordered]@{ attributes = 1 }
+      categoryCounts = [ordered]@{
+        '<div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div>' = 2
+        'Block Diagram objects' = 1
+      }
       bucketCounts = [ordered]@{ 'metadata-rich' = 1 }
     }
     failure = $null
@@ -303,6 +306,18 @@ try {
   if (($executedRun.surfaces.imageMimeTypes -join ',') -ne 'image/png') {
     throw 'Executed exploration run mime-type aggregation mismatch.'
   }
+  if ($executedRun.surfaces.categoryCounts.PSObject.Properties.Name -match 'First VI') {
+    throw 'Executed exploration run category counts must not retain raw comparison identity fragments.'
+  }
+  if ($executedRun.surfaces.categoryCounts.'Block Diagram objects' -ne 1) {
+    throw 'Executed exploration run normalized category counts mismatch.'
+  }
+  if ($executedRun.surfaces.comparisonPairs.Count -ne 1) {
+    throw 'Executed exploration run comparison pair count mismatch.'
+  }
+  if ($executedRun.surfaces.comparisonPairs[0].firstPath -ne '/compare/m0/Base.vi' -or $executedRun.surfaces.comparisonPairs[0].secondPath -ne '/compare/m0/Head.vi' -or $executedRun.surfaces.comparisonPairs[0].count -ne 2) {
+    throw 'Executed exploration run comparison pair normalization mismatch.'
+  }
 
   $timelineMarkdown = Get-Content -LiteralPath $executedRun.outputs.timelineMd -Raw
   if ($timelineMarkdown -notmatch [regex]::Escape([string]$chunkPlan.chunks[0].chunkId)) {
@@ -315,6 +330,7 @@ try {
       'Failed chunk count: `1`',
       'Suppression profile: `unsuppressed`',
       'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`',
+      'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`',
       'Remaining planned chunk count: `0`',
       'Replay status: `degraded` \(partial-chunk-execution\)'
     )) {
@@ -333,6 +349,7 @@ try {
       'Failed chunk count: `1`',
       'Suppression profile: `unsuppressed`',
       'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`',
+      'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`',
       'Replay status: `degraded` \(partial-chunk-execution\)',
       'Bundle status: `not-required`'
     )) {
@@ -346,6 +363,7 @@ try {
       'Failed chunk count: `1`',
       'Remaining planned chunk count: `0`',
       'Continuity break count: `0`',
+      'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`',
       'Replay status: `degraded` \(partial-chunk-execution\)'
     )) {
     if ($executedSummary -notmatch $requiredFragment) {

--- a/scripts/Test-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Test-CompareVIHistoryModeSummary.ps1
@@ -56,7 +56,9 @@ try {
     )
     stats = [ordered]@{
       categoryCounts = [ordered]@{
-        attributes = 1
+        '<div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div>' = 2
+        'Block Diagram Cosmetic' = 1
+        'Block Diagram objects' = 2
       }
       bucketCounts = [ordered]@{
         'metadata-rich' = 1
@@ -76,7 +78,9 @@ try {
       manifest = $fullManifestPath
       flags = @()
       categoryCounts = [ordered]@{
-        attributes = 1
+        '<div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div>' = 2
+        'Block Diagram Cosmetic' = 1
+        'Block Diagram objects' = 2
       }
       bucketCounts = [ordered]@{
         'metadata-rich' = 1
@@ -118,16 +122,22 @@ try {
   if ($summary -notmatch 'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`') {
     throw 'Summary did not surface the aggregate capture metadata.'
   }
-  if ($summary -notmatch 'Category counts: `attributes \(1\)`') {
-    throw 'Summary did not surface category counts.'
+  if ($summary -notmatch 'Category counts: `Block Diagram Cosmetic \(1\), Block Diagram objects \(2\)`') {
+    throw 'Summary did not surface normalized category counts.'
+  }
+  if ($summary -notmatch 'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`') {
+    throw 'Summary did not surface structured comparison pairs.'
   }
   if ($summary -notmatch 'Bucket counts: `metadata-rich \(1\)`') {
     throw 'Summary did not surface bucket counts.'
   }
+  if ($summary -match '<div class=') {
+    throw 'Summary must not leak raw HTML category markup.'
+  }
   if ($summary -notmatch '\| full \| unsuppressed \| none \| 2 \| 1 \| 1 \| in-band \| captures=1; images=1 \| ok \|') {
     throw 'Summary did not include the raw full-mode row.'
   }
-  if ($summary -notmatch '- full: `categories=attributes \(1\); buckets=metadata-rich \(1\); metadata=captures:1, images:1, artifact-dirs:1, mime-types:image/png`') {
+  if ($summary -notmatch '- full: `categories=Block Diagram Cosmetic \(1\), Block Diagram objects \(2\); comparison-pairs=/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\); buckets=metadata-rich \(1\); metadata=captures:1, images:1, artifact-dirs:1, mime-types:image/png`') {
     throw 'Summary did not include the per-mode metadata detail line.'
   }
   if (-not (Test-Path -LiteralPath $outputPath -PathType Leaf)) {
@@ -146,6 +156,18 @@ try {
   }
   if ($modeSummaryJson.metadata.captureCount -ne 1 -or $modeSummaryJson.metadata.imageArtifactCount -ne 1) {
     throw 'Mode summary JSON metadata counts mismatch.'
+  }
+  if ($modeSummaryJson.categoryCounts.PSObject.Properties.Name -match 'First VI') {
+    throw 'Mode summary JSON category counts must not retain comparison identity fragments.'
+  }
+  if ($modeSummaryJson.categoryCounts.'Block Diagram Cosmetic' -ne 1 -or $modeSummaryJson.categoryCounts.'Block Diagram objects' -ne 2) {
+    throw 'Mode summary JSON normalized category counts mismatch.'
+  }
+  if ($modeSummaryJson.comparisonPairs.Count -ne 1) {
+    throw 'Mode summary JSON comparison pair count mismatch.'
+  }
+  if ($modeSummaryJson.comparisonPairs[0].firstPath -ne '/compare/m0/Base.vi' -or $modeSummaryJson.comparisonPairs[0].secondPath -ne '/compare/m0/Head.vi' -or $modeSummaryJson.comparisonPairs[0].count -ne 2) {
+    throw 'Mode summary JSON comparison pair normalization mismatch.'
   }
   if (($modeSummaryJson.metadata.imageMimeTypes -join ',') -ne 'image/png') {
     throw 'Mode summary JSON mime-type aggregation mismatch.'

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -188,6 +188,7 @@ Assert-Match -Content $readme -Pattern 'comparevi-history/revision-catalog@v1' -
 Assert-Match -Content $readme -Pattern 'comparevi-history/exploration-run@v1' -Message 'README must document the exploration run contract.'
 Assert-Match -Content $readme -Pattern 'modes=full' -Message 'README must document the raw manual exploration mode default.'
 Assert-Match -Content $readme -Pattern 'noise_policy=include' -Message 'README must document the raw manual exploration noise-policy default.'
+Assert-Match -Content $readme -Pattern 'structured `comparisonPairs` separately' -Message 'README must document structured comparison-pair outputs for manual exploration.'
 Assert-Match -Content $readme -Pattern 'mode-summary\.json' -Message 'README must document the machine-readable mode summary output.'
 Assert-Match -Content $readme -Pattern 'index\.md' -Message 'README must document the index markdown output.'
 Assert-Match -Content $readme -Pattern 'index\.html' -Message 'README must document the index HTML output.'

--- a/scripts/Write-CompareVIHistoryExplorationRun.ps1
+++ b/scripts/Write-CompareVIHistoryExplorationRun.ps1
@@ -264,6 +264,179 @@ function Format-CountMapText {
   return (($normalized.Keys | ForEach-Object { '{0} ({1})' -f $_, [int]$normalized[$_] }) -join ', ')
 }
 
+function Normalize-CategoryLabel {
+  param(
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return ''
+  }
+
+  $decoded = [System.Net.WebUtility]::HtmlDecode($Value)
+  $withoutTags = [regex]::Replace($decoded, '<[^>]+>', ' ')
+  return ([regex]::Replace($withoutTags, '\s+', ' ')).Trim()
+}
+
+function Try-ParseComparisonPairLabel {
+  param(
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$Label
+  )
+
+  $normalizedLabel = Normalize-CategoryLabel -Value $Label
+  if ([string]::IsNullOrWhiteSpace($normalizedLabel)) {
+    return $null
+  }
+
+  $pattern = '^\s*First\s+VI:\s*(?<first>.+?)\s+Second\s+VI:\s*(?<second>.+?)\s*$'
+  if ($normalizedLabel -notmatch $pattern) {
+    return $null
+  }
+
+  return [ordered]@{
+    firstPath = $Matches['first'].Trim()
+    secondPath = $Matches['second'].Trim()
+  }
+}
+
+function Add-ComparisonPairAggregate {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Target,
+    [Parameter(Mandatory = $true)]
+    [string]$FirstPath,
+    [Parameter(Mandatory = $true)]
+    [string]$SecondPath,
+    [int]$Count = 1
+  )
+
+  $key = '{0}`n{1}' -f $FirstPath, $SecondPath
+  if (-not $Target.Contains($key)) {
+    $Target[$key] = [ordered]@{
+      firstPath = $FirstPath
+      secondPath = $SecondPath
+      count = 0
+    }
+  }
+
+  $Target[$key].count = [int]$Target[$key].count + [int]$Count
+}
+
+function ConvertTo-ComparisonPairArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [System.Collections.IDictionary]) {
+    return @(
+      $Value.GetEnumerator() |
+        Sort-Object { [string]$_.Value.firstPath }, { [string]$_.Value.secondPath } |
+        ForEach-Object {
+          [ordered]@{
+            firstPath = [string]$_.Value.firstPath
+            secondPath = [string]$_.Value.secondPath
+            count = [int]$_.Value.count
+          }
+        }
+    )
+  }
+
+  $pairs = New-Object System.Collections.Generic.List[object]
+  foreach ($pair in @(ConvertTo-ObjectArray -InputObject $Value)) {
+    $firstPath = [string](Get-OptionalPropertyValue -InputObject $pair -PropertyName 'firstPath' -Default '')
+    $secondPath = [string](Get-OptionalPropertyValue -InputObject $pair -PropertyName 'secondPath' -Default '')
+    if ([string]::IsNullOrWhiteSpace($firstPath) -or [string]::IsNullOrWhiteSpace($secondPath)) {
+      continue
+    }
+
+    $pairs.Add([ordered]@{
+        firstPath = $firstPath.Trim()
+        secondPath = $secondPath.Trim()
+        count = [int](Get-OptionalPropertyValue -InputObject $pair -PropertyName 'count' -Default 0)
+      }) | Out-Null
+  }
+
+  return @(
+    $pairs |
+      Sort-Object { [string]$_.firstPath }, { [string]$_.secondPath } |
+      ForEach-Object { $_ }
+  )
+}
+
+function Merge-ComparisonPairCollection {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Target,
+    [AllowNull()]
+    $Source
+  )
+
+  foreach ($pair in @(ConvertTo-ComparisonPairArray -Value $Source)) {
+    Add-ComparisonPairAggregate -Target $Target -FirstPath ([string]$pair.firstPath) -SecondPath ([string]$pair.secondPath) -Count ([int]$pair.count)
+  }
+}
+
+function ConvertTo-NormalizedCategorySurface {
+  param(
+    [AllowNull()]
+    $CategoryCounts,
+    [AllowNull()]
+    $ComparisonPairs
+  )
+
+  $normalizedCategoryCounts = @{}
+  $comparisonPairAggregate = @{}
+
+  foreach ($rawKey in @((ConvertTo-OrderedCountMap -Value $CategoryCounts).Keys | Sort-Object)) {
+    $count = [int](ConvertTo-OrderedCountMap -Value $CategoryCounts)[$rawKey]
+    $comparisonPair = Try-ParseComparisonPairLabel -Label ([string]$rawKey)
+    if ($null -ne $comparisonPair) {
+      Add-ComparisonPairAggregate -Target $comparisonPairAggregate -FirstPath ([string]$comparisonPair.firstPath) -SecondPath ([string]$comparisonPair.secondPath) -Count $count
+      continue
+    }
+
+    $normalizedLabel = Normalize-CategoryLabel -Value ([string]$rawKey)
+    if ([string]::IsNullOrWhiteSpace($normalizedLabel)) {
+      continue
+    }
+
+    if (-not $normalizedCategoryCounts.Contains($normalizedLabel)) {
+      $normalizedCategoryCounts[$normalizedLabel] = 0
+    }
+    $normalizedCategoryCounts[$normalizedLabel] = [int]$normalizedCategoryCounts[$normalizedLabel] + $count
+  }
+
+  Merge-ComparisonPairCollection -Target $comparisonPairAggregate -Source $ComparisonPairs
+
+  return [pscustomobject]@{
+    categoryCounts = ConvertTo-OrderedCountMap -Value $normalizedCategoryCounts
+    comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $comparisonPairAggregate)
+  }
+}
+
+function Format-ComparisonPairText {
+  param(
+    [AllowNull()]
+    $Pairs
+  )
+
+  $pairArray = @(ConvertTo-ComparisonPairArray -Value $Pairs)
+  if ($pairArray.Count -eq 0) {
+    return 'none'
+  }
+
+  return (($pairArray | ForEach-Object { '{0} -> {1} ({2})' -f [string]$_.firstPath, [string]$_.secondPath, [int]$_.count }) -join ', ')
+}
+
 function New-ExplorationSurfaceAggregate {
   param(
     [Parameter(Mandatory = $true)]
@@ -275,6 +448,7 @@ function New-ExplorationSurfaceAggregate {
   $hasUnknownProfile = $false
   $aggregateCategoryCounts = @{}
   $aggregateBucketCounts = @{}
+  $aggregateComparisonPairs = @{}
   $captureCount = 0
   $imageArtifactCount = 0
   $comparisonArtifactCount = 0
@@ -295,7 +469,11 @@ function New-ExplorationSurfaceAggregate {
       [void]$suppressionProfiles.Add($profile)
     }
 
-    Merge-CountMap -Target $aggregateCategoryCounts -Source (Get-OptionalPropertyValue -InputObject $surfaceNode -PropertyName 'categoryCounts')
+    $normalizedSurface = ConvertTo-NormalizedCategorySurface `
+      -CategoryCounts (Get-OptionalPropertyValue -InputObject $surfaceNode -PropertyName 'categoryCounts') `
+      -ComparisonPairs (Get-OptionalPropertyValue -InputObject $surfaceNode -PropertyName 'comparisonPairs')
+    Merge-CountMap -Target $aggregateCategoryCounts -Source $normalizedSurface.categoryCounts
+    Merge-ComparisonPairCollection -Target $aggregateComparisonPairs -Source $normalizedSurface.comparisonPairs
     Merge-CountMap -Target $aggregateBucketCounts -Source (Get-OptionalPropertyValue -InputObject $surfaceNode -PropertyName 'bucketCounts')
 
     $metadataNode = Get-SurfaceMetadataNode -SurfaceNode $surfaceNode
@@ -338,6 +516,7 @@ function New-ExplorationSurfaceAggregate {
     imageMimeTypes = @($imageMimeTypes | Sort-Object)
     chunkCountWithMetadata = $chunkCountWithMetadata
     categoryCounts = ConvertTo-OrderedCountMap -Value $aggregateCategoryCounts
+    comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $aggregateComparisonPairs)
     bucketCounts = ConvertTo-OrderedCountMap -Value $aggregateBucketCounts
   }
 }
@@ -410,6 +589,7 @@ function New-ExplorationSurfaceStats {
     imageMimeTypes            = @($SurfaceAggregate.imageMimeTypes)
     chunkCountWithMetadata    = [int]$SurfaceAggregate.chunkCountWithMetadata
     categoryCounts            = $SurfaceAggregate.categoryCounts
+    comparisonPairs           = @($SurfaceAggregate.comparisonPairs)
     bucketCounts              = $SurfaceAggregate.bucketCounts
   }
 }
@@ -499,6 +679,9 @@ function New-MarkdownTimeline {
   if ($RunStats.categoryCounts.Count -gt 0) {
     $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $RunStats.categoryCounts))) | Out-Null
   }
+  if (@($RunStats.comparisonPairs).Count -gt 0) {
+    $lines.Add(('- Comparison pairs: `{0}`' -f (Format-ComparisonPairText -Pairs $RunStats.comparisonPairs))) | Out-Null
+  }
   if ($RunStats.bucketCounts.Count -gt 0) {
     $lines.Add(('- Bucket counts: `{0}`' -f (Format-CountMapText -Map $RunStats.bucketCounts))) | Out-Null
   }
@@ -543,6 +726,9 @@ function New-MarkdownTimeline {
       $lines.Add(('- Total diffs: `{0}`' -f [int](Get-OptionalPropertyValue -InputObject $chunkSummary -PropertyName 'totalDiffs' -Default 0))) | Out-Null
       $lines.Add(('- Final reason: `{0}`' -f [string](Get-OptionalPropertyValue -InputObject $chunkSummary -PropertyName 'finalReason' -Default 'planned'))) | Out-Null
       if ($chunkSurfaces) {
+        $chunkNormalizedSurface = ConvertTo-NormalizedCategorySurface `
+          -CategoryCounts (Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'categoryCounts') `
+          -ComparisonPairs (Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'comparisonPairs')
         $lines.Add(('- Suppression profile: `{0}`' -f [string](Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'suppressionProfile' -Default 'unknown'))) | Out-Null
         $mimeTypeText = if (@(ConvertTo-ObjectArray -InputObject (Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageMimeTypes' -Default @())).Count -gt 0) {
           @(ConvertTo-ObjectArray -InputObject (Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageMimeTypes' -Default @())) -join ', '
@@ -550,9 +736,11 @@ function New-MarkdownTimeline {
           'none'
         }
         $lines.Add(('- Metadata surfaces: `captures={0}, images={1}, artifact-dirs={2}, mime-types={3}`' -f [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'captureCount' -Default 0), [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageArtifactCount' -Default 0), [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'comparisonArtifactCount' -Default 0), $mimeTypeText)) | Out-Null
-        $chunkCategoryCounts = Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'categoryCounts'
-        if ((ConvertTo-OrderedCountMap -Value $chunkCategoryCounts).Count -gt 0) {
-          $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $chunkCategoryCounts))) | Out-Null
+        if ($chunkNormalizedSurface.categoryCounts.Count -gt 0) {
+          $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $chunkNormalizedSurface.categoryCounts))) | Out-Null
+        }
+        if (@($chunkNormalizedSurface.comparisonPairs).Count -gt 0) {
+          $lines.Add(('- Comparison pairs: `{0}`' -f (Format-ComparisonPairText -Pairs $chunkNormalizedSurface.comparisonPairs))) | Out-Null
         }
         $chunkBucketCounts = Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'bucketCounts'
         if ((ConvertTo-OrderedCountMap -Value $chunkBucketCounts).Count -gt 0) {
@@ -642,6 +830,9 @@ function New-MarkdownIndex {
   if ($RunStats.categoryCounts.Count -gt 0) {
     $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $RunStats.categoryCounts))) | Out-Null
   }
+  if (@($RunStats.comparisonPairs).Count -gt 0) {
+    $lines.Add(('- Comparison pairs: `{0}`' -f (Format-ComparisonPairText -Pairs $RunStats.comparisonPairs))) | Out-Null
+  }
   if ($RunStats.bucketCounts.Count -gt 0) {
     $lines.Add(('- Bucket counts: `{0}`' -f (Format-CountMapText -Map $RunStats.bucketCounts))) | Out-Null
   }
@@ -692,6 +883,9 @@ function New-MarkdownIndex {
     $lines.Add(('- Pair ordinals: `{0}` -> `{1}`' -f [int]$chunk.pairOrdinalStart, [int]$chunk.pairOrdinalEnd)) | Out-Null
     $lines.Add(('- Total diffs: `{0}`' -f [int](Get-OptionalPropertyValue -InputObject $chunkSummary -PropertyName 'totalDiffs' -Default 0))) | Out-Null
     if ($chunkSurfaces) {
+      $chunkNormalizedSurface = ConvertTo-NormalizedCategorySurface `
+        -CategoryCounts (Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'categoryCounts') `
+        -ComparisonPairs (Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'comparisonPairs')
       $lines.Add(('- Suppression profile: `{0}`' -f [string](Get-OptionalPropertyValue -InputObject $chunkSurfaces -PropertyName 'suppressionProfile' -Default 'unknown'))) | Out-Null
       $mimeTypeText = if (@(ConvertTo-ObjectArray -InputObject (Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageMimeTypes' -Default @())).Count -gt 0) {
         @(ConvertTo-ObjectArray -InputObject (Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageMimeTypes' -Default @())) -join ', '
@@ -699,6 +893,12 @@ function New-MarkdownIndex {
         'none'
       }
       $lines.Add(('- Metadata surfaces: `captures={0}, images={1}, artifact-dirs={2}, mime-types={3}`' -f [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'captureCount' -Default 0), [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'imageArtifactCount' -Default 0), [int](Get-OptionalPropertyValue -InputObject $chunkMetadata -PropertyName 'comparisonArtifactCount' -Default 0), $mimeTypeText)) | Out-Null
+      if ($chunkNormalizedSurface.categoryCounts.Count -gt 0) {
+        $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $chunkNormalizedSurface.categoryCounts))) | Out-Null
+      }
+      if (@($chunkNormalizedSurface.comparisonPairs).Count -gt 0) {
+        $lines.Add(('- Comparison pairs: `{0}`' -f (Format-ComparisonPairText -Pairs $chunkNormalizedSurface.comparisonPairs))) | Out-Null
+      }
     }
     if ($receiptReference) {
       $lines.Add(('- Receipt: {0}' -f (Format-MarkdownLink -Label 'chunk-receipt.json' -Href $receiptReference))) | Out-Null
@@ -814,6 +1014,7 @@ function New-HtmlTimeline {
     <strong>Metadata surfaces</strong><span>captures=$([int]$RunStats.captureCount), images=$([int]$RunStats.imageArtifactCount), artifact-dirs=$([int]$RunStats.comparisonArtifactCount)</span>
     <strong>Image MIME types</strong><span>$(if ($RunStats.imageMimeTypes.Count -gt 0) { $RunStats.imageMimeTypes -join ', ' } else { 'none' })</span>
     <strong>Category counts</strong><span>$(Format-CountMapText -Map $RunStats.categoryCounts)</span>
+    <strong>Comparison pairs</strong><span>$(Format-ComparisonPairText -Pairs $RunStats.comparisonPairs)</span>
     <strong>Bucket counts</strong><span>$(Format-CountMapText -Map $RunStats.bucketCounts)</span>
     <strong>Completed chunks</strong><span>$([int]$RunStats.completedChunkCount)</span>
     <strong>Failed chunks</strong><span>$([int]$RunStats.failedChunkCount)</span>
@@ -1001,6 +1202,7 @@ function New-HtmlIndex {
     <strong>Metadata surfaces</strong><span>captures=$([int]$RunStats.captureCount), images=$([int]$RunStats.imageArtifactCount), artifact-dirs=$([int]$RunStats.comparisonArtifactCount)</span>
     <strong>Image MIME types</strong><span>$(if ($RunStats.imageMimeTypes.Count -gt 0) { $RunStats.imageMimeTypes -join ', ' } else { 'none' })</span>
     <strong>Category counts</strong><span>$(Format-CountMapText -Map $RunStats.categoryCounts)</span>
+    <strong>Comparison pairs</strong><span>$(Format-ComparisonPairText -Pairs $RunStats.comparisonPairs)</span>
     <strong>Bucket counts</strong><span>$(Format-CountMapText -Map $RunStats.bucketCounts)</span>
     <strong>Completed chunks</strong><span>$([int]$RunStats.completedChunkCount)</span>
     <strong>Failed chunks</strong><span>$([int]$RunStats.failedChunkCount)</span>
@@ -1252,6 +1454,7 @@ $explorationRun = [ordered]@{
     imageMimeTypes = @($surfaceAggregate.imageMimeTypes)
     chunkCountWithMetadata = [int]$surfaceAggregate.chunkCountWithMetadata
     categoryCounts = $surfaceAggregate.categoryCounts
+    comparisonPairs = @($surfaceAggregate.comparisonPairs)
     bucketCounts = $surfaceAggregate.bucketCounts
   }
   discovery = [ordered]@{
@@ -1345,6 +1548,7 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ('- Suppression profile: `{0}`' -f [string]$surfaceAggregate.suppressionProfile)
     ('- Metadata surfaces: `captures={0}, images={1}, artifact-dirs={2}`' -f [int]$surfaceAggregate.captureCount, [int]$surfaceAggregate.imageArtifactCount, [int]$surfaceAggregate.comparisonArtifactCount)
     ('- Category counts: `{0}`' -f (Format-CountMapText -Map $surfaceAggregate.categoryCounts))
+    ('- Comparison pairs: `{0}`' -f (Format-ComparisonPairText -Pairs $surfaceAggregate.comparisonPairs))
     ('- Bucket counts: `{0}`' -f (Format-CountMapText -Map $surfaceAggregate.bucketCounts))
     ('- Index (md): `{0}`' -f $indexMdResolved)
     ('- Index (html): `{0}`' -f $indexHtmlResolved)


### PR DESCRIPTION
## Summary
- normalize manual exploration category surfaces so HTML comparison identity fragments do not leak into `categoryCounts`
- surface structured `comparisonPairs` in `mode-summary.json` and `exploration-run.json`
- document the receipt contract update in the README

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryModeSummary.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryExplorationRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryExplorationIndex.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #70.
