### PR TITLE
#74 Surface manual exploration preview images

### DIFF
--- a/docs/schemas/comparevi-history-exploration-run-v1.schema.json
+++ b/docs/schemas/comparevi-history-exploration-run-v1.schema.json
@@ -96,7 +96,8 @@
         "chunkCountWithMetadata",
         "categoryCounts",
         "comparisonPairs",
-        "bucketCounts"
+        "bucketCounts",
+        "previewImages"
       ],
       "properties": {
         "suppressionProfile": {
@@ -166,6 +167,66 @@
           "additionalProperties": {
             "type": "integer",
             "minimum": 0
+          }
+        },
+        "previewImages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "chunkId",
+              "mode",
+              "category",
+              "comparisonPair",
+              "mimeType",
+              "byteLength",
+              "relativePath",
+              "sortKey"
+            ],
+            "properties": {
+              "chunkId": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "comparisonPair": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "firstPath",
+                  "secondPath"
+                ],
+                "properties": {
+                  "firstPath": {
+                    "type": "string"
+                  },
+                  "secondPath": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "byteLength": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "relativePath": {
+                "type": "string"
+              },
+              "sortKey": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
           }
         }
       },
@@ -366,7 +427,15 @@
         "finalReason",
         "suppressionProfile",
         "captureCount",
-        "imageArtifactCount"
+        "imageArtifactCount",
+        "previewImageCount",
+        "previewGalleryCap",
+        "previewGalleryCount",
+        "previewGalleryOmittedCount",
+        "stepSummaryPreviewCap",
+        "stepSummaryPreviewCount",
+        "stepSummaryPreviewOmittedCount",
+        "stepSummaryPreviewByteBudget"
       ],
       "properties": {
         "revisionCount": {
@@ -407,6 +476,38 @@
           "minimum": 0
         },
         "imageArtifactCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "previewImageCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "previewGalleryCap": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "previewGalleryCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "previewGalleryOmittedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stepSummaryPreviewCap": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stepSummaryPreviewCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stepSummaryPreviewOmittedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "stepSummaryPreviewByteBudget": {
           "type": "integer",
           "minimum": 0
         }

--- a/scripts/Format-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Format-CompareVIHistoryModeSummary.ps1
@@ -313,6 +313,54 @@ function Merge-ComparisonPairCollection {
   }
 }
 
+function Resolve-ArtifactPath {
+  param(
+    [AllowNull()]
+    [AllowEmptyString()]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $resolved = if ([System.IO.Path]::IsPathRooted($Path)) {
+    [System.IO.Path]::GetFullPath($Path)
+  } else {
+    [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+  }
+
+  if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+    return $null
+  }
+
+  return $resolved
+}
+
+function Resolve-ChildRelativePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RootPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ChildPath
+  )
+
+  $rootResolved = [System.IO.Path]::GetFullPath($RootPath)
+  $childResolved = [System.IO.Path]::GetFullPath($ChildPath)
+  $rootWithSeparator = $rootResolved
+  if (-not $rootWithSeparator.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+    $rootWithSeparator += [System.IO.Path]::DirectorySeparatorChar
+  }
+
+  if (-not $childResolved.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+    return $null
+  }
+
+  return $childResolved.Substring($rootWithSeparator.Length).Replace('\', '/')
+}
+
 function ConvertTo-NormalizedCategorySurface {
   param(
     [AllowNull()]
@@ -360,6 +408,100 @@ function Format-ComparisonPairList {
   }
 
   return (($pairArray | ForEach-Object { '{0} -> {1} ({2})' -f [string]$_.firstPath, [string]$_.secondPath, [int]$_.count }) -join ', ')
+}
+
+function Get-PreviewCategoryLabel {
+  param(
+    [AllowNull()]
+    $CategoryCounts
+  )
+
+  $normalized = ConvertTo-OrderedCountMap -Value $CategoryCounts
+  if ($normalized.Count -eq 1) {
+    return [string]@($normalized.Keys)[0]
+  }
+
+  if ($normalized.Count -gt 1) {
+    return 'multiple-categories'
+  }
+
+  return 'uncategorized'
+}
+
+function Get-UniqueComparisonPair {
+  param(
+    [AllowNull()]
+    $ComparisonPairs
+  )
+
+  if ($null -ne $ComparisonPairs) {
+    $directFirstPath = [string](Get-EntryValue -Entry $ComparisonPairs -Name 'firstPath' -DefaultValue '')
+    $directSecondPath = [string](Get-EntryValue -Entry $ComparisonPairs -Name 'secondPath' -DefaultValue '')
+    if (-not [string]::IsNullOrWhiteSpace($directFirstPath) -and -not [string]::IsNullOrWhiteSpace($directSecondPath)) {
+      return [ordered]@{
+        firstPath = $directFirstPath.Trim()
+        secondPath = $directSecondPath.Trim()
+        count = [int](Get-EntryValue -Entry $ComparisonPairs -Name 'count' -DefaultValue 0)
+      }
+    }
+  }
+
+  $pairArray = @(ConvertTo-ComparisonPairArray -Value $ComparisonPairs)
+  if ($pairArray.Count -ne 1) {
+    return $null
+  }
+
+  return [ordered]@{
+    firstPath = [string]$pairArray[0].firstPath
+    secondPath = [string]$pairArray[0].secondPath
+    count = [int]$pairArray[0].count
+  }
+}
+
+function ConvertTo-PreviewImageArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  $previewImages = New-Object System.Collections.Generic.List[object]
+  foreach ($entry in @(ConvertTo-ObjectArray -Value $Value)) {
+    $mimeType = [string](Get-EntryValue -Entry $entry -Name 'mimeType' -DefaultValue '')
+    $byteLength = [int](Get-EntryValue -Entry $entry -Name 'byteLength' -DefaultValue 0)
+    $savedPath = [string](Get-EntryValue -Entry $entry -Name 'savedPath' -DefaultValue '')
+    $artifactRelativePath = [string](Get-EntryValue -Entry $entry -Name 'artifactRelativePath' -DefaultValue '')
+    $mode = [string](Get-EntryValue -Entry $entry -Name 'mode' -DefaultValue 'unknown')
+    $category = [string](Get-EntryValue -Entry $entry -Name 'category' -DefaultValue 'uncategorized')
+    if ([string]::IsNullOrWhiteSpace($savedPath) -or [string]::IsNullOrWhiteSpace($artifactRelativePath)) {
+      continue
+    }
+
+    $comparisonPair = Get-EntryValue -Entry $entry -Name 'comparisonPair' -DefaultValue $null
+    $normalizedPair = Get-UniqueComparisonPair -ComparisonPairs $comparisonPair
+    $pairFirstPath = if ($null -eq $normalizedPair) { '' } else { [string]$normalizedPair.firstPath }
+    $pairSecondPath = if ($null -eq $normalizedPair) { '' } else { [string]$normalizedPair.secondPath }
+    $sortKey = [string](Get-EntryValue -Entry $entry -Name 'sortKey' -DefaultValue '')
+    if ([string]::IsNullOrWhiteSpace($sortKey)) {
+      $sortKey = ('{0}|{1}|{2}|{3}|{4}' -f $mode, $category, $pairFirstPath, $pairSecondPath, $artifactRelativePath).ToLowerInvariant()
+    }
+
+    $previewImages.Add([ordered]@{
+        mode = $(if ([string]::IsNullOrWhiteSpace($mode)) { 'unknown' } else { $mode })
+        category = $(if ([string]::IsNullOrWhiteSpace($category)) { 'uncategorized' } else { $category })
+        comparisonPair = $normalizedPair
+        mimeType = $mimeType
+        byteLength = $byteLength
+        savedPath = $savedPath
+        artifactRelativePath = $artifactRelativePath
+        sortKey = $sortKey
+      }) | Out-Null
+  }
+
+  return @(
+    $previewImages |
+      Sort-Object { [string]$_.sortKey }, { [string]$_.artifactRelativePath } |
+      ForEach-Object { $_ }
+  )
 }
 
 function Get-ModeSummaryTotal {
@@ -428,6 +570,7 @@ function Read-CaptureMetadata {
     captureCount = 0
     imageArtifactCount = 0
     imageMimeTypes = @()
+    previewImages = @()
   }
 
   if ([string]::IsNullOrWhiteSpace($ArtifactDir)) {
@@ -453,14 +596,30 @@ function Read-CaptureMetadata {
   $summary.captureCount = 1
   $mimeTypes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
   $images = ConvertTo-ObjectArray -Value $capture.environment.cli.artifacts.images
+  $previewImages = New-Object System.Collections.Generic.List[object]
   foreach ($image in $images) {
     $summary.imageArtifactCount++
     $mimeType = [string](Get-EntryValue -Entry $image -Name 'mimeType' -DefaultValue '')
     if (-not [string]::IsNullOrWhiteSpace($mimeType)) {
       [void]$mimeTypes.Add($mimeType.Trim())
     }
+
+    $savedPath = Resolve-ArtifactPath -Path ([string](Get-EntryValue -Entry $image -Name 'savedPath' -DefaultValue '')) -BasePath $ArtifactDir
+    $artifactRelativePath = if ($null -eq $savedPath) { $null } else { Resolve-ChildRelativePath -RootPath $ArtifactDir -ChildPath $savedPath }
+    if ($null -eq $savedPath -or [string]::IsNullOrWhiteSpace($artifactRelativePath)) {
+      continue
+    }
+
+    $previewImages.Add([ordered]@{
+        mimeType = $mimeType
+        byteLength = [int](Get-EntryValue -Entry $image -Name 'byteLength' -DefaultValue 0)
+        index = [int](Get-EntryValue -Entry $image -Name 'index' -DefaultValue 0)
+        savedPath = $savedPath
+        artifactRelativePath = $artifactRelativePath
+      }) | Out-Null
   }
   $summary.imageMimeTypes = @($mimeTypes | Sort-Object)
+  $summary.previewImages = @(ConvertTo-PreviewImageArray -Value $previewImages)
   return $summary
 }
 
@@ -506,6 +665,10 @@ function Get-ModeSurfaceSummary {
   $imageArtifactCount = 0
   $comparisonArtifactCount = 0
   $imageMimeTypes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $previewImages = New-Object System.Collections.Generic.List[object]
+  $modeValue = [string](Get-EntryValue -Entry $Entry -Name 'mode' -DefaultValue 'unknown')
+  $previewCategory = Get-PreviewCategoryLabel -CategoryCounts $categoryCounts
+  $previewComparisonPair = Get-UniqueComparisonPair -ComparisonPairs $comparisonPairs
   foreach ($comparison in @(ConvertTo-ObjectArray -Value $(if ($manifest) { Get-EntryValue -Entry $manifest -Name 'comparisons' -DefaultValue @() } else { @() }))) {
     $resultNode = Get-EntryValue -Entry $comparison -Name 'result' -DefaultValue $null
     $artifactDir = [string](Get-EntryValue -Entry $resultNode -Name 'artifactDir' -DefaultValue '')
@@ -528,6 +691,26 @@ function Get-ModeSurfaceSummary {
     foreach ($mimeType in @($captureSummary.imageMimeTypes)) {
       [void]$imageMimeTypes.Add([string]$mimeType)
     }
+    foreach ($previewImage in @(ConvertTo-ObjectArray -Value $captureSummary.previewImages)) {
+      $artifactRelativePath = [string](Get-EntryValue -Entry $previewImage -Name 'artifactRelativePath' -DefaultValue '')
+      $savedPath = [string](Get-EntryValue -Entry $previewImage -Name 'savedPath' -DefaultValue '')
+      if ([string]::IsNullOrWhiteSpace($artifactRelativePath) -or [string]::IsNullOrWhiteSpace($savedPath)) {
+        continue
+      }
+
+      $pairFirstPath = if ($null -eq $previewComparisonPair) { '' } else { [string]$previewComparisonPair.firstPath }
+      $pairSecondPath = if ($null -eq $previewComparisonPair) { '' } else { [string]$previewComparisonPair.secondPath }
+      $previewImages.Add([ordered]@{
+          mode = $(if ([string]::IsNullOrWhiteSpace($modeValue)) { 'unknown' } else { $modeValue })
+          category = $previewCategory
+          comparisonPair = $previewComparisonPair
+          mimeType = [string](Get-EntryValue -Entry $previewImage -Name 'mimeType' -DefaultValue '')
+          byteLength = [int](Get-EntryValue -Entry $previewImage -Name 'byteLength' -DefaultValue 0)
+          savedPath = $savedPath
+          artifactRelativePath = $artifactRelativePath
+          sortKey = ('{0}|{1}|{2}|{3}|{4}' -f $modeValue, $previewCategory, $pairFirstPath, $pairSecondPath, $artifactRelativePath).ToLowerInvariant()
+        }) | Out-Null
+    }
   }
 
   return [pscustomobject]@{
@@ -543,6 +726,7 @@ function Get-ModeSurfaceSummary {
     categoryCounts = $categoryCounts
     comparisonPairs = $comparisonPairs
     bucketCounts = $bucketCounts
+    previewImages = @(ConvertTo-PreviewImageArray -Value $previewImages)
     metadata = [ordered]@{
       comparisonArtifactCount = $comparisonArtifactCount
       captureCount = $captureCount
@@ -587,6 +771,7 @@ $aggregateImageArtifactCount = 0
 $aggregateComparisonArtifactCount = 0
 $aggregateMimeTypes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $aggregateProfiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$aggregatePreviewImages = New-Object System.Collections.Generic.List[object]
 $hasUnknownProfile = $false
 
 foreach ($modeSummary in $modeSummaries) {
@@ -604,6 +789,9 @@ foreach ($modeSummary in $modeSummaries) {
   $aggregateComparisonArtifactCount += [int]$modeSummary.metadata.comparisonArtifactCount
   foreach ($mimeType in @($modeSummary.metadata.imageMimeTypes)) {
     [void]$aggregateMimeTypes.Add([string]$mimeType)
+  }
+  foreach ($previewImage in @(ConvertTo-ObjectArray -Value (Get-EntryValue -Entry $modeSummary -Name 'previewImages' -DefaultValue @()))) {
+    $aggregatePreviewImages.Add($previewImage) | Out-Null
   }
 }
 
@@ -638,6 +826,7 @@ $modeSummaryObject = [ordered]@{
   categoryCounts = [ordered]@{}
   comparisonPairs = @()
   bucketCounts = [ordered]@{}
+  previewImages = @()
   metadata = [ordered]@{
     comparisonArtifactCount = $aggregateComparisonArtifactCount
     captureCount = $aggregateCaptureCount
@@ -654,6 +843,7 @@ $modeSummaryObject.comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $agg
 foreach ($key in @($aggregateBucketCounts.Keys | Sort-Object)) {
   $modeSummaryObject.bucketCounts[$key] = [int]$aggregateBucketCounts[$key]
 }
+$modeSummaryObject.previewImages = @(ConvertTo-PreviewImageArray -Value $aggregatePreviewImages)
 
 $summaryLines = New-Object System.Collections.Generic.List[string]
 $summaryLines.Add(('Requested modes: `{0}`' -f $(if ($requestedModes.Count -gt 0) { $requestedModes -join ', ' } else { 'n/a' })))
@@ -670,6 +860,9 @@ if (-not [string]::IsNullOrWhiteSpace($StopReason)) {
 if ($aggregateCaptureCount -gt 0 -or $aggregateImageArtifactCount -gt 0 -or $aggregateComparisonArtifactCount -gt 0) {
   $mimeTypeText = if ($aggregateMimeTypes.Count -gt 0) { @($aggregateMimeTypes | Sort-Object) -join ', ' } else { 'none' }
   $summaryLines.Add(('Metadata surfaces: `captures={0}, images={1}, artifact-dirs={2}, mime-types={3}`' -f $aggregateCaptureCount, $aggregateImageArtifactCount, $aggregateComparisonArtifactCount, $mimeTypeText))
+}
+if ($modeSummaryObject.previewImages.Count -gt 0) {
+  $summaryLines.Add(('Preview images: `{0}`' -f $modeSummaryObject.previewImages.Count))
 }
 if ($modeSummaryObject.categoryCounts.Count -gt 0) {
   $summaryLines.Add(('Category counts: `{0}`' -f (Format-CountMap -Map $modeSummaryObject.categoryCounts)))
@@ -727,6 +920,9 @@ if ($modeSummaries.Count -gt 0) {
     if ([int]$entry.metadata.captureCount -gt 0 -or [int]$entry.metadata.imageArtifactCount -gt 0) {
       $mimeTypeText = if ($entry.metadata.imageMimeTypes.Count -gt 0) { $entry.metadata.imageMimeTypes -join ', ' } else { 'none' }
       $detailParts.Add(('metadata=captures:{0}, images:{1}, artifact-dirs:{2}, mime-types:{3}' -f [int]$entry.metadata.captureCount, [int]$entry.metadata.imageArtifactCount, [int]$entry.metadata.comparisonArtifactCount, $mimeTypeText)) | Out-Null
+    }
+    if (@($entry.previewImages).Count -gt 0) {
+      $detailParts.Add(('preview-images={0}' -f @($entry.previewImages).Count)) | Out-Null
     }
     if ($detailParts.Count -gt 0) {
       $summaryLines.Add(('- {0}: `{1}`' -f $entry.mode, ($detailParts -join '; ')))

--- a/scripts/Test-CompareVIHistoryChunkExecution.ps1
+++ b/scripts/Test-CompareVIHistoryChunkExecution.ps1
@@ -256,6 +256,15 @@ $processedCount = if ($null -eq $MaxPairs) { 1 } else { [int]$MaxPairs }
     if ($receipt.surfaces.suppressionProfile -ne 'unsuppressed') {
       throw "Expected unsuppressed mode profile for $($chunk.chunkId)."
     }
+    if ($receipt.surfaces.previewImages.Count -ne 1) {
+      throw "Expected one preview image in the chunk surfaces for $($chunk.chunkId)."
+    }
+    if ($receipt.surfaces.previewImages[0].artifactRelativePath -ne 'cli-images/cli-image-00.png') {
+      throw "Expected normalized artifact-relative preview path for $($chunk.chunkId)."
+    }
+    if ($receipt.surfaces.previewImages[0].byteLength -ne 4) {
+      throw "Expected preview image byte length for $($chunk.chunkId)."
+    }
   }
 
   $githubOutputs = Get-Content -LiteralPath $githubOutputPath -Raw

--- a/scripts/Test-CompareVIHistoryExplorationIndex.ps1
+++ b/scripts/Test-CompareVIHistoryExplorationIndex.ps1
@@ -69,6 +69,10 @@ try {
   $chunkRoot = [string]$chunk.outputs.chunkRoot
   $historyDir = Join-Path $chunkRoot 'history'
   New-Item -ItemType Directory -Path $historyDir -Force | Out-Null
+  $previewDir = Join-Path $historyDir 'preview-images'
+  New-Item -ItemType Directory -Path $previewDir -Force | Out-Null
+  $previewPath = Join-Path $previewDir 'cli-image-00.png'
+  [System.IO.File]::WriteAllBytes($previewPath, @(0xCA,0xFE,0xBA,0xBE))
   '# history report' | Set-Content -LiteralPath (Join-Path $historyDir 'history-report.md') -Encoding utf8
   '<html><body>history report</body></html>' | Set-Content -LiteralPath (Join-Path $historyDir 'history-report.html') -Encoding utf8
   '# mode summary' | Set-Content -LiteralPath (Join-Path $chunkRoot 'mode-summary.md') -Encoding utf8
@@ -94,6 +98,18 @@ try {
       imageMimeTypes = @('image/png')
       chunkCountWithMetadata = 1
       categoryCounts = [ordered]@{ attributes = 1 }
+      previewImages = @(
+        [ordered]@{
+          mode = 'attributes'
+          category = 'attributes'
+          comparisonPair = $null
+          mimeType = 'image/png'
+          byteLength = 4
+          savedPath = $previewPath
+          artifactRelativePath = 'preview-images/cli-image-00.png'
+          sortKey = 'attributes|attributes|preview-images/cli-image-00.png'
+        }
+      )
       bucketCounts = [ordered]@{ 'metadata-rich' = 1 }
     }) -Force
   $receipt.outputs | Add-Member -NotePropertyName historyResultsDir -NotePropertyValue $historyDir -Force
@@ -133,12 +149,17 @@ try {
   if ($indexMarkdown -notmatch [regex]::Escape('chunk-receipts/chunk-001/history/history-report.html')) {
     throw 'Index markdown must link the chunk HTML report.'
   }
+  if ($indexMarkdown -notmatch [regex]::Escape('![attributes | attributes](chunk-receipts/chunk-001/history/preview-images/cli-image-00.png)')) {
+    throw 'Index markdown must embed the preview image gallery entry.'
+  }
   foreach ($requiredFragment in @(
       'Continuity status: `break-detected`',
       'Continuity break count: `1`',
       'Segment count: `2`',
       'Suppression profile: `unsuppressed`',
       'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`',
+      'Preview images: `1`',
+      'Preview gallery: `1` shown, `0` omitted, cap `12`',
       'Segment `1`: revisions `1` -> `3`, pairs `2`, start `selected-ref-lineage-start`; break after revision `3` \(delete-observed\)',
       'Segment `2`: revisions `4` -> `4`, pairs `0`, start `reintroduced-after-delete`'
     )) {
@@ -157,11 +178,15 @@ try {
   if ($indexHtmlContent -notmatch [regex]::Escape('history-report.html')) {
     throw 'Index HTML must link the chunk HTML report.'
   }
+  if ($indexHtmlContent -notmatch [regex]::Escape('src="chunk-receipts/chunk-001/history/preview-images/cli-image-00.png"')) {
+    throw 'Index HTML must embed the preview image gallery entry.'
+  }
   foreach ($requiredFragment in @(
       'Continuity status</strong><span>break-detected</span>',
       'Continuity break count</strong><span>1</span>',
       'Suppression profile</strong><span>unsuppressed</span>',
       'Metadata surfaces</strong><span>captures=1, images=1, artifact-dirs=1</span>',
+      'Preview images</strong><span>1</span>',
       'Remaining planned chunks</strong><span>0</span>',
       'reintroduced-after-delete',
       'delete-observed'

--- a/scripts/Test-CompareVIHistoryExplorationRun.ps1
+++ b/scripts/Test-CompareVIHistoryExplorationRun.ps1
@@ -149,6 +149,10 @@ try {
   $secondHistoryDir = Join-Path ([string]$chunkPlan.chunks[1].outputs.chunkRoot) 'history'
   New-Item -ItemType Directory -Path $firstHistoryDir -Force | Out-Null
   New-Item -ItemType Directory -Path $secondHistoryDir -Force | Out-Null
+  $firstPreviewDir = Join-Path $firstHistoryDir 'preview-images'
+  New-Item -ItemType Directory -Path $firstPreviewDir -Force | Out-Null
+  $firstPreviewPath = Join-Path $firstPreviewDir 'cli-image-00.png'
+  [System.IO.File]::WriteAllBytes($firstPreviewPath, @(0xCA,0xFE,0xBA,0xBE))
   $firstReportMd = Join-Path $firstHistoryDir 'history-report.md'
   $firstReportHtml = Join-Path $firstHistoryDir 'history-report.html'
   $firstModeSummaryJson = Join-Path ([string]$chunkPlan.chunks[0].outputs.chunkRoot) 'mode-summary.json'
@@ -215,6 +219,21 @@ try {
         '<div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div>' = 2
         'Block Diagram objects' = 1
       }
+      previewImages = @(
+        [ordered]@{
+          mode = 'attributes'
+          category = 'Block Diagram objects'
+          comparisonPair = [ordered]@{
+            firstPath = '/compare/m0/Base.vi'
+            secondPath = '/compare/m0/Head.vi'
+          }
+          mimeType = 'image/png'
+          byteLength = 4
+          savedPath = $firstPreviewPath
+          artifactRelativePath = 'preview-images/cli-image-00.png'
+          sortKey = 'attributes|block diagram objects|preview-images/cli-image-00.png'
+        }
+      )
       bucketCounts = [ordered]@{ 'metadata-rich' = 1 }
     }
     failure = $null
@@ -318,6 +337,21 @@ try {
   if ($executedRun.surfaces.comparisonPairs[0].firstPath -ne '/compare/m0/Base.vi' -or $executedRun.surfaces.comparisonPairs[0].secondPath -ne '/compare/m0/Head.vi' -or $executedRun.surfaces.comparisonPairs[0].count -ne 2) {
     throw 'Executed exploration run comparison pair normalization mismatch.'
   }
+  if ($executedRun.surfaces.previewImages.Count -ne 1) {
+    throw 'Executed exploration run preview image count mismatch.'
+  }
+  if ($executedRun.surfaces.previewImages[0].chunkId -ne [string]$chunkPlan.chunks[0].chunkId) {
+    throw 'Executed exploration run preview image chunkId mismatch.'
+  }
+  if ($executedRun.surfaces.previewImages[0].relativePath -ne 'chunk-receipts/chunk-001/history/preview-images/cli-image-00.png') {
+    throw 'Executed exploration run preview image relative path mismatch.'
+  }
+  if ($executedRun.summary.previewImageCount -ne 1 -or $executedRun.summary.previewGalleryCount -ne 1 -or $executedRun.summary.previewGalleryOmittedCount -ne 0) {
+    throw 'Executed exploration run preview gallery summary mismatch.'
+  }
+  if ($executedRun.summary.stepSummaryPreviewCount -ne 1 -or $executedRun.summary.stepSummaryPreviewOmittedCount -ne 0) {
+    throw 'Executed exploration run step-summary preview summary mismatch.'
+  }
 
   $timelineMarkdown = Get-Content -LiteralPath $executedRun.outputs.timelineMd -Raw
   if ($timelineMarkdown -notmatch [regex]::Escape([string]$chunkPlan.chunks[0].chunkId)) {
@@ -349,6 +383,8 @@ try {
       'Failed chunk count: `1`',
       'Suppression profile: `unsuppressed`',
       'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`',
+      'Preview images: `1`',
+      'Preview gallery: `1` shown, `0` omitted, cap `12`',
       'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`',
       'Replay status: `degraded` \(partial-chunk-execution\)',
       'Bundle status: `not-required`'
@@ -357,18 +393,26 @@ try {
       throw "Executed index markdown must include '$requiredFragment'."
     }
   }
+  if ($indexMarkdown -notmatch [regex]::Escape('![attributes | Block Diagram objects](chunk-receipts/chunk-001/history/preview-images/cli-image-00.png)')) {
+    throw 'Executed index markdown must embed the preview image gallery entry.'
+  }
   $executedSummary = Get-Content -LiteralPath $executedSummaryPath -Raw
   foreach ($requiredFragment in @(
       'Total chunk count: `2`',
       'Failed chunk count: `1`',
       'Remaining planned chunk count: `0`',
       'Continuity break count: `0`',
+      'Preview images: `1`',
+      'Step summary previews: `1` shown, `0` omitted, cap `2`, byte-budget `196608`',
       'Comparison pairs: `/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\)`',
       'Replay status: `degraded` \(partial-chunk-execution\)'
     )) {
     if ($executedSummary -notmatch $requiredFragment) {
       throw "Executed step summary must include '$requiredFragment'."
     }
+  }
+  if ($executedSummary -notmatch 'data:image/png;base64,') {
+    throw 'Executed step summary must embed a preview image data URI.'
   }
 
   $secondReceipt.status = 'succeeded'

--- a/scripts/Test-CompareVIHistoryModeSummary.ps1
+++ b/scripts/Test-CompareVIHistoryModeSummary.ps1
@@ -122,6 +122,9 @@ try {
   if ($summary -notmatch 'Metadata surfaces: `captures=1, images=1, artifact-dirs=1, mime-types=image/png`') {
     throw 'Summary did not surface the aggregate capture metadata.'
   }
+  if ($summary -notmatch 'Preview images: `1`') {
+    throw 'Summary did not surface the preview image count.'
+  }
   if ($summary -notmatch 'Category counts: `Block Diagram Cosmetic \(1\), Block Diagram objects \(2\)`') {
     throw 'Summary did not surface normalized category counts.'
   }
@@ -137,7 +140,7 @@ try {
   if ($summary -notmatch '\| full \| unsuppressed \| none \| 2 \| 1 \| 1 \| in-band \| captures=1; images=1 \| ok \|') {
     throw 'Summary did not include the raw full-mode row.'
   }
-  if ($summary -notmatch '- full: `categories=Block Diagram Cosmetic \(1\), Block Diagram objects \(2\); comparison-pairs=/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\); buckets=metadata-rich \(1\); metadata=captures:1, images:1, artifact-dirs:1, mime-types:image/png`') {
+  if ($summary -notmatch '- full: `categories=Block Diagram Cosmetic \(1\), Block Diagram objects \(2\); comparison-pairs=/compare/m0/Base\.vi -> /compare/m0/Head\.vi \(2\); buckets=metadata-rich \(1\); metadata=captures:1, images:1, artifact-dirs:1, mime-types:image/png; preview-images=1`') {
     throw 'Summary did not include the per-mode metadata detail line.'
   }
   if (-not (Test-Path -LiteralPath $outputPath -PathType Leaf)) {
@@ -171,6 +174,18 @@ try {
   }
   if (($modeSummaryJson.metadata.imageMimeTypes -join ',') -ne 'image/png') {
     throw 'Mode summary JSON mime-type aggregation mismatch.'
+  }
+  if ($modeSummaryJson.previewImages.Count -ne 1) {
+    throw 'Mode summary JSON preview image count mismatch.'
+  }
+  if ($modeSummaryJson.previewImages[0].artifactRelativePath -ne 'cli-images/cli-image-00.png') {
+    throw 'Mode summary JSON preview image artifact-relative path mismatch.'
+  }
+  if ($modeSummaryJson.previewImages[0].byteLength -ne 4) {
+    throw 'Mode summary JSON preview image byte-length mismatch.'
+  }
+  if ($modeSummaryJson.previewImages[0].comparisonPair.firstPath -ne '/compare/m0/Base.vi' -or $modeSummaryJson.previewImages[0].comparisonPair.secondPath -ne '/compare/m0/Head.vi') {
+    throw 'Mode summary JSON preview image comparison pair mismatch.'
   }
 
   $githubOutput = Get-Content -LiteralPath $githubOutputPath -Raw

--- a/scripts/Write-CompareVIHistoryExplorationRun.ps1
+++ b/scripts/Write-CompareVIHistoryExplorationRun.ps1
@@ -22,6 +22,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+$script:PreviewGalleryCap = 12
+$script:StepSummaryPreviewCap = 2
+$script:StepSummaryPreviewByteBudget = 196608
+
 function Write-ActionOutput {
   param(
     [Parameter(Mandatory = $true)]
@@ -206,6 +210,19 @@ function Format-HtmlLink {
   }
 
   return ('<a href="{0}">{1}</a>' -f $Href, $Label)
+}
+
+function ConvertTo-HtmlText {
+  param(
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ($null -eq $Value) {
+    return ''
+  }
+
+  return [System.Net.WebUtility]::HtmlEncode([string]$Value)
 }
 
 function ConvertTo-OrderedCountMap {
@@ -437,10 +454,357 @@ function Format-ComparisonPairText {
   return (($pairArray | ForEach-Object { '{0} -> {1} ({2})' -f [string]$_.firstPath, [string]$_.secondPath, [int]$_.count }) -join ', ')
 }
 
+function ConvertTo-PreviewComparisonPair {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $firstPath = [string](Get-OptionalPropertyValue -InputObject $Value -PropertyName 'firstPath' -Default '')
+  $secondPath = [string](Get-OptionalPropertyValue -InputObject $Value -PropertyName 'secondPath' -Default '')
+  if ([string]::IsNullOrWhiteSpace($firstPath) -or [string]::IsNullOrWhiteSpace($secondPath)) {
+    return $null
+  }
+
+  return [ordered]@{
+    firstPath = $firstPath.Trim()
+    secondPath = $secondPath.Trim()
+  }
+}
+
+function Format-PreviewComparisonPairText {
+  param(
+    [AllowNull()]
+    $Pair
+  )
+
+  $normalizedPair = ConvertTo-PreviewComparisonPair -Value $Pair
+  if ($null -eq $normalizedPair) {
+    return 'n/a'
+  }
+
+  return ('{0} -> {1}' -f [string]$normalizedPair.firstPath, [string]$normalizedPair.secondPath)
+}
+
+function ConvertTo-PreviewImageArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  $images = New-Object System.Collections.Generic.List[object]
+  foreach ($preview in @(ConvertTo-ObjectArray -InputObject $Value)) {
+    $relativePath = [string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'relativePath' -Default '')
+    if ([string]::IsNullOrWhiteSpace($relativePath)) {
+      continue
+    }
+
+    $chunkId = [string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'chunkId' -Default 'unknown')
+    $mode = [string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'mode' -Default 'unknown')
+    $category = Normalize-CategoryLabel -Value ([string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'category' -Default 'uncategorized'))
+    if ([string]::IsNullOrWhiteSpace($category)) {
+      $category = 'uncategorized'
+    }
+
+    $comparisonPair = ConvertTo-PreviewComparisonPair -Value (Get-OptionalPropertyValue -InputObject $preview -PropertyName 'comparisonPair')
+    $sortKey = [string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'sortKey' -Default '')
+    $normalizedRelativePath = $relativePath.Replace('\', '/')
+    if ([string]::IsNullOrWhiteSpace($sortKey)) {
+      $sortKey = ('{0}|{1}|{2}|{3}|{4}|{5}' -f $chunkId, $mode, $category, $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.firstPath }), $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.secondPath }), $normalizedRelativePath).ToLowerInvariant()
+    }
+
+    $images.Add([ordered]@{
+        chunkId = $(if ([string]::IsNullOrWhiteSpace($chunkId)) { 'unknown' } else { $chunkId.Trim() })
+        mode = $(if ([string]::IsNullOrWhiteSpace($mode)) { 'unknown' } else { $mode.Trim() })
+        category = $category
+        comparisonPair = $comparisonPair
+        mimeType = [string](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'mimeType' -Default '')
+        byteLength = [int](Get-OptionalPropertyValue -InputObject $preview -PropertyName 'byteLength' -Default 0)
+        relativePath = $normalizedRelativePath
+        sortKey = $sortKey
+      }) | Out-Null
+  }
+
+  return @(
+    $images |
+      Sort-Object { [string]$_.sortKey }, { [string]$_.relativePath } |
+      ForEach-Object { $_ }
+  )
+}
+
+function Add-PreviewImageAggregate {
+  param(
+    [Parameter(Mandatory = $true)]
+    [hashtable]$Target,
+    [Parameter(Mandatory = $true)]
+    [string]$ChunkId,
+    [AllowNull()]
+    $PreviewImage,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
+  )
+
+  if ($null -eq $PreviewImage) {
+    return
+  }
+
+  $relativePath = [string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'relativePath' -Default '')
+  if ([string]::IsNullOrWhiteSpace($relativePath)) {
+    $savedPath = [string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'savedPath' -Default '')
+    if (-not [string]::IsNullOrWhiteSpace($savedPath)) {
+      $relativePath = ConvertTo-ArtifactReference -Path $savedPath -ResultsRoot $ResultsRoot -OnlyIfExists
+    }
+  }
+  if ([string]::IsNullOrWhiteSpace($relativePath)) {
+    return
+  }
+
+  $mode = [string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'mode' -Default 'unknown')
+  $category = Normalize-CategoryLabel -Value ([string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'category' -Default 'uncategorized'))
+  if ([string]::IsNullOrWhiteSpace($category)) {
+    $category = 'uncategorized'
+  }
+
+  $comparisonPair = ConvertTo-PreviewComparisonPair -Value (Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'comparisonPair')
+  $mimeType = [string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'mimeType' -Default '')
+  $byteLength = [int](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'byteLength' -Default 0)
+  $sortKey = [string](Get-OptionalPropertyValue -InputObject $PreviewImage -PropertyName 'sortKey' -Default '')
+  $normalizedRelativePath = $relativePath.Replace('\', '/')
+  if ([string]::IsNullOrWhiteSpace($sortKey)) {
+    $sortKey = ('{0}|{1}|{2}|{3}|{4}|{5}' -f $ChunkId, $mode, $category, $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.firstPath }), $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.secondPath }), $normalizedRelativePath).ToLowerInvariant()
+  }
+
+  $key = ('{0}|{1}|{2}|{3}|{4}|{5}' -f $ChunkId.Trim(), $mode.Trim(), $category, $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.firstPath }), $(if ($null -eq $comparisonPair) { '' } else { [string]$comparisonPair.secondPath }), $normalizedRelativePath).ToLowerInvariant()
+  if ($Target.Contains($key)) {
+    return
+  }
+
+  $Target[$key] = [ordered]@{
+    chunkId = $(if ([string]::IsNullOrWhiteSpace($ChunkId)) { 'unknown' } else { $ChunkId.Trim() })
+    mode = $(if ([string]::IsNullOrWhiteSpace($mode)) { 'unknown' } else { $mode.Trim() })
+    category = $category
+    comparisonPair = $comparisonPair
+    mimeType = $mimeType
+    byteLength = $byteLength
+    relativePath = $normalizedRelativePath
+    sortKey = $sortKey
+  }
+}
+
+function Select-PreviewGalleryImages {
+  param(
+    [AllowNull()]
+    $PreviewImages,
+    [Parameter(Mandatory = $true)]
+    [int]$Limit
+  )
+
+  if ($Limit -le 0) {
+    return @()
+  }
+
+  return @((ConvertTo-PreviewImageArray -Value $PreviewImages) | Select-Object -First $Limit)
+}
+
+function Select-StepSummaryPreviewImages {
+  param(
+    [AllowNull()]
+    $PreviewImages,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot,
+    [Parameter(Mandatory = $true)]
+    [int]$Limit,
+    [Parameter(Mandatory = $true)]
+    [int]$ByteBudget
+  )
+
+  $selected = New-Object System.Collections.Generic.List[object]
+  $usedBytes = 0
+  $previewArray = @(ConvertTo-PreviewImageArray -Value $PreviewImages)
+  foreach ($preview in $previewArray) {
+    if ($selected.Count -ge $Limit) {
+      break
+    }
+
+    $mimeType = [string]$preview.mimeType
+    if ([string]::IsNullOrWhiteSpace($mimeType) -or -not $mimeType.StartsWith('image/', [System.StringComparison]::OrdinalIgnoreCase)) {
+      continue
+    }
+
+    $resolvedPath = Resolve-AbsolutePath -Path ([string]$preview.relativePath) -BasePath $ResultsRoot
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+      continue
+    }
+
+    $imageBytes = [System.IO.File]::ReadAllBytes($resolvedPath)
+    $byteLength = if ([int]$preview.byteLength -gt 0) { [int]$preview.byteLength } else { $imageBytes.Length }
+    if (($usedBytes + $byteLength) -gt $ByteBudget) {
+      break
+    }
+
+    $selected.Add([ordered]@{
+        chunkId = [string]$preview.chunkId
+        mode = [string]$preview.mode
+        category = [string]$preview.category
+        comparisonPair = $preview.comparisonPair
+        mimeType = $mimeType
+        byteLength = $byteLength
+        relativePath = [string]$preview.relativePath
+        sortKey = [string]$preview.sortKey
+        dataUri = ('data:{0};base64,{1}' -f $mimeType, [Convert]::ToBase64String($imageBytes))
+      }) | Out-Null
+    $usedBytes += $byteLength
+  }
+
+  return [pscustomobject]@{
+    images = @($selected | ForEach-Object { $_ })
+    byteCount = $usedBytes
+  }
+}
+
+function New-MarkdownPreviewGallery {
+  param(
+    [AllowNull()]
+    $PreviewImages,
+    [Parameter(Mandatory = $true)]
+    $RunStats
+  )
+
+  $previewArray = @(ConvertTo-PreviewImageArray -Value $PreviewImages)
+  if ($previewArray.Count -eq 0) {
+    return ''
+  }
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('## Preview gallery') | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('- Preview images available: `{0}`' -f [int]$RunStats.previewImageCount)) | Out-Null
+  $lines.Add(('- Gallery cap: `{0}`' -f [int]$RunStats.previewGalleryCap)) | Out-Null
+  $lines.Add(('- Gallery shown: `{0}`' -f [int]$RunStats.previewGalleryCount)) | Out-Null
+  $lines.Add(('- Gallery omitted: `{0}`' -f [int]$RunStats.previewGalleryOmittedCount)) | Out-Null
+  $lines.Add('') | Out-Null
+
+  $previewOrdinal = 1
+  foreach ($preview in $previewArray) {
+    $title = '{0} | {1}' -f [string]$preview.mode, [string]$preview.category
+    $lines.Add(('### Preview `{0}`: {1}' -f $previewOrdinal, $title)) | Out-Null
+    $lines.Add(('- Chunk: `{0}`' -f [string]$preview.chunkId)) | Out-Null
+    $lines.Add(('- MIME type: `{0}`' -f [string]$preview.mimeType)) | Out-Null
+    $lines.Add(('- Byte length: `{0}`' -f [int]$preview.byteLength)) | Out-Null
+    if ($null -ne $preview.comparisonPair) {
+      $lines.Add(('- Comparison pair: `{0}`' -f (Format-PreviewComparisonPairText -Pair $preview.comparisonPair))) | Out-Null
+    }
+    $lines.Add(('![{0}]({1})' -f $title, [string]$preview.relativePath)) | Out-Null
+    $lines.Add('') | Out-Null
+    $previewOrdinal++
+  }
+
+  return ($lines -join [Environment]::NewLine)
+}
+
+function New-HtmlPreviewGallery {
+  param(
+    [AllowNull()]
+    $PreviewImages,
+    [Parameter(Mandatory = $true)]
+    $RunStats
+  )
+
+  $previewArray = @(ConvertTo-PreviewImageArray -Value $PreviewImages)
+  if ($previewArray.Count -eq 0) {
+    return ''
+  }
+
+  $cards = New-Object System.Collections.Generic.List[string]
+  foreach ($preview in $previewArray) {
+    $comparisonPairMarkup = if ($null -eq $preview.comparisonPair) {
+      ''
+    } else {
+      ('<div><strong>Comparison pair</strong><span>{0}</span></div>' -f (ConvertTo-HtmlText -Value (Format-PreviewComparisonPairText -Pair $preview.comparisonPair)))
+    }
+
+    $cards.Add(@"
+    <article class="preview-card">
+      <div class="preview-card-title">$((ConvertTo-HtmlText -Value ([string]$preview.mode))) | $((ConvertTo-HtmlText -Value ([string]$preview.category)))</div>
+      <div class="preview-card-meta">
+        <div><strong>Chunk</strong><span>$((ConvertTo-HtmlText -Value ([string]$preview.chunkId)))</span></div>
+        <div><strong>MIME type</strong><span>$((ConvertTo-HtmlText -Value ([string]$preview.mimeType)))</span></div>
+        <div><strong>Byte length</strong><span>$([int]$preview.byteLength)</span></div>
+$comparisonPairMarkup
+      </div>
+      <img src="$([string]$preview.relativePath)" alt="$((ConvertTo-HtmlText -Value ('{0} | {1}' -f [string]$preview.mode, [string]$preview.category)))" loading="lazy" />
+    </article>
+"@) | Out-Null
+  }
+
+  return @"
+  <h2>Preview gallery</h2>
+  <div class="preview-summary">
+    <strong>Preview images available</strong><span>$([int]$RunStats.previewImageCount)</span>
+    <strong>Gallery cap</strong><span>$([int]$RunStats.previewGalleryCap)</span>
+    <strong>Gallery shown</strong><span>$([int]$RunStats.previewGalleryCount)</span>
+    <strong>Gallery omitted</strong><span>$([int]$RunStats.previewGalleryOmittedCount)</span>
+  </div>
+  <div class="preview-grid">
+$($cards -join [Environment]::NewLine)
+  </div>
+"@
+}
+
+function New-StepSummaryPreviewSection {
+  param(
+    [Parameter(Mandatory = $true)]
+    $RunStats,
+    [Parameter(Mandatory = $true)]
+    $PreviewSelection
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  if ([int]$RunStats.previewImageCount -le 0) {
+    return @()
+  }
+
+  $selectedImages = @(ConvertTo-ObjectArray -InputObject $PreviewSelection.images)
+  $lines.Add(('- Preview images: `{0}`' -f [int]$RunStats.previewImageCount)) | Out-Null
+  $lines.Add(('- Preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f [int]$RunStats.previewGalleryCount, [int]$RunStats.previewGalleryOmittedCount, [int]$RunStats.previewGalleryCap)) | Out-Null
+  $lines.Add(('- Step summary previews: `{0}` shown, `{1}` omitted, cap `{2}`, byte-budget `{3}`' -f [int]$RunStats.stepSummaryPreviewCount, [int]$RunStats.stepSummaryPreviewOmittedCount, [int]$RunStats.stepSummaryPreviewCap, [int]$RunStats.stepSummaryPreviewByteBudget)) | Out-Null
+
+  if ($selectedImages.Count -gt 0) {
+    $lines.Add('') | Out-Null
+    $lines.Add('### Preview gallery') | Out-Null
+    foreach ($preview in $selectedImages) {
+      $comparisonPairLine = if ($null -eq $preview.comparisonPair) {
+        ''
+      } else {
+        ('<br/><strong>Comparison pair:</strong> <code>{0}</code>' -f (ConvertTo-HtmlText -Value (Format-PreviewComparisonPairText -Pair $preview.comparisonPair)))
+      }
+      $lines.Add((
+          '<p><strong>{0} | {1}</strong><br/><strong>Chunk:</strong> <code>{2}</code><br/><strong>MIME type:</strong> <code>{3}</code><br/><strong>Byte length:</strong> <code>{4}</code>{5}<br/><img src="{6}" alt="{7}" style="max-width: 420px; height: auto; border: 1px solid #d0d7de; background: #ffffff;" /></p>' -f
+          (ConvertTo-HtmlText -Value ([string]$preview.mode)),
+          (ConvertTo-HtmlText -Value ([string]$preview.category)),
+          (ConvertTo-HtmlText -Value ([string]$preview.chunkId)),
+          (ConvertTo-HtmlText -Value ([string]$preview.mimeType)),
+          [int]$preview.byteLength,
+          $comparisonPairLine,
+          [string]$preview.dataUri,
+          (ConvertTo-HtmlText -Value ('{0} | {1}' -f [string]$preview.mode, [string]$preview.category))
+        )) | Out-Null
+    }
+  }
+
+  return @($lines | ForEach-Object { $_ })
+}
+
 function New-ExplorationSurfaceAggregate {
   param(
     [Parameter(Mandatory = $true)]
-    $ChunkReceipts
+    $ChunkReceipts,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
   )
 
   $chunkReceiptArray = ConvertTo-ObjectArray -InputObject $ChunkReceipts
@@ -454,6 +818,7 @@ function New-ExplorationSurfaceAggregate {
   $comparisonArtifactCount = 0
   $chunkCountWithMetadata = 0
   $imageMimeTypes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $aggregatePreviewImages = @{}
 
   foreach ($chunk in $chunkReceiptArray) {
     $surfaceNode = Get-OptionalPropertyValue -InputObject $chunk -PropertyName 'surfaces'
@@ -495,6 +860,10 @@ function New-ExplorationSurfaceAggregate {
       }
     }
 
+    foreach ($previewImage in @(ConvertTo-ObjectArray -InputObject (Get-OptionalPropertyValue -InputObject $surfaceNode -PropertyName 'previewImages' -Default @()))) {
+      Add-PreviewImageAggregate -Target $aggregatePreviewImages -ChunkId ([string]$chunk.chunkId) -PreviewImage $previewImage -ResultsRoot $ResultsRoot
+    }
+
     if ($chunkHasMetadata) {
       $chunkCountWithMetadata++
     }
@@ -518,6 +887,7 @@ function New-ExplorationSurfaceAggregate {
     categoryCounts = ConvertTo-OrderedCountMap -Value $aggregateCategoryCounts
     comparisonPairs = @(ConvertTo-ComparisonPairArray -Value $aggregateComparisonPairs)
     bucketCounts = ConvertTo-OrderedCountMap -Value $aggregateBucketCounts
+    previewImages = @(ConvertTo-PreviewImageArray -Value $aggregatePreviewImages.Values)
   }
 }
 
@@ -546,7 +916,11 @@ function New-ExplorationSurfaceStats {
     [Parameter(Mandatory = $true)]
     [string[]]$RequestedModes,
     [Parameter(Mandatory = $true)]
-    [string]$NoisePolicy
+    [string]$NoisePolicy,
+    [Parameter(Mandatory = $true)]
+    [int]$PreviewGalleryCount,
+    [Parameter(Mandatory = $true)]
+    [int]$StepSummaryPreviewCount
   )
 
   $segmentArray = ConvertTo-ObjectArray -InputObject $ChunkPlan.segments
@@ -560,6 +934,7 @@ function New-ExplorationSurfaceStats {
   $failedChunkCount = @($chunkReceiptArray | Where-Object { [string]$_.status -eq 'failed' }).Count
   $skippedChunkCount = @($chunkReceiptArray | Where-Object { [string]$_.status -eq 'skipped' }).Count
   $remainingPlannedChunkCount = @($chunkReceiptArray | Where-Object { [string]$_.status -eq 'planned' }).Count
+  $previewImageCount = @(ConvertTo-PreviewImageArray -Value $SurfaceAggregate.previewImages).Count
 
   return [pscustomobject]@{
     revisionCount             = [int]$Catalog.summary.revisionCount
@@ -591,6 +966,14 @@ function New-ExplorationSurfaceStats {
     categoryCounts            = $SurfaceAggregate.categoryCounts
     comparisonPairs           = @($SurfaceAggregate.comparisonPairs)
     bucketCounts              = $SurfaceAggregate.bucketCounts
+    previewImageCount         = $previewImageCount
+    previewGalleryCap         = $script:PreviewGalleryCap
+    previewGalleryCount       = $PreviewGalleryCount
+    previewGalleryOmittedCount = [Math]::Max($previewImageCount - $PreviewGalleryCount, 0)
+    stepSummaryPreviewCap     = $script:StepSummaryPreviewCap
+    stepSummaryPreviewCount   = $StepSummaryPreviewCount
+    stepSummaryPreviewOmittedCount = [Math]::Max($previewImageCount - $StepSummaryPreviewCount, 0)
+    stepSummaryPreviewByteBudget = $script:StepSummaryPreviewByteBudget
   }
 }
 
@@ -787,6 +1170,8 @@ function New-MarkdownIndex {
     [Parameter(Mandatory = $true)]
     [string]$ResultsRoot,
     [AllowNull()]
+    $PreviewImages,
+    [AllowNull()]
     [string]$TimelineMdPath,
     [AllowNull()]
     [string]$TimelineHtmlPath,
@@ -827,6 +1212,11 @@ function New-MarkdownIndex {
     $lines.Add(('- Metadata surfaces: `captures={0}, images={1}, artifact-dirs={2}, mime-types={3}`' -f [int]$RunStats.captureCount, [int]$RunStats.imageArtifactCount, [int]$RunStats.comparisonArtifactCount, $mimeTypeText)) | Out-Null
     $lines.Add(('- Chunks with metadata: `{0}`' -f [int]$RunStats.chunkCountWithMetadata)) | Out-Null
   }
+  if ([int]$RunStats.previewImageCount -gt 0) {
+    $lines.Add(('- Preview images: `{0}`' -f [int]$RunStats.previewImageCount)) | Out-Null
+    $lines.Add(('- Preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f [int]$RunStats.previewGalleryCount, [int]$RunStats.previewGalleryOmittedCount, [int]$RunStats.previewGalleryCap)) | Out-Null
+    $lines.Add(('- Step summary previews: `{0}` shown, `{1}` omitted, cap `{2}`, byte-budget `{3}`' -f [int]$RunStats.stepSummaryPreviewCount, [int]$RunStats.stepSummaryPreviewOmittedCount, [int]$RunStats.stepSummaryPreviewCap, [int]$RunStats.stepSummaryPreviewByteBudget)) | Out-Null
+  }
   if ($RunStats.categoryCounts.Count -gt 0) {
     $lines.Add(('- Category counts: `{0}`' -f (Format-CountMapText -Map $RunStats.categoryCounts))) | Out-Null
   }
@@ -862,6 +1252,11 @@ function New-MarkdownIndex {
     $lines.Add(('- Bundle zip: {0}' -f (Format-MarkdownLink -Label 'manual-vi-exploration-bundle.zip' -Href $bundleReference))) | Out-Null
   }
   $lines.Add('') | Out-Null
+  $previewGalleryMarkdown = New-MarkdownPreviewGallery -PreviewImages $PreviewImages -RunStats $RunStats
+  if (-not [string]::IsNullOrWhiteSpace($previewGalleryMarkdown)) {
+    $lines.Add($previewGalleryMarkdown) | Out-Null
+    $lines.Add('') | Out-Null
+  }
   $lines.Add('## Chunk navigation') | Out-Null
   $lines.Add('') | Out-Null
 
@@ -1080,6 +1475,8 @@ function New-HtmlIndex {
     [Parameter(Mandatory = $true)]
     [string]$ResultsRoot,
     [AllowNull()]
+    $PreviewImages,
+    [AllowNull()]
     [string]$TimelineMdPath,
     [AllowNull()]
     [string]$TimelineHtmlPath,
@@ -1157,6 +1554,7 @@ function New-HtmlIndex {
   if ($bundleReference) {
     $topLevelLinks.Add(('<li><a href="{0}">manual-vi-exploration-bundle.zip</a></li>' -f $bundleReference)) | Out-Null
   }
+  $previewGalleryHtml = New-HtmlPreviewGallery -PreviewImages $PreviewImages -RunStats $RunStats
 
   return @"
 <!DOCTYPE html>
@@ -1175,6 +1573,12 @@ function New-HtmlIndex {
     .status-warn { background: #fff7e8; border-left-color: #b26a00; }
     .status-bad { background: #fdecea; border-left-color: #b42318; }
     .status-neutral { background: #f3f3f3; border-left-color: #666; }
+    .preview-summary { display: grid; grid-template-columns: max-content 1fr; gap: 0.5rem 1rem; margin: 1rem 0; }
+    .preview-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .preview-card { border: 1px solid #ccc; padding: 0.75rem; background: #fff; }
+    .preview-card-title { font-weight: 600; margin-bottom: 0.5rem; }
+    .preview-card-meta { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 0.75rem; margin-bottom: 0.75rem; }
+    .preview-card img { max-width: 100%; height: auto; border: 1px solid #ddd; background: #fafafa; }
   </style>
 </head>
 <body>
@@ -1201,6 +1605,9 @@ function New-HtmlIndex {
     <strong>Total chunk count</strong><span>$([int]$RunStats.totalChunkCount)</span>
     <strong>Metadata surfaces</strong><span>captures=$([int]$RunStats.captureCount), images=$([int]$RunStats.imageArtifactCount), artifact-dirs=$([int]$RunStats.comparisonArtifactCount)</span>
     <strong>Image MIME types</strong><span>$(if ($RunStats.imageMimeTypes.Count -gt 0) { $RunStats.imageMimeTypes -join ', ' } else { 'none' })</span>
+    <strong>Preview images</strong><span>$([int]$RunStats.previewImageCount)</span>
+    <strong>Preview gallery</strong><span>$([int]$RunStats.previewGalleryCount) shown, $([int]$RunStats.previewGalleryOmittedCount) omitted, cap $([int]$RunStats.previewGalleryCap)</span>
+    <strong>Step summary previews</strong><span>$([int]$RunStats.stepSummaryPreviewCount) shown, $([int]$RunStats.stepSummaryPreviewOmittedCount) omitted, cap $([int]$RunStats.stepSummaryPreviewCap), byte-budget $([int]$RunStats.stepSummaryPreviewByteBudget)</span>
     <strong>Category counts</strong><span>$(Format-CountMapText -Map $RunStats.categoryCounts)</span>
     <strong>Comparison pairs</strong><span>$(Format-ComparisonPairText -Pairs $RunStats.comparisonPairs)</span>
     <strong>Bucket counts</strong><span>$(Format-CountMapText -Map $RunStats.bucketCounts)</span>
@@ -1231,6 +1638,7 @@ $($continuityRows -join [Environment]::NewLine)
   <ul>
 $($topLevelLinks -join [Environment]::NewLine)
   </ul>
+$previewGalleryHtml
   <h2>Chunk navigation</h2>
   <table>
     <thead>
@@ -1380,7 +1788,13 @@ if ($planningStatus -eq 'complete' -and $effectiveBundleStatus -eq 'failed') {
   $replayReason = 'bundle-packaging-failed'
 }
 
-$surfaceAggregate = New-ExplorationSurfaceAggregate -ChunkReceipts $chunkReceipts
+$surfaceAggregate = New-ExplorationSurfaceAggregate -ChunkReceipts $chunkReceipts -ResultsRoot $resultsDirResolved
+$previewGalleryImages = @(Select-PreviewGalleryImages -PreviewImages $surfaceAggregate.previewImages -Limit $script:PreviewGalleryCap)
+$stepSummaryPreviewSelection = Select-StepSummaryPreviewImages `
+  -PreviewImages $surfaceAggregate.previewImages `
+  -ResultsRoot $resultsDirResolved `
+  -Limit $script:StepSummaryPreviewCap `
+  -ByteBudget $script:StepSummaryPreviewByteBudget
 $runStats = New-ExplorationSurfaceStats `
   -Catalog $catalog `
   -ChunkPlan $chunkPlan `
@@ -1393,7 +1807,9 @@ $runStats = New-ExplorationSurfaceStats `
   -BundleReason $effectiveBundleReason `
   -SurfaceAggregate $surfaceAggregate `
   -RequestedModes $requestedModes `
-  -NoisePolicy $NoisePolicy
+  -NoisePolicy $NoisePolicy `
+  -PreviewGalleryCount $previewGalleryImages.Count `
+  -StepSummaryPreviewCount (@(ConvertTo-ObjectArray -InputObject $stepSummaryPreviewSelection.images).Count)
 
 $chunkReceiptArray = @(ConvertTo-ObjectArray -InputObject $chunkReceipts)
 $timelineMarkdown = New-MarkdownTimeline -Catalog $catalog -ChunkPlan $chunkPlan -ChunkReceipts $chunkReceiptArray -RunStats $runStats -FinalStatus $finalStatus -FinalReason $finalReason
@@ -1408,6 +1824,7 @@ $indexMarkdown = New-MarkdownIndex `
   -BundleStatus $effectiveBundleStatus `
   -BundleReason $effectiveBundleReason `
   -ResultsRoot $resultsDirResolved `
+  -PreviewImages $previewGalleryImages `
   -TimelineMdPath $timelineMdResolved `
   -TimelineHtmlPath $timelineHtmlResolved `
   -BundlePath $bundlePathResolved
@@ -1421,6 +1838,7 @@ $indexHtml = New-HtmlIndex `
   -BundleStatus $effectiveBundleStatus `
   -BundleReason $effectiveBundleReason `
   -ResultsRoot $resultsDirResolved `
+  -PreviewImages $previewGalleryImages `
   -TimelineMdPath $timelineMdResolved `
   -TimelineHtmlPath $timelineHtmlResolved `
   -BundlePath $bundlePathResolved
@@ -1456,6 +1874,7 @@ $explorationRun = [ordered]@{
     categoryCounts = $surfaceAggregate.categoryCounts
     comparisonPairs = @($surfaceAggregate.comparisonPairs)
     bucketCounts = $surfaceAggregate.bucketCounts
+    previewImages = @(ConvertTo-PreviewImageArray -Value $surfaceAggregate.previewImages)
   }
   discovery = [ordered]@{
     revisionCatalogPath = $revisionCatalogPathResolved
@@ -1506,6 +1925,14 @@ $explorationRun = [ordered]@{
     suppressionProfile = [string]$surfaceAggregate.suppressionProfile
     captureCount = [int]$surfaceAggregate.captureCount
     imageArtifactCount = [int]$surfaceAggregate.imageArtifactCount
+    previewImageCount = [int]$runStats.previewImageCount
+    previewGalleryCap = [int]$runStats.previewGalleryCap
+    previewGalleryCount = [int]$runStats.previewGalleryCount
+    previewGalleryOmittedCount = [int]$runStats.previewGalleryOmittedCount
+    stepSummaryPreviewCap = [int]$runStats.stepSummaryPreviewCap
+    stepSummaryPreviewCount = [int]$runStats.stepSummaryPreviewCount
+    stepSummaryPreviewOmittedCount = [int]$runStats.stepSummaryPreviewOmittedCount
+    stepSummaryPreviewByteBudget = [int]$runStats.stepSummaryPreviewByteBudget
   }
   replay = [ordered]@{
     status = $replayStatus
@@ -1524,6 +1951,7 @@ Write-ActionOutput -Key 'timeline-html' -Value $timelineHtmlResolved
 Write-ActionOutput -Key 'bundle-path' -Value $(if ($null -eq $bundlePathResolved) { '' } else { $bundlePathResolved })
 
 if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  $stepSummaryLines = New-Object System.Collections.Generic.List[string]
   @(
     ''
     '## comparevi-history exploration run'
@@ -1557,7 +1985,11 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ('- Bundle path: `{0}`' -f $(if ($null -eq $bundlePathResolved) { '' } else { $bundlePathResolved }))
     ('- Timeline (md): `{0}`' -f $timelineMdResolved)
     ('- Timeline (html): `{0}`' -f $timelineHtmlResolved)
-  ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+  ) | ForEach-Object { $stepSummaryLines.Add($_) | Out-Null }
+  foreach ($line in @(New-StepSummaryPreviewSection -RunStats $runStats -PreviewSelection $stepSummaryPreviewSelection)) {
+    $stepSummaryLines.Add($line) | Out-Null
+  }
+  $stepSummaryLines | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
 }
 
 $explorationRun | ConvertTo-Json -Depth 64


### PR DESCRIPTION
## Summary
- surface structured preview image manifests in `mode-summary` and `exploration-run`
- render a bounded preview gallery in the manual exploration index surfaces
- embed a smaller bounded preview subset directly in the GitHub step summary with data URIs

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryModeSummary.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryChunkExecution.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryExplorationRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryExplorationIndex.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #74.
