### PR TITLE
Add automatic PR changed-VI diagnostics workflow (#95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           set -euo pipefail
           ./actionlint -color
           ./actionlint -color \
+            docs/examples/comparevi-history-pull-request-diagnostics.yml \
             docs/examples/comparevi-history-manual-vi-exploration.yml \
             docs/examples/comparevi-history-workflow-dispatch.yml \
             docs/examples/comparevi-history-comment-gated.yml
@@ -104,17 +105,20 @@ jobs:
             'scripts/Resolve-CompareVIHistoryPublishedRefs.ps1',
             'scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1',
             'scripts/Resolve-CompareVIHistoryRequest.ps1',
+            'scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1',
             'scripts/Write-CompareVIHistoryRevisionCatalog.ps1',
             'scripts/Write-CompareVIHistoryChunkPlan.ps1',
             'scripts/Invoke-CompareVIHistoryChunkExecution.ps1',
             'scripts/Write-CompareVIHistoryExplorationBundle.ps1',
             'scripts/Write-CompareVIHistoryExplorationRun.ps1',
             'scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1',
+            'scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1',
             'scripts/Invoke-CompareVIHistoryFacade.ps1',
             'scripts/Format-CompareVIHistoryModeSummary.ps1',
             'scripts/Write-CompareVIHistorySharedEvidence.ps1',
             'scripts/Write-CompareVIHistoryCorpusIndex.ps1',
             'scripts/Write-CompareVIHistoryDownstreamProcessorSummary.ps1',
+            'scripts/Write-CompareVIHistoryPullRequestRun.ps1',
             'scripts/Write-CompareVIHistoryPublicRun.ps1',
             'scripts/Assert-CompareVIHistoryPublishedRun.ps1',
             'scripts/Sync-CompareVIHistoryPublishedTemplates.ps1',
@@ -181,6 +185,9 @@ jobs:
             'scripts/Test-CompareVIHistoryTrust.ps1',
             'scripts/Test-CompareVIHistoryPublishedRefs.ps1',
             'scripts/Test-CompareVIHistoryReleasePublishReadiness.ps1',
+            'scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1',
+            'scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1',
+            'scripts/Test-CompareVIHistoryPullRequestRun.ps1',
             'scripts/Test-CompareVIHistoryRequest.ps1',
             'scripts/Test-CompareVIHistoryRevisionCatalog.ps1',
             'scripts/Test-CompareVIHistoryChunkPlan.ps1',

--- a/.github/workflows/pull-request-diagnostics.yml
+++ b/.github/workflows/pull-request-diagnostics.yml
@@ -1,0 +1,235 @@
+name: pull-request-diagnostics
+
+on:
+  workflow_call:
+    inputs:
+      consumer_repository:
+        description: Consumer repository that owns the target catalog.
+        required: false
+        type: string
+      target_spec_path:
+        description: Trusted target catalog path resolved from the pull request base checkout.
+        required: false
+        default: .github/comparevi-history-targets.json
+        type: string
+      results_dir:
+        description: Workflow-owned results root for aggregate PR diagnostics receipts and per-target runs.
+        required: false
+        default: tests/results/pr-diagnostics/history
+        type: string
+      max_pairs:
+        description: Optional cap on adjacent commit pairs per matched target.
+        required: false
+        default: '5'
+        type: string
+      max_signal_pairs:
+        description: Optional cap on surfaced signal pairs per matched target.
+        required: false
+        default: '5'
+        type: string
+      compare_timeout_seconds:
+        description: Optional per-compare timeout passed to the backend.
+        required: false
+        default: ''
+        type: string
+      platform_ref:
+        description: comparevi-history ref to checkout for the platform scripts. Keep aligned with the workflow ref.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-diagnostics-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  pull-request-diagnostics:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+    outputs:
+      changed-vi-discovery-path: ${{ steps.discovery.outputs['changed-vi-discovery-path'] }}
+      changed-vi-count: ${{ steps.discovery.outputs['changed-vi-count'] }}
+      matched-target-count: ${{ steps.discovery.outputs['matched-target-count'] }}
+      target-runs-manifest-path: ${{ steps.execute.outputs['target-runs-manifest-path'] }}
+      pr-run-path: ${{ steps.aggregate.outputs['pr-run-path'] }}
+      public-comment-path: ${{ steps.aggregate.outputs['public-comment-path'] }}
+      public-step-summary-path: ${{ steps.aggregate.outputs['public-step-summary-path'] }}
+      results-dir: ${{ steps.aggregate.outputs['results-dir'] }}
+      final-status: ${{ steps.aggregate.outputs['final-status'] }}
+      final-reason: ${{ steps.aggregate.outputs['final-reason'] }}
+    steps:
+      - name: Resolve workflow defaults
+        id: defaults
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $consumerRepository = '${{ inputs.consumer_repository }}'
+          if ([string]::IsNullOrWhiteSpace($consumerRepository)) {
+            $consumerRepository = $env:GITHUB_REPOSITORY
+          }
+
+          $platformRef = '${{ inputs.platform_ref }}'
+          if ([string]::IsNullOrWhiteSpace($platformRef)) {
+            if ($env:GITHUB_REPOSITORY -eq 'LabVIEW-Community-CI-CD/comparevi-history') {
+              $platformRef = $env:GITHUB_SHA
+            } else {
+              $platformRef = 'v1'
+            }
+          }
+
+          @(
+            "consumer_repository=$consumerRepository"
+            "platform_ref=$platformRef"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Resolve workflow results root
+        id: results_root
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $resultsRoot = if ([System.IO.Path]::IsPathRooted('${{ inputs.results_dir }}')) {
+            [System.IO.Path]::GetFullPath('${{ inputs.results_dir }}')
+          } else {
+            [System.IO.Path]::GetFullPath((Join-Path $env:GITHUB_WORKSPACE '${{ inputs.results_dir }}'))
+          }
+
+          New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+          "results-root=$resultsRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout trusted consumer base repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.defaults.outputs.consumer_repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-consumer
+          fetch-depth: 1
+
+      - name: Checkout comparevi-history platform repo
+        uses: actions/checkout@v5
+        with:
+          repository: LabVIEW-Community-CI-CD/comparevi-history
+          ref: ${{ steps.defaults.outputs.platform_ref }}
+          path: platform
+          fetch-depth: 1
+
+      - name: Discover changed VI targets
+        id: discovery
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1" `
+            -EventName $env:GITHUB_EVENT_NAME `
+            -EventPath $env:GITHUB_EVENT_PATH `
+            -Repository '${{ steps.defaults.outputs.consumer_repository }}' `
+            -TargetSpecPath (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.target_spec_path }}') `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
+            -GitHubToken $env:GITHUB_TOKEN `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+      - name: Pre-pull NI Linux image
+        if: ${{ steps.discovery.outputs['execution-status'] == 'ready' }}
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
+      - name: Checkout pull request head repository
+        if: ${{ steps.discovery.outputs['execution-status'] == 'ready' }}
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.discovery.outputs['head-repo'] }}
+          ref: ${{ steps.discovery.outputs['head-sha'] }}
+          path: candidate-consumer
+          fetch-depth: 0
+
+      - name: Run comparevi-history for matched targets
+        id: execute
+        if: ${{ steps.discovery.outputs['execution-status'] == 'ready' }}
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $invokeArgs = @{
+            CandidateRepositoryRoot = (Join-Path $env:GITHUB_WORKSPACE 'candidate-consumer')
+            TrustedRepositoryRoot = (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer')
+            DiscoveryPath = '${{ steps.discovery.outputs['changed-vi-discovery-path'] }}'
+            TargetSpecPath = (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.target_spec_path }}')
+            ResultsDir = '${{ steps.results_root.outputs['results-root'] }}'
+            HeadSha = '${{ steps.discovery.outputs['head-sha'] }}'
+            HeadRef = '${{ steps.discovery.outputs['head-ref'] }}'
+            HeadRepository = '${{ steps.discovery.outputs['head-repo'] }}'
+            PullRequestNumber = '${{ steps.discovery.outputs['pull-request-number'] }}'
+            ReviewerIsFork = '${{ steps.discovery.outputs['reviewer-is-fork'] }}'
+            NoisePolicy = 'collapse'
+            ContainerImage = $env:COMPAREVI_NI_LINUX_IMAGE
+            PlatformRoot = (Join-Path $env:GITHUB_WORKSPACE 'platform')
+            RunUrl = $env:RUN_URL
+            GitHubToken = $env:GITHUB_TOKEN
+            GitHubOutputPath = $env:GITHUB_OUTPUT
+            StepSummaryPath = $env:GITHUB_STEP_SUMMARY
+          }
+          if (-not [string]::IsNullOrWhiteSpace('${{ inputs.max_pairs }}')) {
+            $invokeArgs.MaxPairs = [int]'${{ inputs.max_pairs }}'
+          }
+          if (-not [string]::IsNullOrWhiteSpace('${{ inputs.max_signal_pairs }}')) {
+            $invokeArgs.MaxSignalPairs = [int]'${{ inputs.max_signal_pairs }}'
+          }
+          if (-not [string]::IsNullOrWhiteSpace('${{ inputs.compare_timeout_seconds }}')) {
+            $invokeArgs.CompareTimeoutSeconds = [int]'${{ inputs.compare_timeout_seconds }}'
+          }
+
+          & "$env:GITHUB_WORKSPACE/platform/scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1" @invokeArgs | Out-Null
+
+      - name: Write aggregate PR diagnostics receipt
+        id: aggregate
+        if: ${{ always() && steps.discovery.outputs['changed-vi-discovery-path'] != '' }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryPullRequestRun.ps1" `
+            -DiscoveryPath '${{ steps.discovery.outputs['changed-vi-discovery-path'] }}' `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
+            -TargetRunsManifestPath '${{ steps.execute.outputs['target-runs-manifest-path'] }}' `
+            -GitHubOutputPath $env:GITHUB_OUTPUT | Out-Null
+
+      - name: Append aggregate step summary
+        if: ${{ always() && steps.aggregate.outputs['public-step-summary-path'] != '' }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          Get-Content -LiteralPath '${{ steps.aggregate.outputs['public-step-summary-path'] }}' -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Upload PR diagnostics artifacts
+        if: ${{ always() && steps.discovery.outputs['changed-vi-discovery-path'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-diagnostics-${{ github.run_id }}
+          path: ${{ steps.results_root.outputs['results-root'] }}/**
+          if-no-files-found: error
+
+      - name: Fail closed on degraded PR diagnostics
+        if: ${{ always() && steps.aggregate.outputs['final-status'] == 'failed' }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          throw "comparevi-history PR diagnostics failed closed with final-status '${{ steps.aggregate.outputs['final-status'] }}' and reason '${{ steps.aggregate.outputs['final-reason'] }}'. Review the uploaded artifacts."

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Legacy direct invocation remains available for maintainers:
 - Emits `comparevi-history/public-run@v1` plus stable public artifact paths for comments, step summaries, and replay.
 - Emits `comparevi-history/shared-evidence@v1` as the canonical cross-entrypoint evidence receipt that both curated PR
   diagnostics and manual exploration can share without sharing policy wrappers.
+- Emits `comparevi-history/changed-vi-discovery@v1` as the changed-VI discovery receipt for automatic PR diagnostics.
+- Emits `comparevi-history/pr-run@v1` as the aggregate pull-request diagnostics receipt that points reviewers and
+  downstream processors at per-target public-run and shared-evidence surfaces.
 - Renders reviewer-facing markdown from the bundled helper resolved through `tooling-path` instead of copied inline
   consumer scripts.
 - Verifies the downloaded bundle against the published release digest before extraction.
@@ -144,6 +147,14 @@ Manual exploration workflows emit additive planning receipts alongside the actio
 - `manual-vi-exploration-bundle.zip`
 - `bundle-manifest.json`
 
+Automatic pull-request diagnostics workflows emit additive PR-scope receipts alongside the action outputs:
+
+- `changed-vi-discovery.json` (`comparevi-history/changed-vi-discovery@v1`)
+- `pr-target-runs-manifest.json`
+- `pr-run.json` (`comparevi-history/pr-run@v1`)
+- `pr-comment.md`
+- `pr-step-summary.md`
+
 Corpus/downstream-processing pilots can also emit additive processing receipts:
 
 - `downstream-processor-summary.json` (`comparevi-history/downstream-processor-summary@v1`)
@@ -186,6 +197,36 @@ available, and degrades the final exploration run instead of hiding the packagin
 
 Because reusable workflows do not automatically expose the called workflow repository as a local checkout, the consumer
 wrapper should keep `platform_ref` aligned with the same release ref used in the `uses:` pin.
+
+## Automatic pull request diagnostics workflow
+
+Trusted consumer repositories can expose automatic PR diagnostics for changed VIs through the reusable workflow
+[`./.github/workflows/pull-request-diagnostics.yml`](.github/workflows/pull-request-diagnostics.yml) plus a thin
+consumer wrapper such as
+[`docs/examples/comparevi-history-pull-request-diagnostics.yml`](docs/examples/comparevi-history-pull-request-diagnostics.yml).
+
+The current first slice stays intentionally narrow:
+
+- the platform discovers changed `.vi` files from the live pull request context and writes `changed-vi-discovery.json`
+- the trusted target catalog stays on the pull request base checkout, not the candidate head checkout
+- the trusted consumer-local hosted NI Linux adapter stays on the pull request base checkout, not the candidate head
+  checkout
+- the candidate head checkout supplies the repository root and file content for execution
+- only catalog-declared targets whose `path` matches a changed `.vi` path are executed
+- same-repo pull requests can auto-run immediately
+- cross-repository and fork pull requests fail closed by producing a blocked discovery receipt instead of executing the
+  backend
+- each matched target reuses the existing `request.json`, `public-run.json`, `shared-evidence.json`, and reviewer
+  artifact path without inventing a second backend execution contract
+- the workflow aggregates those per-target runs into `pr-run.json`, `pr-comment.md`, and `pr-step-summary.md`
+- publication of pull-request comments remains a later policy slice; this first workflow writes the deterministic
+  comment body but does not post it automatically
+
+This keeps consumer repositories thin while the automatic PR surface stabilizes:
+
+- target allowlists still live in `.github/comparevi-history-targets.json`
+- execution remains bundle-backed and platform-owned
+- reviewer-facing consumers get stable receipt and markdown paths before comment publication policy is widened
 
 ## Local manual exploration fast loop
 
@@ -296,11 +337,15 @@ Do not copy backend renderers or repo-local history execution logic into consume
 - The action fails closed on `pull_request` and `pull_request_target` events for forked repositories. For public
   repositories, use comment-gated or maintainer-dispatched workflows for PR diagnostics instead of running the facade
   directly on fork PR events.
+- Automatic PR diagnostics reusable workflows should only auto-run on same-repo `pull_request` events. Fork and other
+  cross-repository pull requests should block and point reviewers at maintainer-dispatched or comment-gated trusted
+  flows instead of executing the backend automatically.
 - Public reviewer surfaces accept only explicit scoped modes: `attributes`, `front-panel`, and `block-diagram`.
   Aggregate aliases such as `default`, `full`, and `all` are not part of the public platform contract.
 - Consumer-ready public PR diagnostics templates are published in `docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md`.
 - Reviewer-facing consumers should use `public-comment-path`, `public-step-summary-path`, `public-run-path`, and
-  `shared-evidence-path` instead of rebuilding evidence from raw backend manifests.
+  `shared-evidence-path` instead of rebuilding evidence from raw backend manifests. Automatic PR diagnostics also expose
+  `changed-vi-discovery.json` and `pr-run.json` for aggregate pull-request automation.
 - `comparevi_repository`, `comparevi_ref`, and `invoke_script_path` are maintainer-only overrides. The action rejects
   them when the PR context is not provably repo-local and trusted, and normal consumer workflows should leave them at
   their defaults.

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -8,6 +8,8 @@ of repo-local inline comment renderers.
 
 - Maintainer-dispatched template:
   [comparevi-history-workflow-dispatch.yml](examples/comparevi-history-workflow-dispatch.yml)
+- Automatic PR discovery template:
+  [comparevi-history-pull-request-diagnostics.yml](examples/comparevi-history-pull-request-diagnostics.yml)
 - Comment-gated template:
   [comparevi-history-comment-gated.yml](examples/comparevi-history-comment-gated.yml)
 - Example consumer target catalog source:
@@ -47,6 +49,9 @@ Consumer repositories should not contain:
 ## Use These Patterns
 
 - Use the maintainer-dispatched template when a maintainer wants to inspect a specific pull request on demand.
+- Use the automatic PR discovery template when you want same-repo pull requests to discover changed `.vi` files and run
+  `comparevi-history` automatically for catalog-matched targets without copying orchestration logic into the consumer
+  repository.
 - Use the comment-gated template when you want a slash command such as
   `/comparevi-history vip-post-install-custom-action --modes attributes,front-panel,block-diagram`
   to trigger diagnostics from a trusted maintainer comment.
@@ -69,6 +74,9 @@ Consumer repositories should not contain:
 
 - Do not run `comparevi-history` directly from `pull_request` on public fork PRs. The action intentionally fails closed
   there because the event does not prove a trusted runner or trusted refs.
+- Do not expect the automatic PR discovery template to execute on fork or other cross-repository PR heads. In this
+  slice it should produce a blocked discovery receipt and leave trusted execution to the maintainer-dispatched or
+  comment-gated paths.
 - Do not use `pull_request_target` to run the action automatically against fork content with write-scoped tokens or
   secrets. That crosses the trust boundary the guard is designed to enforce.
 - Do not pin consumer workflows to branch refs such as `@main`, `@develop`, or unpublished SHAs. Use released facade
@@ -81,9 +89,16 @@ Consumer repositories should not contain:
 
 - The maintainer-dispatched template uses `LabVIEW-Community-CI-CD/comparevi-history@v1`. That is the right default
   when you want compatible updates after each reviewed facade release.
+- The automatic PR discovery template uses the reusable workflow surface
+  `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics.yml@v1`. That keeps consumer
+  repositories thin and leaves changed-VI discovery, trusted base/head orchestration, and aggregate receipt generation
+  inside the platform layer.
 - The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.8`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
+- The automatic PR discovery template keeps the target catalog and hosted NI Linux adapter on the pull request base
+  checkout while executing against the candidate head checkout. That is the minimum safe split that keeps repo policy
+  trusted without inventing repo-local orchestration code.
 - Both templates resolve the PR head repository and head SHA from the GitHub API, then check out that exact SHA with
   `fetch-depth: 0` so the backend can traverse commit history deterministically.
 - Both templates keep maintainer-only override inputs unset. That aligns with the trust guard and keeps consumers on the
@@ -106,7 +121,9 @@ Consumer repositories should not contain:
 
 1. Check in `.github/comparevi-history-targets.json` first.
 2. Start with the maintainer-dispatched template when your project is new to VI History diagnostics.
-3. Keep the default explicit public mode bundle unless you have a documented reason to narrow it.
-4. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
+3. Add the automatic PR discovery template when you want same-repo pull requests to run automatically from the checked-
+   in target catalog.
+4. Keep the default explicit public mode bundle unless you have a documented reason to narrow it.
+5. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
    comments on a trusted hosted runner.
-5. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
+6. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.

--- a/docs/examples/comparevi-history-pull-request-diagnostics.yml
+++ b/docs/examples/comparevi-history-pull-request-diagnostics.yml
@@ -1,0 +1,22 @@
+name: CompareVI History Pull Request Diagnostics
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  comparevi-history-pr-diagnostics:
+    uses: LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics.yml@v1
+    with:
+      target_spec_path: .github/comparevi-history-targets.json
+      results_dir: tests/results/pr-diagnostics/history
+      max_pairs: '5'
+      max_signal_pairs: '5'
+      platform_ref: v1

--- a/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
+++ b/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-changed-vi-discovery-v1.schema.json",
+  "title": "comparevi-history changed VI discovery receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "repository",
+    "eventName",
+    "targetCatalog",
+    "pullRequest",
+    "changedViFiles",
+    "matchedTargets",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/changed-vi-discovery@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "eventName": {
+      "type": "string",
+      "enum": ["pull_request", "pull_request_target"]
+    },
+    "targetCatalog": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "path"],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/consumer-targets@v1"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "pullRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "baseRepository",
+        "baseRef",
+        "baseSha",
+        "headRepository",
+        "headRef",
+        "headSha",
+        "isFork",
+        "changedFileCount"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "htmlUrl": {
+          "type": ["string", "null"]
+        },
+        "baseRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "isFork": {
+          "type": "boolean"
+        },
+        "changedFileCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "changedViFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["status", "currentPath"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "minLength": 1
+          },
+          "currentPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "previousPath": {
+            "type": ["string", "null"]
+          }
+        }
+      }
+    },
+    "matchedTargets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["targetId", "targetPath", "matchKind", "changeStatus"],
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "targetPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "publicModes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "matchKind": {
+            "type": "string",
+            "enum": ["current-path", "previous-path"]
+          },
+          "currentPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "previousPath": {
+            "type": ["string", "null"]
+          },
+          "changeStatus": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["executionStatus", "executionReason", "changedViCount", "matchedTargetCount"],
+      "properties": {
+        "executionStatus": {
+          "type": "string",
+          "enum": ["ready", "skipped", "blocked"]
+        },
+        "executionReason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "matchedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/comparevi-history-pr-run-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-run-v1.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-pr-run-v1.schema.json",
+  "title": "comparevi-history pull request run receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "pullRequest",
+    "discovery",
+    "outputs",
+    "summary",
+    "targets"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/pr-run@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "pullRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "baseRepository",
+        "baseRef",
+        "baseSha",
+        "headRepository",
+        "headRef",
+        "headSha",
+        "isFork"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "htmlUrl": {
+          "type": ["string", "null"]
+        },
+        "baseRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "isFork": {
+          "type": "boolean"
+        }
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "path", "status", "reason", "changedViCount", "matchedTargetCount"],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/changed-vi-discovery@v1"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": ["ready", "skipped", "blocked"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "matchedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["resultsDir", "prRunPath", "publicCommentPath", "publicStepSummaryPath"],
+      "properties": {
+        "resultsDir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prRunPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicCommentPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicStepSummaryPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targetRunsManifestPath": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "finalStatus",
+        "finalReason",
+        "changedViCount",
+        "matchedTargetCount",
+        "executedTargetCount",
+        "failedTargetCount",
+        "totalProcessed",
+        "totalDiffs"
+      ],
+      "properties": {
+        "finalStatus": {
+          "type": "string",
+          "enum": ["succeeded", "skipped", "blocked", "failed"]
+        },
+        "finalReason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "matchedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "executedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalProcessed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalDiffs": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["targetId", "targetPath", "finalStatus", "finalReason"],
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "targetPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "matchKind": {
+            "type": ["string", "null"]
+          },
+          "finalStatus": {
+            "type": "string",
+            "enum": ["succeeded", "failed", "cancelled", "unknown"]
+          },
+          "finalReason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "publicRunPath": {
+            "type": ["string", "null"]
+          },
+          "sharedEvidencePath": {
+            "type": ["string", "null"]
+          },
+          "totalProcessed": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "totalDiffs": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1
+++ b/scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1
@@ -1,0 +1,535 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$CandidateRepositoryRoot,
+  [Parameter(Mandatory = $true)]
+  [string]$TrustedRepositoryRoot,
+  [Parameter(Mandatory = $true)]
+  [string]$DiscoveryPath,
+  [Parameter(Mandatory = $true)]
+  [string]$TargetSpecPath,
+  [Parameter(Mandatory = $true)]
+  [string]$ResultsDir,
+  [Parameter(Mandatory = $true)]
+  [string]$HeadSha,
+  [Parameter(Mandatory = $true)]
+  [string]$HeadRef,
+  [Parameter(Mandatory = $true)]
+  [string]$HeadRepository,
+  [Parameter(Mandatory = $true)]
+  [string]$PullRequestNumber,
+  [string]$ReviewerIsFork = 'false',
+  [ValidateSet('include', 'collapse', 'skip')]
+  [string]$NoisePolicy = 'collapse',
+  [Nullable[int]]$MaxPairs,
+  [Nullable[int]]$MaxSignalPairs,
+  [Nullable[int]]$CompareTimeoutSeconds,
+  [string]$InvokeScriptPath,
+  [string]$ToolingRoot,
+  [string]$CompareviRepository = 'LabVIEW-Community-CI-CD/compare-vi-cli-action',
+  [string]$CompareviRef,
+  [string]$ContainerImage = 'nationalinstruments/labview:2026q1-linux',
+  [string]$PlatformRoot,
+  [string]$RunUrl,
+  [string]$GitHubToken,
+  [string]$GitHubOutputPath,
+  [string]$StepSummaryPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionOutput {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    return
+  }
+
+  $safeValue = if ($null -eq $Value) { '' } else { [string]$Value }
+  "$Key=$safeValue" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Read-JsonFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $raw = Get-Content -LiteralPath $Path -Raw
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw "JSON file was empty: $Path"
+  }
+
+  return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Read-KeyValueFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $values = @{}
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    return $values
+  }
+
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    if ($line -match '^(?<key>[^=]+)=(?<value>.*)$') {
+      $values[$Matches['key']] = $Matches['value']
+    }
+  }
+
+  return $values
+}
+
+function Get-OptionalString {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+function Resolve-DefaultInvokeScriptPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryRoot
+  )
+
+  $candidate = Join-Path $RepositoryRoot 'Tooling' 'Invoke-CompareVIHistoryHostedNILinux.ps1'
+  if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+    return $candidate
+  }
+
+  return $null
+}
+
+function ConvertTo-SafeName {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Value
+  )
+
+  $safe = $Value -replace '[^A-Za-z0-9._-]+', '-'
+  $safe = $safe.Trim('-')
+  if ([string]::IsNullOrWhiteSpace($safe)) {
+    return 'target'
+  }
+
+  return $safe
+}
+
+$basePath = (Get-Location).Path
+$candidateRepositoryRootResolved = Resolve-AbsolutePath -Path $CandidateRepositoryRoot -BasePath $basePath
+$trustedRepositoryRootResolved = Resolve-AbsolutePath -Path $TrustedRepositoryRoot -BasePath $basePath
+$discoveryPathResolved = Resolve-AbsolutePath -Path $DiscoveryPath -BasePath $basePath
+$targetSpecPathResolved = Resolve-AbsolutePath -Path $TargetSpecPath -BasePath $basePath
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
+$platformRootResolved = if ([string]::IsNullOrWhiteSpace($PlatformRoot)) {
+  Split-Path -Parent $PSScriptRoot
+} else {
+  Resolve-AbsolutePath -Path $PlatformRoot -BasePath $basePath
+}
+
+foreach ($requiredDirectory in @($candidateRepositoryRootResolved, $trustedRepositoryRootResolved, $platformRootResolved)) {
+  if (-not (Test-Path -LiteralPath $requiredDirectory -PathType Container)) {
+    throw "Required directory was not found: $requiredDirectory"
+  }
+}
+foreach ($requiredFile in @($discoveryPathResolved, $targetSpecPathResolved)) {
+  if (-not (Test-Path -LiteralPath $requiredFile -PathType Leaf)) {
+    throw "Required file was not found: $requiredFile"
+  }
+}
+
+New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
+
+$discovery = Read-JsonFile -Path $discoveryPathResolved
+if ([string]$discovery.schema -ne 'comparevi-history/changed-vi-discovery@v1') {
+  throw "Unsupported discovery schema in '$discoveryPathResolved': $($discovery.schema)"
+}
+if ([string]$discovery.summary.executionStatus -ne 'ready') {
+  throw "Pull request diagnostics require a ready discovery receipt. Actual status: $($discovery.summary.executionStatus)"
+}
+
+$effectiveInvokeScriptPath = if (-not [string]::IsNullOrWhiteSpace($InvokeScriptPath)) {
+  Resolve-AbsolutePath -Path $InvokeScriptPath -BasePath $trustedRepositoryRootResolved
+} else {
+  Resolve-DefaultInvokeScriptPath -RepositoryRoot $trustedRepositoryRootResolved
+}
+if ([string]::IsNullOrWhiteSpace($effectiveInvokeScriptPath) -or -not (Test-Path -LiteralPath $effectiveInvokeScriptPath -PathType Leaf)) {
+  throw 'Pull request diagnostics require a trusted consumer-local Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1 adapter.'
+}
+
+$toolingRootResolved = $null
+$toolingSource = $null
+$effectiveCompareviRef = $null
+if (-not [string]::IsNullOrWhiteSpace($ToolingRoot)) {
+  $toolingRootResolved = Resolve-AbsolutePath -Path $ToolingRoot -BasePath $basePath
+  if (-not (Test-Path -LiteralPath $toolingRootResolved -PathType Container)) {
+    throw "Provided tooling root was not found: $toolingRootResolved"
+  }
+
+  $toolingSource = 'provided-tooling-root'
+  $effectiveCompareviRef = if ([string]::IsNullOrWhiteSpace($CompareviRef)) { 'provided-tooling-root' } else { $CompareviRef.Trim() }
+} else {
+  $resolveOutputPath = Join-Path $resultsDirResolved 'resolve-backend.out'
+  & (Join-Path $platformRootResolved 'scripts' 'Resolve-CompareVIHistoryBackend.ps1') `
+    -Repository $CompareviRepository `
+    -RequestedRef $CompareviRef `
+    -DefaultRefPath (Join-Path $platformRootResolved 'comparevi-backend-ref.txt') `
+    -ActionRef 'pull-request-diagnostics' `
+    -ToolingPath (Join-Path $resultsDirResolved '.comparevi-history-tools') `
+    -AllowSourceFallback `
+    -GitHubToken $GitHubToken `
+    -GitHubOutputPath $resolveOutputPath | Out-Null
+
+  $resolveValues = Read-KeyValueFile -Path $resolveOutputPath
+  $toolingSource = [string]$resolveValues['tooling-source']
+  $effectiveCompareviRef = [string]$resolveValues['comparevi-ref']
+  if ([string]::IsNullOrWhiteSpace($toolingSource)) {
+    throw 'Failed to resolve comparevi-history backend tooling source.'
+  }
+
+  if ($toolingSource -eq 'bundle') {
+    $acquireOutputPath = Join-Path $resultsDirResolved 'acquire-backend.out'
+    & (Join-Path $platformRootResolved 'scripts' 'Acquire-CompareVIToolsBundle.ps1') `
+      -Repository $CompareviRepository `
+      -ReleaseTag ([string]$resolveValues['release-tag']) `
+      -BundleAssetName ([string]$resolveValues['bundle-asset-name']) `
+      -BundleAssetUrl ([string]$resolveValues['bundle-asset-url']) `
+      -BundleAssetDigest ([string]$resolveValues['bundle-asset-digest']) `
+      -DestinationPath ([string]$resolveValues['tooling-path']) `
+      -GitHubToken $GitHubToken `
+      -GitHubOutputPath $acquireOutputPath | Out-Null
+
+    $acquireValues = Read-KeyValueFile -Path $acquireOutputPath
+    $toolingRootResolved = Resolve-AbsolutePath -Path ([string]$acquireValues['tooling-path']) -BasePath $basePath
+  } else {
+    $toolingRootResolved = Resolve-AbsolutePath -Path ([string]$resolveValues['tooling-path']) -BasePath $basePath
+  }
+}
+
+if (-not (Test-Path -LiteralPath $toolingRootResolved -PathType Container)) {
+  throw "Resolved tooling root was not found: $toolingRootResolved"
+}
+
+$targetsRoot = Join-Path $resultsDirResolved 'targets'
+New-Item -ItemType Directory -Path $targetsRoot -Force | Out-Null
+$manifestPath = Join-Path $resultsDirResolved 'pr-target-runs-manifest.json'
+
+$targetRuns = New-Object System.Collections.Generic.List[object]
+$executedTargetCount = 0
+$failedTargetCount = 0
+$skippedTargetCount = 0
+$index = 0
+
+foreach ($matchedTarget in @($discovery.matchedTargets)) {
+  $targetId = [string]$matchedTarget.targetId
+  $targetPath = [string]$matchedTarget.targetPath
+  $targetSafeName = ConvertTo-SafeName -Value $targetId
+  $targetRoot = Join-Path $targetsRoot ('{0:d3}-{1}' -f ($index + 1), $targetSafeName)
+  $historyResultsDir = Join-Path $targetRoot 'history'
+  New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+  $requestOutputPath = Join-Path $targetRoot 'request.out'
+  $runOutputPath = Join-Path $targetRoot 'run.out'
+  $publicRunOutputPath = Join-Path $targetRoot 'public-run.out'
+  $modeSummaryJsonPath = Join-Path $targetRoot 'mode-summary.json'
+  $modeSummaryPath = Join-Path $targetRoot 'mode-summary.md'
+
+  $requestOutcome = 'failure'
+  $runOutcome = 'skipped'
+  $runConclusion = 'skipped'
+  $requestError = $null
+  $runError = $null
+  $publicRunError = $null
+
+  try {
+    $requestArgs = @{
+      RepositoryRoot = $candidateRepositoryRootResolved
+      TargetSpecPath = $targetSpecPathResolved
+      TargetId = $targetId
+      StartRef = $HeadSha
+      NoisePolicy = $NoisePolicy
+      ResultsDir = $historyResultsDir
+      ReportFormat = 'html'
+      RenderReport = $true
+      Detailed = $true
+      ConsumerRepository = $HeadRepository
+      ConsumerRef = $HeadSha
+      SourceBranchRef = $HeadRef
+      ReviewerSurface = 'manual'
+      ReviewerPullRequestNumber = $PullRequestNumber
+      ReviewerIsFork = $ReviewerIsFork
+      ContainerImage = $ContainerImage
+      GitHubOutputPath = $requestOutputPath
+    }
+    if ($null -ne $MaxPairs) {
+      $requestArgs.MaxPairs = [int]$MaxPairs
+    }
+    if ($null -ne $MaxSignalPairs) {
+      $requestArgs.MaxSignalPairs = [int]$MaxSignalPairs
+    }
+    if ($null -ne $CompareTimeoutSeconds) {
+      $requestArgs.CompareTimeoutSeconds = [int]$CompareTimeoutSeconds
+    }
+
+    & (Join-Path $platformRootResolved 'scripts' 'Resolve-CompareVIHistoryRequest.ps1') @requestArgs | Out-Null
+    $requestOutcome = 'success'
+  } catch {
+    $requestError = $_
+  }
+
+  $requestValues = Read-KeyValueFile -Path $requestOutputPath
+  $runValues = @{}
+  $publicRunValues = @{}
+  if ($requestOutcome -eq 'success') {
+    $executedTargetCount += 1
+    try {
+      $invokeArgs = @{
+        RepositoryRoot = $candidateRepositoryRootResolved
+        ToolingRoot = $toolingRootResolved
+        TargetPath = [string]$requestValues['target-path']
+        StartRef = $HeadSha
+        NoisePolicy = $NoisePolicy
+        Mode = [string]$requestValues['requested-mode-list']
+        ResultsDir = [string]$requestValues['results-dir']
+        ReportFormat = 'html'
+        RenderReport = $true
+        Detailed = $true
+        InvokeScriptPath = $effectiveInvokeScriptPath
+        GitHubOutputPath = $runOutputPath
+      }
+      if (-not [string]::IsNullOrWhiteSpace([string]$requestValues['source-branch-ref'])) {
+        $invokeArgs.SourceBranchRef = [string]$requestValues['source-branch-ref']
+      }
+      if (-not [string]::IsNullOrWhiteSpace([string]$requestValues['max-branch-commits'])) {
+        $invokeArgs.MaxBranchCommits = [int][string]$requestValues['max-branch-commits']
+      }
+      if ($null -ne $MaxPairs) {
+        $invokeArgs.MaxPairs = [int]$MaxPairs
+      }
+      if ($null -ne $MaxSignalPairs) {
+        $invokeArgs.MaxSignalPairs = [int]$MaxSignalPairs
+      }
+      if ($null -ne $CompareTimeoutSeconds) {
+        $invokeArgs.CompareTimeoutSeconds = [int]$CompareTimeoutSeconds
+      }
+
+      & (Join-Path $platformRootResolved 'scripts' 'Invoke-CompareVIHistoryFacade.ps1') @invokeArgs | Out-Null
+      $runOutcome = 'success'
+      $runConclusion = 'success'
+    } catch {
+      $runOutcome = 'failure'
+      $runConclusion = 'failure'
+      $runError = $_
+    }
+
+    $runValues = Read-KeyValueFile -Path $runOutputPath
+
+    & (Join-Path $platformRootResolved 'scripts' 'Format-CompareVIHistoryModeSummary.ps1') `
+      -RequestedModeList $([string]$runValues['requested-mode-list']) `
+      -ExecutedModeList $([string]$runValues['executed-mode-list']) `
+      -ModeManifestsJson $([string]$runValues['mode-manifests-json']) `
+      -TotalProcessed $([string]$runValues['total-processed']) `
+      -TotalDiffs $([string]$runValues['total-diffs']) `
+      -StopReason $([string]$runValues['stop-reason']) `
+      -JsonOutputPath $modeSummaryJsonPath `
+      -OutputPath $modeSummaryPath | Out-Null
+
+    $modeSummaryMarkdown = if (Test-Path -LiteralPath $modeSummaryPath -PathType Leaf) {
+      Get-Content -LiteralPath $modeSummaryPath -Raw
+    } else {
+      ''
+    }
+
+    try {
+      & (Join-Path $platformRootResolved 'scripts' 'Write-CompareVIHistoryPublicRun.ps1') `
+        -RequestPath ([string]$requestValues['request-path']) `
+        -ToolingRoot $toolingRootResolved `
+        -CompareviRepository $CompareviRepository `
+        -CompareviRef $effectiveCompareviRef `
+        -ToolingSource $toolingSource `
+        -ActionRef 'comparevi-history/pull-request-diagnostics' `
+        -HistorySummaryJson $([string]$runValues['history-summary-json']) `
+        -ManifestPath $([string]$runValues['manifest-path']) `
+        -ResultsDir $([string]$runValues['results-dir']) `
+        -HistoryReportMd $([string]$runValues['history-report-md']) `
+        -HistoryReportHtml $([string]$runValues['history-report-html']) `
+        -ModeSummaryJsonPath $modeSummaryJsonPath `
+        -ModeSummaryPath $modeSummaryPath `
+        -RequestedModeList $([string]$runValues['requested-mode-list']) `
+        -ExecutedModeList $([string]$runValues['executed-mode-list']) `
+        -ModeSummaryMarkdown $modeSummaryMarkdown `
+        -ModeCount $([string]$runValues['mode-count']) `
+        -TotalProcessed $([string]$runValues['total-processed']) `
+        -TotalDiffs $([string]$runValues['total-diffs']) `
+        -StopReason $([string]$runValues['stop-reason']) `
+        -RunOutcome $runOutcome `
+        -RunConclusion $runConclusion `
+        -RunUrl $RunUrl `
+        -GitHubOutputPath $publicRunOutputPath | Out-Null
+    } catch {
+      $publicRunError = $_
+    }
+
+    $publicRunValues = Read-KeyValueFile -Path $publicRunOutputPath
+  }
+
+  $finalStatus = if ($publicRunValues.ContainsKey('final-status')) {
+    [string]$publicRunValues['final-status']
+  } elseif ($requestOutcome -ne 'success') {
+    'failed'
+  } elseif ($runOutcome -eq 'failure') {
+    'failed'
+  } else {
+    'unknown'
+  }
+
+  $finalReason = if ($publicRunValues.ContainsKey('final-reason')) {
+    [string]$publicRunValues['final-reason']
+  } elseif ($requestOutcome -ne 'success') {
+    'request-normalization-failed'
+  } elseif ($null -ne $publicRunError) {
+    'public-run-write-failed'
+  } elseif ($runOutcome -eq 'failure') {
+    'facade-step-failed'
+  } else {
+    'unknown'
+  }
+
+  if ($finalStatus -ne 'succeeded') {
+    $failedTargetCount += 1
+  }
+
+  $targetRuns.Add([ordered]@{
+      targetId = $targetId
+      targetPath = $targetPath
+      matchKind = Get-OptionalString -Value $matchedTarget.matchKind
+      currentPath = Get-OptionalString -Value $matchedTarget.currentPath
+      previousPath = Get-OptionalString -Value $matchedTarget.previousPath
+      changeStatus = Get-OptionalString -Value $matchedTarget.changeStatus
+      requestOutcome = $requestOutcome
+      runOutcome = $runOutcome
+      finalStatus = $finalStatus
+      finalReason = $finalReason
+      requestPath = Get-OptionalString -Value $requestValues['request-path']
+      publicRunPath = Get-OptionalString -Value $publicRunValues['public-run-path']
+      sharedEvidencePath = Get-OptionalString -Value $publicRunValues['shared-evidence-path']
+      publicCommentPath = Get-OptionalString -Value $publicRunValues['public-comment-path']
+      publicStepSummaryPath = Get-OptionalString -Value $publicRunValues['public-step-summary-path']
+      totalProcessed = if ([string]::IsNullOrWhiteSpace([string]$runValues['total-processed'])) { $null } else { [int][string]$runValues['total-processed'] }
+      totalDiffs = if ([string]::IsNullOrWhiteSpace([string]$runValues['total-diffs'])) { $null } else { [int][string]$runValues['total-diffs'] }
+      resultsDir = Get-OptionalString -Value $requestValues['results-dir']
+      requestError = if ($null -eq $requestError) { $null } else { [string]$requestError.Exception.Message }
+      runError = if ($null -eq $runError) { $null } else { [string]$runError.Exception.Message }
+      publicRunError = if ($null -eq $publicRunError) { $null } else { [string]$publicRunError.Exception.Message }
+    }) | Out-Null
+
+  $index += 1
+}
+
+$executionStatus = if ($failedTargetCount -gt 0) {
+  'failed'
+} elseif ($executedTargetCount -eq 0) {
+  'skipped'
+} else {
+  'succeeded'
+}
+$executionReason = switch ($executionStatus) {
+  'failed' { 'one-or-more-targets-failed' }
+  'skipped' { 'no-targets-executed' }
+  default { 'completed' }
+}
+
+$manifest = [ordered]@{
+  schema = 'comparevi-history/pr-target-runs-manifest@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  pullRequest = [ordered]@{
+    number = [int]$PullRequestNumber
+    headRepository = $HeadRepository
+    headRef = $HeadRef
+    headSha = $HeadSha
+    isFork = [string]$ReviewerIsFork
+  }
+  tooling = [ordered]@{
+    source = $toolingSource
+    repository = $CompareviRepository
+    ref = $effectiveCompareviRef
+    root = $toolingRootResolved
+    invokeScriptPath = $effectiveInvokeScriptPath
+    containerImage = $ContainerImage
+  }
+  summary = [ordered]@{
+    matchedTargetCount = @($discovery.matchedTargets).Count
+    executedTargetCount = $executedTargetCount
+    failedTargetCount = $failedTargetCount
+    skippedTargetCount = $skippedTargetCount
+    executionStatus = $executionStatus
+    executionReason = $executionReason
+  }
+  targets = @($targetRuns | ForEach-Object { $_ })
+}
+
+$manifest | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+Write-ActionOutput -Key 'target-runs-manifest-path' -Value $manifestPath
+Write-ActionOutput -Key 'tooling-path' -Value $toolingRootResolved
+Write-ActionOutput -Key 'tooling-source' -Value $toolingSource
+Write-ActionOutput -Key 'comparevi-ref' -Value $effectiveCompareviRef
+Write-ActionOutput -Key 'executed-target-count' -Value ([string]$executedTargetCount)
+Write-ActionOutput -Key 'failed-target-count' -Value ([string]$failedTargetCount)
+Write-ActionOutput -Key 'skipped-target-count' -Value ([string]$skippedTargetCount)
+Write-ActionOutput -Key 'execution-status' -Value $executionStatus
+Write-ActionOutput -Key 'execution-reason' -Value $executionReason
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  @(
+    '## comparevi-history pull request diagnostics'
+    ''
+    ('- Head repository: `{0}`' -f $HeadRepository)
+    ('- Head ref: `{0}`' -f $HeadRef)
+    ('- Head SHA: `{0}`' -f $HeadSha)
+    ('- Tooling source: `{0}`' -f $toolingSource)
+    ('- Tooling ref: `{0}`' -f $effectiveCompareviRef)
+    ('- Executed target count: `{0}`' -f $executedTargetCount)
+    ('- Failed target count: `{0}`' -f $failedTargetCount)
+    ('- Execution status: `{0}`' -f $executionStatus)
+    ('- Execution reason: `{0}`' -f $executionReason)
+    ('- Target runs manifest: `{0}`' -f $manifestPath)
+  ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+$manifest | ConvertTo-Json -Depth 32

--- a/scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1
@@ -1,0 +1,353 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Invoke-CompareVIHistoryPullRequestDiagnostics.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-pr-diag-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try {
+  $candidateRoot = Join-Path $tempRoot 'candidate'
+  $trustedRoot = Join-Path $tempRoot 'trusted'
+  $platformRoot = Join-Path $tempRoot 'platform'
+  $toolingRoot = Join-Path $tempRoot 'tooling'
+  $resultsDir = Join-Path $tempRoot 'results'
+  foreach ($path in @($candidateRoot, $trustedRoot, $platformRoot, $toolingRoot, $resultsDir, (Join-Path $platformRoot 'scripts'), (Join-Path $toolingRoot 'tools'), (Join-Path $trustedRoot 'Tooling'))) {
+    New-Item -ItemType Directory -Path $path -Force | Out-Null
+  }
+
+  'stub' | Set-Content -LiteralPath (Join-Path $trustedRoot 'Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1') -Encoding utf8
+
+  $targetSpecPath = Join-Path $trustedRoot '.github/comparevi-history-targets.json'
+  New-Item -ItemType Directory -Path (Split-Path -Parent $targetSpecPath) -Force | Out-Null
+  @'
+{
+  "schema": "comparevi-history/consumer-targets@v1",
+  "targets": [
+    {
+      "id": "target-success",
+      "path": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"]
+    },
+    {
+      "id": "target-fail",
+      "path": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"]
+    }
+  ]
+}
+'@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
+
+  $discoveryPath = Join-Path $resultsDir 'changed-vi-discovery.json'
+  @'
+{
+  "schema": "comparevi-history/changed-vi-discovery@v1",
+  "generatedAtUtc": "2026-03-17T00:00:00Z",
+  "repository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+  "eventName": "pull_request",
+  "targetCatalog": {
+    "schema": "comparevi-history/consumer-targets@v1",
+    "path": "placeholder"
+  },
+  "pullRequest": {
+    "number": 22,
+    "htmlUrl": null,
+    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "baseRef": "develop",
+    "baseSha": "base-sha",
+    "headRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "headRef": "feature/history",
+    "headSha": "head-sha",
+    "isFork": false,
+    "changedFileCount": 2
+  },
+  "changedViFiles": [
+    {
+      "status": "modified",
+      "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "previousPath": null
+    },
+    {
+      "status": "modified",
+      "currentPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "previousPath": null
+    }
+  ],
+  "matchedTargets": [
+    {
+      "targetId": "target-success",
+      "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "matchKind": "current-path",
+      "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "previousPath": null,
+      "changeStatus": "modified"
+    },
+    {
+      "targetId": "target-fail",
+      "targetPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "matchKind": "current-path",
+      "currentPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "previousPath": null,
+      "changeStatus": "modified"
+    }
+  ],
+  "summary": {
+    "executionStatus": "ready",
+    "executionReason": "matched-targets",
+    "changedViCount": 2,
+    "matchedTargetCount": 2
+  }
+}
+'@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
+
+  @'
+param(
+  [string]$RepositoryRoot,
+  [string]$TargetSpecPath,
+  [string]$TargetId,
+  [string]$StartRef,
+  [string]$NoisePolicy,
+  [string]$ResultsDir,
+  [string]$ConsumerRepository,
+  [string]$ConsumerRef,
+  [string]$SourceBranchRef,
+  [string]$ReviewerSurface,
+  [string]$ReviewerPullRequestNumber,
+  [string]$ReviewerIsFork,
+  [string]$ContainerImage,
+  [string]$GitHubOutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$targetPath = if ($TargetId -eq 'target-success') {
+  'Tooling/deployment/VIP_Post-Install Custom Action.vi'
+} else {
+  'Tooling/deployment/VIP_Pre-Install Custom Action.vi'
+}
+$publicRoot = Join-Path $ResultsDir 'public'
+New-Item -ItemType Directory -Path $publicRoot -Force | Out-Null
+$requestPath = Join-Path $publicRoot 'request.json'
+[ordered]@{
+  schema = 'comparevi-history/request@v1'
+  consumer = [ordered]@{
+    repositoryRoot = $RepositoryRoot
+    repository = $ConsumerRepository
+    ref = $ConsumerRef
+  }
+  target = [ordered]@{
+    id = $TargetId
+    path = $targetPath
+    requestedModes = @('attributes', 'front-panel', 'block-diagram')
+    publicModes = @('attributes', 'front-panel', 'block-diagram')
+  }
+  history = [ordered]@{
+    renderReport = $true
+  }
+  results = [ordered]@{
+    resultsDir = $ResultsDir
+    publicRunPath = (Join-Path $publicRoot 'public-run.json')
+    publicCommentPath = (Join-Path $publicRoot 'comment.md')
+    publicStepSummaryPath = (Join-Path $publicRoot 'step-summary.md')
+  }
+} | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $requestPath -Encoding utf8
+"target-path=$targetPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"request-path=$requestPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"results-dir=$ResultsDir" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"requested-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"source-branch-ref=$SourceBranchRef" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+'@ | Set-Content -LiteralPath (Join-Path $platformRoot 'scripts/Resolve-CompareVIHistoryRequest.ps1') -Encoding utf8
+
+  @'
+param(
+  [string]$RepositoryRoot,
+  [string]$ToolingRoot,
+  [string]$TargetPath,
+  [string]$ResultsDir,
+  [string]$GitHubOutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
+$historySummaryPath = Join-Path $ResultsDir 'history-summary.json'
+$manifestPath = Join-Path $ResultsDir 'manifest.json'
+$reportMdPath = Join-Path $ResultsDir 'history-report.md'
+$reportHtmlPath = Join-Path $ResultsDir 'history-report.html'
+'{}' | Set-Content -LiteralPath $historySummaryPath -Encoding utf8
+'{}' | Set-Content -LiteralPath $manifestPath -Encoding utf8
+'# report' | Set-Content -LiteralPath $reportMdPath -Encoding utf8
+'<html></html>' | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
+"history-summary-json=$historySummaryPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"manifest-path=$manifestPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"results-dir=$ResultsDir" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"history-report-md=$reportMdPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"history-report-html=$reportHtmlPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"requested-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"executed-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"mode-count=3" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"stop-reason=completed" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+if ($TargetPath -like '*Pre-Install*') {
+  "total-processed=0" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+  "total-diffs=0" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+  throw 'simulated failure'
+}
+"total-processed=5" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"total-diffs=2" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+'@ | Set-Content -LiteralPath (Join-Path $platformRoot 'scripts/Invoke-CompareVIHistoryFacade.ps1') -Encoding utf8
+
+  @'
+param(
+  [string]$RequestedModeList,
+  [string]$ExecutedModeList,
+  [string]$TotalProcessed,
+  [string]$TotalDiffs,
+  [string]$StopReason,
+  [string]$JsonOutputPath,
+  [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+@"
+{
+  ""schema"": ""comparevi-history/mode-summary@v1"",
+  ""requestedModes"": [""attributes"", ""front-panel"", ""block-diagram""],
+  ""executedModes"": [""attributes"", ""front-panel"", ""block-diagram""],
+  ""totalProcessed"": $TotalProcessed,
+  ""totalDiffs"": $TotalDiffs,
+  ""stopReason"": ""$StopReason"",
+  ""categoryCounts"": {},
+  ""comparisonPairs"": [],
+  ""bucketCounts"": {},
+  ""previewImages"": [],
+  ""metadata"": {
+    ""comparisonArtifactCount"": 0,
+    ""captureCount"": 0,
+    ""imageArtifactCount"": 0,
+    ""imageMimeTypes"": []
+  }
+}
+"@ | Set-Content -LiteralPath $JsonOutputPath -Encoding utf8
+'mode summary' | Set-Content -LiteralPath $OutputPath -Encoding utf8
+'@ | Set-Content -LiteralPath (Join-Path $platformRoot 'scripts/Format-CompareVIHistoryModeSummary.ps1') -Encoding utf8
+
+  @'
+param(
+  [string]$RequestPath,
+  [string]$ToolingRoot,
+  [string]$CompareviRepository,
+  [string]$CompareviRef,
+  [string]$ToolingSource,
+  [string]$ActionRef,
+  [string]$HistorySummaryJson,
+  [string]$ManifestPath,
+  [string]$ResultsDir,
+  [string]$HistoryReportMd,
+  [string]$HistoryReportHtml,
+  [string]$ModeSummaryJsonPath,
+  [string]$ModeSummaryPath,
+  [string]$RequestedModeList,
+  [string]$ExecutedModeList,
+  [string]$ModeSummaryMarkdown,
+  [string]$ModeCount,
+  [string]$TotalProcessed,
+  [string]$TotalDiffs,
+  [string]$StopReason,
+  [string]$RunOutcome,
+  [string]$RunConclusion,
+  [string]$RunUrl,
+  [string]$GitHubOutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$request = Get-Content -LiteralPath $RequestPath -Raw | ConvertFrom-Json -Depth 50
+$publicRunPath = $request.results.publicRunPath
+$sharedEvidencePath = Join-Path (Split-Path -Parent $publicRunPath) 'shared-evidence.json'
+$commentPath = $request.results.publicCommentPath
+$stepSummaryPath = $request.results.publicStepSummaryPath
+$finalStatus = if ($RunOutcome -eq 'success') { 'succeeded' } else { 'failed' }
+$finalReason = if ($RunOutcome -eq 'success') { 'completed' } else { 'facade-step-failed' }
+[ordered]@{
+  schema = 'comparevi-history/public-run@v1'
+  target = [ordered]@{
+    id = [string]$request.target.id
+    path = [string]$request.target.path
+  }
+  summary = [ordered]@{
+    totalProcessed = [int]$TotalProcessed
+    totalDiffs = [int]$TotalDiffs
+    finalStatus = $finalStatus
+    finalReason = $finalReason
+  }
+  outputs = [ordered]@{
+    publicCommentPath = $commentPath
+    publicStepSummaryPath = $stepSummaryPath
+  }
+  evidence = [ordered]@{
+    schema = 'comparevi-history/shared-evidence@v1'
+    path = $sharedEvidencePath
+  }
+} | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $publicRunPath -Encoding utf8
+[ordered]@{
+  schema = 'comparevi-history/shared-evidence@v1'
+  source = [ordered]@{
+    schema = 'comparevi-history/public-run@v1'
+  }
+} | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $sharedEvidencePath -Encoding utf8
+'comment' | Set-Content -LiteralPath $commentPath -Encoding utf8
+'summary' | Set-Content -LiteralPath $stepSummaryPath -Encoding utf8
+"public-run-path=$publicRunPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"shared-evidence-path=$sharedEvidencePath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"public-comment-path=$commentPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"public-step-summary-path=$stepSummaryPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"final-status=$finalStatus" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"final-reason=$finalReason" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+'@ | Set-Content -LiteralPath (Join-Path $platformRoot 'scripts/Write-CompareVIHistoryPublicRun.ps1') -Encoding utf8
+
+  $outputPath = Join-Path $tempRoot 'pr-diag.out'
+  $manifestJson = & $scriptPath `
+    -CandidateRepositoryRoot $candidateRoot `
+    -TrustedRepositoryRoot $trustedRoot `
+    -DiscoveryPath $discoveryPath `
+    -TargetSpecPath $targetSpecPath `
+    -ResultsDir $resultsDir `
+    -HeadSha 'head-sha' `
+    -HeadRef 'feature/history' `
+    -HeadRepository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -PullRequestNumber '22' `
+    -ReviewerIsFork 'false' `
+    -ToolingRoot $toolingRoot `
+    -PlatformRoot $platformRoot `
+    -GitHubOutputPath $outputPath
+
+  $manifest = $manifestJson | ConvertFrom-Json -Depth 100
+  if ($manifest.summary.executionStatus -ne 'failed') {
+    throw 'Expected one simulated target failure.'
+  }
+  if ($manifest.summary.failedTargetCount -ne 1) {
+    throw 'Failed target count mismatch.'
+  }
+  if ($manifest.summary.executedTargetCount -ne 2) {
+    throw 'Executed target count mismatch.'
+  }
+  if (-not ($manifest.targets | Where-Object { $_.targetId -eq 'target-success' -and $_.finalStatus -eq 'succeeded' })) {
+    throw 'Successful target was not recorded.'
+  }
+  if (-not ($manifest.targets | Where-Object { $_.targetId -eq 'target-fail' -and $_.finalStatus -eq 'failed' })) {
+    throw 'Failed target was not recorded.'
+  }
+
+  $outputText = Get-Content -LiteralPath $outputPath -Raw
+  foreach ($requiredKey in @('target-runs-manifest-path=', 'execution-status=failed', 'failed-target-count=1', 'executed-target-count=2')) {
+    if ($outputText -notmatch [regex]::Escape($requiredKey)) {
+      throw "Expected GitHub output '$requiredKey'."
+    }
+  }
+} finally {
+  Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
@@ -1,0 +1,149 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryPullRequestDiscovery.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-pr-discovery-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try {
+  $targetSpecPath = Join-Path $tempRoot 'comparevi-history-targets.json'
+  @'
+{
+  "schema": "comparevi-history/consumer-targets@v1",
+  "targets": [
+    {
+      "id": "vip-post-install",
+      "path": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"]
+    },
+    {
+      "id": "vip-pre-install",
+      "path": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"]
+    }
+  ]
+}
+'@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
+
+  $eventPath = Join-Path $tempRoot 'event.json'
+  @'
+{
+  "pull_request": {
+    "number": 42,
+    "html_url": "https://github.com/example/repo/pull/42",
+    "changed_files": 3,
+    "base": {
+      "ref": "develop",
+      "sha": "base-sha",
+      "repo": {
+        "full_name": "LabVIEW-Community-CI-CD/labview-icon-editor-demo"
+      }
+    },
+    "head": {
+      "ref": "feature/history",
+      "sha": "head-sha",
+      "repo": {
+        "full_name": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+        "fork": false
+      }
+    }
+  }
+}
+'@ | Set-Content -LiteralPath $eventPath -Encoding utf8
+
+  $filesPayloadPath = Join-Path $tempRoot 'files.json'
+  @'
+[
+  {
+    "filename": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+    "status": "modified"
+  },
+  {
+    "filename": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+    "previous_filename": "Tooling/deployment/VIP_Pre-Install Legacy.vi",
+    "status": "renamed"
+  },
+  {
+    "filename": "README.md",
+    "status": "modified"
+  }
+]
+'@ | Set-Content -LiteralPath $filesPayloadPath -Encoding utf8
+
+  $outputPath = Join-Path $tempRoot 'discovery.out'
+  $resultsDir = Join-Path $tempRoot 'results'
+  $receiptJson = & $scriptPath `
+    -EventName 'pull_request' `
+    -EventPath $eventPath `
+    -TargetSpecPath $targetSpecPath `
+    -ResultsDir $resultsDir `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -FilesPayloadPath $filesPayloadPath `
+    -GitHubOutputPath $outputPath
+
+  $receipt = $receiptJson | ConvertFrom-Json -Depth 50
+  if ($receipt.schema -ne 'comparevi-history/changed-vi-discovery@v1') {
+    throw 'Discovery schema mismatch.'
+  }
+  if ($receipt.summary.executionStatus -ne 'ready') {
+    throw 'Discovery should be ready for same-repo VI changes.'
+  }
+  if ($receipt.summary.changedViCount -ne 2) {
+    throw 'Changed VI count mismatch.'
+  }
+  if ($receipt.summary.matchedTargetCount -ne 2) {
+    throw 'Matched target count mismatch.'
+  }
+  if ($receipt.matchedTargets[1].matchKind -ne 'current-path') {
+    throw 'Expected current-path match for renamed current target path.'
+  }
+
+  $outputText = Get-Content -LiteralPath $outputPath -Raw
+  foreach ($requiredKey in @('changed-vi-discovery-path=', 'execution-status=ready', 'matched-target-count=2', 'pull-request-number=42')) {
+    if ($outputText -notmatch [regex]::Escape($requiredKey)) {
+      throw "Expected GitHub output '$requiredKey'."
+    }
+  }
+
+  $forkEventPath = Join-Path $tempRoot 'fork-event.json'
+  @'
+{
+  "pull_request": {
+    "number": 7,
+    "changed_files": 1,
+    "base": {
+      "ref": "develop",
+      "sha": "base-sha",
+      "repo": {
+        "full_name": "LabVIEW-Community-CI-CD/labview-icon-editor-demo"
+      }
+    },
+    "head": {
+      "ref": "feature/from-fork",
+      "sha": "fork-sha",
+      "repo": {
+        "full_name": "some-user/labview-icon-editor-demo",
+        "fork": true
+      }
+    }
+  }
+}
+'@ | Set-Content -LiteralPath $forkEventPath -Encoding utf8
+
+  $forkReceiptJson = & $scriptPath `
+    -EventName 'pull_request' `
+    -EventPath $forkEventPath `
+    -TargetSpecPath $targetSpecPath `
+    -ResultsDir (Join-Path $tempRoot 'fork-results') `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -FilesPayloadPath $filesPayloadPath
+  $forkReceipt = $forkReceiptJson | ConvertFrom-Json -Depth 50
+  if ($forkReceipt.summary.executionStatus -ne 'blocked') {
+    throw 'Fork pull request must be blocked.'
+  }
+  if ($forkReceipt.summary.executionReason -ne 'untrusted-cross-repository-pull-request') {
+    throw 'Fork pull request block reason mismatch.'
+  }
+} finally {
+  Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestRun.ps1
@@ -1,0 +1,170 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryPullRequestRun.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-pr-run-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+try {
+  $resultsDir = Join-Path $tempRoot 'results'
+  New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
+
+  $discoveryPath = Join-Path $resultsDir 'changed-vi-discovery.json'
+  @'
+{
+  "schema": "comparevi-history/changed-vi-discovery@v1",
+  "generatedAtUtc": "2026-03-17T00:00:00Z",
+  "repository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+  "eventName": "pull_request",
+  "targetCatalog": {
+    "schema": "comparevi-history/consumer-targets@v1",
+    "path": "C:/repo/.github/comparevi-history-targets.json"
+  },
+  "pullRequest": {
+    "number": 22,
+    "htmlUrl": "https://github.com/example/repo/pull/22",
+    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "baseRef": "develop",
+    "baseSha": "base-sha",
+    "headRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "headRef": "feature/history",
+    "headSha": "head-sha",
+    "isFork": false,
+    "changedFileCount": 2
+  },
+  "changedViFiles": [
+    {
+      "status": "modified",
+      "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "previousPath": null
+    }
+  ],
+  "matchedTargets": [
+    {
+      "targetId": "vip-post-install",
+      "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"],
+      "matchKind": "current-path",
+      "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "previousPath": null,
+      "changeStatus": "modified"
+    }
+  ],
+  "summary": {
+    "executionStatus": "ready",
+    "executionReason": "matched-targets",
+    "changedViCount": 1,
+    "matchedTargetCount": 1
+  }
+}
+'@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
+
+  $manifestPath = Join-Path $resultsDir 'pr-target-runs-manifest.json'
+  @'
+{
+  "schema": "comparevi-history/pr-target-runs-manifest@v1",
+  "generatedAtUtc": "2026-03-17T00:01:00Z",
+  "summary": {
+    "matchedTargetCount": 1,
+    "executedTargetCount": 1,
+    "failedTargetCount": 0,
+    "skippedTargetCount": 0,
+    "executionStatus": "succeeded",
+    "executionReason": "completed"
+  },
+  "targets": [
+    {
+      "targetId": "vip-post-install",
+      "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "matchKind": "current-path",
+      "finalStatus": "succeeded",
+      "finalReason": "completed",
+      "publicRunPath": "C:/results/targets/001-vip-post-install/history/public/public-run.json",
+      "sharedEvidencePath": "C:/results/targets/001-vip-post-install/history/public/shared-evidence.json",
+      "totalProcessed": 5,
+      "totalDiffs": 2
+    }
+  ]
+}
+'@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+  $outputPath = Join-Path $tempRoot 'pr-run.out'
+  $receiptJson = & $scriptPath `
+    -DiscoveryPath $discoveryPath `
+    -ResultsDir $resultsDir `
+    -TargetRunsManifestPath $manifestPath `
+    -GitHubOutputPath $outputPath
+
+  $receipt = $receiptJson | ConvertFrom-Json -Depth 64
+  if ($receipt.schema -ne 'comparevi-history/pr-run@v1') {
+    throw 'PR run schema mismatch.'
+  }
+  if ($receipt.summary.finalStatus -ne 'succeeded') {
+    throw 'PR run final status mismatch.'
+  }
+  if ($receipt.summary.totalProcessed -ne 5) {
+    throw 'PR run total processed mismatch.'
+  }
+  if (-not (Test-Path -LiteralPath $receipt.outputs.publicCommentPath -PathType Leaf)) {
+    throw 'PR run comment body was not written.'
+  }
+  if (-not (Test-Path -LiteralPath $receipt.outputs.publicStepSummaryPath -PathType Leaf)) {
+    throw 'PR run step summary was not written.'
+  }
+
+  $commentBody = Get-Content -LiteralPath $receipt.outputs.publicCommentPath -Raw
+  if ($commentBody -notmatch 'comparevi-history PR diagnostics') {
+    throw 'PR run comment body did not include the heading.'
+  }
+
+  $outputText = Get-Content -LiteralPath $outputPath -Raw
+  foreach ($requiredKey in @('pr-run-path=', 'public-comment-path=', 'public-step-summary-path=', 'final-status=succeeded', 'final-reason=completed')) {
+    if ($outputText -notmatch [regex]::Escape($requiredKey)) {
+      throw "Expected GitHub output '$requiredKey'."
+    }
+  }
+
+  $blockedDiscoveryPath = Join-Path $resultsDir 'blocked-discovery.json'
+  @'
+{
+  "schema": "comparevi-history/changed-vi-discovery@v1",
+  "generatedAtUtc": "2026-03-17T00:00:00Z",
+  "repository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+  "eventName": "pull_request",
+  "targetCatalog": {
+    "schema": "comparevi-history/consumer-targets@v1",
+    "path": "C:/repo/.github/comparevi-history-targets.json"
+  },
+  "pullRequest": {
+    "number": 23,
+    "htmlUrl": null,
+    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "baseRef": "develop",
+    "baseSha": "base-sha",
+    "headRepository": "some-user/labview-icon-editor-demo",
+    "headRef": "feature/from-fork",
+    "headSha": "head-sha",
+    "isFork": true,
+    "changedFileCount": 1
+  },
+  "changedViFiles": [],
+  "matchedTargets": [],
+  "summary": {
+    "executionStatus": "blocked",
+    "executionReason": "untrusted-cross-repository-pull-request",
+    "changedViCount": 0,
+    "matchedTargetCount": 0
+  }
+}
+'@ | Set-Content -LiteralPath $blockedDiscoveryPath -Encoding utf8
+
+  $blockedReceiptJson = & $scriptPath `
+    -DiscoveryPath $blockedDiscoveryPath `
+    -ResultsDir (Join-Path $tempRoot 'blocked-results')
+  $blockedReceipt = $blockedReceiptJson | ConvertFrom-Json -Depth 64
+  if ($blockedReceipt.summary.finalStatus -ne 'blocked') {
+    throw 'Blocked discovery should remain blocked in PR run receipt.'
+  }
+} finally {
+  Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -3,10 +3,12 @@ $ErrorActionPreference = 'Stop'
 
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $manualTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-workflow-dispatch.yml'
+$pullRequestTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-pull-request-diagnostics.yml'
 $commentTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-comment-gated.yml'
 $manualExplorationTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-manual-vi-exploration.yml'
 $safeTemplatesPath = Join-Path $repoRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
 $publishedValidationWorkflowPath = Join-Path $repoRoot '.github/workflows/published-consumer-validation.yml'
+$pullRequestWorkflowPath = Join-Path $repoRoot '.github/workflows/pull-request-diagnostics.yml'
 $manualExplorationWorkflowPath = Join-Path $repoRoot '.github/workflows/manual-vi-exploration.yml'
 $smokeWorkflowPath = Join-Path $repoRoot '.github/workflows/smoke.yml'
 $releaseWorkflowPath = Join-Path $repoRoot '.github/workflows/release.yml'
@@ -79,10 +81,12 @@ function Assert-MatchCount {
 }
 
 $manualTemplate = Get-Content -LiteralPath $manualTemplatePath -Raw
+$pullRequestTemplate = Get-Content -LiteralPath $pullRequestTemplatePath -Raw
 $commentTemplate = Get-Content -LiteralPath $commentTemplatePath -Raw
 $manualExplorationTemplate = Get-Content -LiteralPath $manualExplorationTemplatePath -Raw
 $safeTemplates = Get-Content -LiteralPath $safeTemplatesPath -Raw
 $publishedValidationWorkflow = Get-Content -LiteralPath $publishedValidationWorkflowPath -Raw
+$pullRequestWorkflow = Get-Content -LiteralPath $pullRequestWorkflowPath -Raw
 $manualExplorationWorkflow = Get-Content -LiteralPath $manualExplorationWorkflowPath -Raw
 $smokeWorkflow = Get-Content -LiteralPath $smokeWorkflowPath -Raw
 $releaseWorkflow = Get-Content -LiteralPath $releaseWorkflowPath -Raw
@@ -100,6 +104,12 @@ Assert-Match -Content $manualTemplate -Pattern 'target_id:\s+\$\{\{ inputs\.targ
 Assert-Match -Content $manualTemplate -Pattern 'reviewer_surface:\s+manual' -Message 'Manual template must declare the manual reviewer surface.'
 Assert-Match -Content $manualTemplate -Pattern 'public-step-summary-path' -Message 'Manual template must consume the action-owned public step summary output.'
 Assert-NotMatch -Content $manualTemplate -Pattern '## comparevi-history manual PR diagnostics' -Message 'Manual template must not rebuild the diagnostics summary inline.'
+
+Assert-Match -Content $pullRequestTemplate -Pattern 'LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/pull-request-diagnostics\.yml@v1' -Message 'Pull request template must call the reusable workflow surface.'
+Assert-Match -Content $pullRequestTemplate -Pattern 'target_spec_path:\s+\.github/comparevi-history-targets\.json' -Message 'Pull request template must consume the checked-in target catalog.'
+Assert-Match -Content $pullRequestTemplate -Pattern 'results_dir:\s+tests/results/pr-diagnostics/history' -Message 'Pull request template must keep the standard PR diagnostics results root.'
+Assert-Match -Content $pullRequestTemplate -Pattern 'platform_ref:\s+v1' -Message 'Pull request template must keep platform_ref aligned with the workflow pin.'
+Assert-NotMatch -Content $pullRequestTemplate -Pattern 'invoke_script_path:' -Message 'Pull request template must not own the hosted invoke adapter path.'
 
 Assert-Match -Content $manualExplorationTemplate -Pattern '(?m)^\s*vi_path:\s*$' -Message 'Manual exploration template must accept vi_path.'
 Assert-Match -Content $manualExplorationTemplate -Pattern '(?m)^\s*default:\s+develop\s*$' -Message 'Manual exploration template must default the consumer ref to develop.'
@@ -142,6 +152,23 @@ Assert-Match -Content $manualExplorationWorkflow -Pattern "Split-Path -Parent '\
 Assert-Match -Content $manualExplorationWorkflow -Pattern "\$\{\{ steps\.results_root\.outputs\['results-root'\] \}\}" -Message 'Manual exploration workflow must route the resolved results root into later stages.'
 Assert-MatchCount -Content $manualExplorationWorkflow -Pattern "'tests/results/ref-compare/history-exploration'" -ExpectedCount 1 -Message 'Manual exploration workflow must only use the relative results directory during catalog generation.'
 Assert-Match -Content $manualExplorationWorkflow -Pattern "steps\.exploration\.outputs\['exploration-status'\] != 'succeeded'" -Message 'Manual exploration workflow must fail closed when exploration output is degraded.'
+
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*workflow_call:\s*$' -Message 'Pull request workflow must be reusable.'
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*target_spec_path:\s*$' -Message 'Pull request workflow must accept target_spec_path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*default:\s+\.github/comparevi-history-targets\.json\s*$' -Message 'Pull request workflow must default to the checked-in target catalog path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*COMPAREVI_NI_LINUX_IMAGE:\s+nationalinstruments/labview:2026q1-linux\s*$' -Message 'Pull request workflow must pin the NI Linux image.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'Write-CompareVIHistoryPullRequestDiscovery\.ps1' -Message 'Pull request workflow must discover changed VI targets.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'Checkout trusted consumer base repository' -Message 'Pull request workflow must keep a trusted base checkout.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'Checkout pull request head repository' -Message 'Pull request workflow must keep a candidate head checkout.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'Invoke-CompareVIHistoryPullRequestDiagnostics\.ps1' -Message 'Pull request workflow must orchestrate matched-target diagnostics.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'Write-CompareVIHistoryPullRequestRun\.ps1' -Message 'Pull request workflow must write the aggregate PR run receipt.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'changed-vi-discovery-path' -Message 'Pull request workflow must expose the discovery receipt path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'pr-run-path' -Message 'Pull request workflow must expose the aggregate PR run path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'public-comment-path' -Message 'Pull request workflow must expose the deterministic PR comment body path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'public-step-summary-path' -Message 'Pull request workflow must expose the deterministic step summary path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern 'comparevi-history-pr-diagnostics-' -Message 'Pull request workflow must upload PR diagnostics artifacts.'
+Assert-Match -Content $pullRequestWorkflow -Pattern "steps\.aggregate\.outputs\['final-status'\] == 'failed'" -Message 'Pull request workflow must fail closed only on failed aggregate diagnostics.'
+Assert-NotMatch -Content $pullRequestWorkflow -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Pull request workflow must not request PR comment publication permissions in this slice.'
 
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Comment-gated template must use ubuntu-latest.'
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Comment-gated template must request pull-requests: write.'
@@ -192,6 +219,8 @@ Assert-Match -Content $actionYaml -Pattern 'mode-summary-json-path' -Message 'Ac
 Assert-Match -Content $readme -Pattern 'comparevi-history/consumer-targets@v1' -Message 'README must document the target catalog contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/public-run@v1' -Message 'README must document the public run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/shared-evidence@v1' -Message 'README must document the shared evidence contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/changed-vi-discovery@v1' -Message 'README must document the changed-VI discovery contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/pr-run@v1' -Message 'README must document the aggregate pull-request run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/revision-catalog@v1' -Message 'README must document the revision catalog contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/exploration-run@v1' -Message 'README must document the exploration run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/evidence-graph@v1' -Message 'README must document the canonical evidence graph contract.'
@@ -219,9 +248,14 @@ Assert-Match -Content $readme -Pattern 'VIP_Post-Install Custom Action\.vi' -Mes
 Assert-Match -Content $readme -Pattern 'VIP_Pre-Install Custom Action\.vi' -Message 'README must identify the first corpus pilot targets.'
 Assert-Match -Content $readme -Pattern 'bounded teaser surface' -Message 'README must document that the step summary remains bounded.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-manual-vi-exploration\.yml' -Message 'README must point to the manual exploration wrapper example.'
+Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pull-request-diagnostics\.yml' -Message 'README must point to the pull request diagnostics wrapper example.'
 Assert-Match -Content $readme -Pattern 'hosted NI Linux container path wired by a repo-local adapter' -Message 'README must document the hosted NI Linux adapter path.'
 Assert-Match -Content $readme -Pattern 'public-comment-path' -Message 'README must document the action-owned public comment output.'
 Assert-Match -Content $readme -Pattern 'shared-evidence\.json' -Message 'README must document the shared evidence output.'
+Assert-Match -Content $readme -Pattern 'changed-vi-discovery\.json' -Message 'README must document the changed-VI discovery output.'
+Assert-Match -Content $readme -Pattern 'pr-run\.json' -Message 'README must document the aggregate PR run output.'
+Assert-Match -Content $readme -Pattern 'same-repo pull requests can auto-run immediately' -Message 'README must document same-repo automatic PR execution.'
+Assert-Match -Content $readme -Pattern 'cross-repository and fork pull requests fail closed' -Message 'README must document blocked cross-repository PR execution.'
 Assert-Match -Content $readme -Pattern 'attributes`, `front-panel`, and `block-diagram' -Message 'README must document explicit public modes only.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/issues/24' -Message 'README must point at the comparevi-history platform-boundary epic.'
 Assert-Match -Content $readme -Pattern 'merge a\s+prep PR first' -Message 'README must explain the protected-main release prep requirement.'

--- a/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
@@ -1,0 +1,411 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$EventName,
+  [Parameter(Mandatory = $true)]
+  [string]$EventPath,
+  [Parameter(Mandatory = $true)]
+  [string]$TargetSpecPath,
+  [Parameter(Mandatory = $true)]
+  [string]$ResultsDir,
+  [string]$Repository,
+  [string]$GitHubToken,
+  [string]$FilesPayloadPath,
+  [string]$GitHubOutputPath,
+  [string]$StepSummaryPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionOutput {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    return
+  }
+
+  $safeValue = if ($null -eq $Value) { '' } else { [string]$Value }
+  "$Key=$safeValue" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Get-NestedValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+    [AllowNull()]
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function ConvertTo-ObjectArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable]) {
+    return @($Value)
+  }
+
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($item in ([System.Collections.IEnumerable]$Value)) {
+    $items.Add($item) | Out-Null
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function Get-OptionalString {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+function Read-JsonFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $raw = Get-Content -LiteralPath $Path -Raw
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw "JSON file was empty: $Path"
+  }
+
+  return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Invoke-PullRequestFilesApi {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositorySlug,
+    [Parameter(Mandatory = $true)]
+    [int]$PullRequestNumber,
+    [string]$Token
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Token)) {
+    throw 'GitHub token is required to discover changed pull-request files.'
+  }
+
+  $headers = @{
+    Accept = 'application/vnd.github+json'
+    Authorization = "Bearer $Token"
+    'User-Agent' = 'comparevi-history-pr-discovery'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+
+  $files = New-Object System.Collections.Generic.List[object]
+  $page = 1
+  while ($true) {
+    $uri = "https://api.github.com/repos/$RepositorySlug/pulls/$PullRequestNumber/files?per_page=100&page=$page"
+    $response = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+    $pageEntries = @(ConvertTo-ObjectArray -Value $response)
+    foreach ($entry in $pageEntries) {
+      $files.Add($entry) | Out-Null
+    }
+
+    if ($pageEntries.Count -lt 100) {
+      break
+    }
+
+    $page += 1
+  }
+
+  return @($files | ForEach-Object { $_ })
+}
+
+if ($EventName -notin @('pull_request', 'pull_request_target')) {
+  throw "comparevi-history pull-request discovery requires pull_request or pull_request_target events. Actual: $EventName"
+}
+
+$basePath = (Get-Location).Path
+$eventPathResolved = Resolve-AbsolutePath -Path $EventPath -BasePath $basePath
+$targetSpecPathResolved = Resolve-AbsolutePath -Path $TargetSpecPath -BasePath $basePath
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
+$receiptPath = Join-Path $resultsDirResolved 'changed-vi-discovery.json'
+
+if (-not (Test-Path -LiteralPath $eventPathResolved -PathType Leaf)) {
+  throw "GitHub event payload not found: $eventPathResolved"
+}
+if (-not (Test-Path -LiteralPath $targetSpecPathResolved -PathType Leaf)) {
+  throw "Target catalog not found: $targetSpecPathResolved"
+}
+
+New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
+
+$eventPayload = Read-JsonFile -Path $eventPathResolved
+$pullRequest = Get-NestedValue -Object $eventPayload -Path @('pull_request')
+if ($null -eq $pullRequest) {
+  throw 'GitHub event payload did not contain pull_request context.'
+}
+
+$targetCatalog = Read-JsonFile -Path $targetSpecPathResolved
+if ([string]$targetCatalog.schema -ne 'comparevi-history/consumer-targets@v1') {
+  throw "Unsupported target catalog schema in '$targetSpecPathResolved': $($targetCatalog.schema)"
+}
+
+$pullRequestNumber = [int](Get-NestedValue -Object $pullRequest -Path @('number') -Default 0)
+$baseRepository = [string](Get-NestedValue -Object $pullRequest -Path @('base', 'repo', 'full_name') -Default '')
+$baseRef = [string](Get-NestedValue -Object $pullRequest -Path @('base', 'ref') -Default '')
+$baseSha = [string](Get-NestedValue -Object $pullRequest -Path @('base', 'sha') -Default '')
+$headRepository = [string](Get-NestedValue -Object $pullRequest -Path @('head', 'repo', 'full_name') -Default '')
+$headRef = [string](Get-NestedValue -Object $pullRequest -Path @('head', 'ref') -Default '')
+$headSha = [string](Get-NestedValue -Object $pullRequest -Path @('head', 'sha') -Default '')
+$pullRequestUrl = Get-OptionalString -Value (Get-NestedValue -Object $pullRequest -Path @('html_url'))
+$reportedChangedFileCount = [int](Get-NestedValue -Object $pullRequest -Path @('changed_files') -Default 0)
+$headFork = [bool](Get-NestedValue -Object $pullRequest -Path @('head', 'repo', 'fork') -Default $false)
+$isFork = $headFork
+if (-not $isFork -and -not [string]::IsNullOrWhiteSpace($headRepository) -and -not [string]::IsNullOrWhiteSpace($baseRepository)) {
+  $isFork = $headRepository -ne $baseRepository
+}
+
+$repositorySlug = if (-not [string]::IsNullOrWhiteSpace($Repository)) {
+  $Repository.Trim()
+} elseif (-not [string]::IsNullOrWhiteSpace($baseRepository)) {
+  $baseRepository
+} else {
+  $env:GITHUB_REPOSITORY
+}
+
+$executionStatus = 'ready'
+$executionReason = 'matched-targets'
+if ($isFork) {
+  $executionStatus = 'blocked'
+  $executionReason = 'untrusted-cross-repository-pull-request'
+} elseif ($reportedChangedFileCount -gt 3000) {
+  $executionStatus = 'blocked'
+  $executionReason = 'pr-files-api-limit-exceeded'
+}
+
+$rawFiles = @()
+if (-not [string]::IsNullOrWhiteSpace($FilesPayloadPath)) {
+  $filesPayloadResolved = Resolve-AbsolutePath -Path $FilesPayloadPath -BasePath $basePath
+  if (-not (Test-Path -LiteralPath $filesPayloadResolved -PathType Leaf)) {
+    throw "Files payload override not found: $filesPayloadResolved"
+  }
+  $rawFiles = @(ConvertTo-ObjectArray -Value (Read-JsonFile -Path $filesPayloadResolved))
+} elseif ($executionStatus -ne 'blocked') {
+  $rawFiles = @(Invoke-PullRequestFilesApi -RepositorySlug $repositorySlug -PullRequestNumber $pullRequestNumber -Token $GitHubToken)
+}
+
+$changedViFiles = New-Object System.Collections.Generic.List[object]
+$seenChanges = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($file in $rawFiles) {
+  $currentPath = Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('filename'))
+  $previousPath = Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('previous_filename'))
+  if ([string]::IsNullOrWhiteSpace($currentPath) -and [string]::IsNullOrWhiteSpace($previousPath)) {
+    continue
+  }
+
+  $isCurrentVi = -not [string]::IsNullOrWhiteSpace($currentPath) -and $currentPath.EndsWith('.vi', [System.StringComparison]::OrdinalIgnoreCase)
+  $isPreviousVi = -not [string]::IsNullOrWhiteSpace($previousPath) -and $previousPath.EndsWith('.vi', [System.StringComparison]::OrdinalIgnoreCase)
+  if (-not $isCurrentVi -and -not $isPreviousVi) {
+    continue
+  }
+
+  $changeStatus = Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('status'))
+  if ([string]::IsNullOrWhiteSpace($changeStatus)) {
+    $changeStatus = 'unknown'
+  }
+
+  $signature = '{0}|{1}|{2}' -f $changeStatus, $currentPath, $previousPath
+  if (-not $seenChanges.Add($signature)) {
+    continue
+  }
+
+  $changedViFiles.Add([pscustomobject][ordered]@{
+      status = $changeStatus
+      currentPath = if ([string]::IsNullOrWhiteSpace($currentPath)) { $previousPath } else { $currentPath }
+      previousPath = $previousPath
+    }) | Out-Null
+}
+
+$matchedTargets = New-Object System.Collections.Generic.List[object]
+foreach ($target in $targetCatalog.targets) {
+  $targetId = Get-OptionalString -Value $target.id
+  $targetPath = Get-OptionalString -Value $target.path
+  if ([string]::IsNullOrWhiteSpace($targetId) -or [string]::IsNullOrWhiteSpace($targetPath)) {
+    continue
+  }
+
+  $match = $null
+  $matchKind = $null
+  foreach ($change in $changedViFiles) {
+    if ([string]$change.currentPath -eq $targetPath) {
+      $match = $change
+      $matchKind = 'current-path'
+      break
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$change.previousPath) -and [string]$change.previousPath -eq $targetPath) {
+      $match = $change
+      $matchKind = 'previous-path'
+      break
+    }
+  }
+
+  if ($null -eq $match) {
+    continue
+  }
+
+  $publicModes = @(
+    @(ConvertTo-ObjectArray -Value $target.publicModes) |
+      ForEach-Object { Get-OptionalString -Value $_ } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $matchedTargets.Add([pscustomobject][ordered]@{
+      targetId = $targetId
+      targetPath = $targetPath
+      publicModes = @($publicModes)
+      matchKind = $matchKind
+      currentPath = [string]$match.currentPath
+      previousPath = if ([string]::IsNullOrWhiteSpace([string]$match.previousPath)) { $null } else { [string]$match.previousPath }
+      changeStatus = [string]$match.status
+    }) | Out-Null
+}
+
+$changedViArray = @(
+  $changedViFiles |
+    Sort-Object { [string]$_.currentPath }, { [string]$_.previousPath }, { [string]$_.status } |
+    ForEach-Object { $_ }
+)
+$matchedTargetArray = @(
+  $matchedTargets |
+    Sort-Object { [string]$_.targetPath }, { [string]$_.targetId } |
+    ForEach-Object { $_ }
+)
+
+if ($executionStatus -eq 'ready') {
+  if ($changedViArray.Count -eq 0) {
+    $executionStatus = 'skipped'
+    $executionReason = 'no-vi-files-changed'
+  } elseif ($matchedTargetArray.Count -eq 0) {
+    $executionStatus = 'skipped'
+    $executionReason = 'no-target-catalog-matches'
+  }
+}
+
+$receipt = [ordered]@{
+  schema = 'comparevi-history/changed-vi-discovery@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  repository = $repositorySlug
+  eventName = $EventName
+  targetCatalog = [ordered]@{
+    schema = 'comparevi-history/consumer-targets@v1'
+    path = $targetSpecPathResolved
+  }
+  pullRequest = [ordered]@{
+    number = $pullRequestNumber
+    htmlUrl = $pullRequestUrl
+    baseRepository = $baseRepository
+    baseRef = $baseRef
+    baseSha = $baseSha
+    headRepository = $headRepository
+    headRef = $headRef
+    headSha = $headSha
+    isFork = $isFork
+    changedFileCount = $reportedChangedFileCount
+  }
+  changedViFiles = @($changedViArray)
+  matchedTargets = @($matchedTargetArray)
+  summary = [ordered]@{
+    executionStatus = $executionStatus
+    executionReason = $executionReason
+    changedViCount = $changedViArray.Count
+    matchedTargetCount = $matchedTargetArray.Count
+  }
+}
+
+$receipt | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $receiptPath -Encoding utf8
+
+Write-ActionOutput -Key 'changed-vi-discovery-path' -Value $receiptPath
+Write-ActionOutput -Key 'changed-vi-count' -Value ([string]$changedViArray.Count)
+Write-ActionOutput -Key 'matched-target-count' -Value ([string]$matchedTargetArray.Count)
+Write-ActionOutput -Key 'execution-status' -Value $executionStatus
+Write-ActionOutput -Key 'execution-reason' -Value $executionReason
+Write-ActionOutput -Key 'matched-targets-json' -Value (($matchedTargetArray | ConvertTo-Json -Depth 20 -Compress))
+Write-ActionOutput -Key 'base-repo' -Value $baseRepository
+Write-ActionOutput -Key 'base-ref' -Value $baseRef
+Write-ActionOutput -Key 'base-sha' -Value $baseSha
+Write-ActionOutput -Key 'head-repo' -Value $headRepository
+Write-ActionOutput -Key 'head-ref' -Value $headRef
+Write-ActionOutput -Key 'head-sha' -Value $headSha
+Write-ActionOutput -Key 'pull-request-number' -Value ([string]$pullRequestNumber)
+Write-ActionOutput -Key 'reviewer-is-fork' -Value ($isFork.ToString().ToLowerInvariant())
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  @(
+    '## comparevi-history pull request discovery'
+    ''
+    ('- Pull request: `#{0}`' -f $pullRequestNumber)
+    ('- Base repository: `{0}`' -f $baseRepository)
+    ('- Head repository: `{0}`' -f $headRepository)
+    ('- Fork PR: `{0}`' -f $isFork.ToString().ToLowerInvariant())
+    ('- Changed VI count: `{0}`' -f $changedViArray.Count)
+    ('- Matched target count: `{0}`' -f $matchedTargetArray.Count)
+    ('- Execution status: `{0}`' -f $executionStatus)
+    ('- Execution reason: `{0}`' -f $executionReason)
+    ('- Discovery receipt: `{0}`' -f $receiptPath)
+  ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+$receipt | ConvertTo-Json -Depth 20

--- a/scripts/Write-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestRun.ps1
@@ -1,0 +1,272 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$DiscoveryPath,
+  [Parameter(Mandatory = $true)]
+  [string]$ResultsDir,
+  [string]$TargetRunsManifestPath,
+  [string]$GitHubOutputPath,
+  [string]$StepSummaryPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionOutput {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    return
+  }
+
+  $safeValue = if ($null -eq $Value) { '' } else { [string]$Value }
+  "$Key=$safeValue" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Read-JsonFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $raw = Get-Content -LiteralPath $Path -Raw
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw "JSON file was empty: $Path"
+  }
+
+  return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Get-OptionalString {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+$basePath = (Get-Location).Path
+$discoveryPathResolved = Resolve-AbsolutePath -Path $DiscoveryPath -BasePath $basePath
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
+$targetRunsManifestPathResolved = if ([string]::IsNullOrWhiteSpace($TargetRunsManifestPath)) { $null } else { Resolve-AbsolutePath -Path $TargetRunsManifestPath -BasePath $basePath }
+$prRunPath = Join-Path $resultsDirResolved 'pr-run.json'
+$publicCommentPath = Join-Path $resultsDirResolved 'pr-comment.md'
+$publicStepSummaryPath = Join-Path $resultsDirResolved 'pr-step-summary.md'
+
+if (-not (Test-Path -LiteralPath $discoveryPathResolved -PathType Leaf)) {
+  throw "Discovery receipt not found: $discoveryPathResolved"
+}
+
+New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
+
+$discovery = Read-JsonFile -Path $discoveryPathResolved
+if ([string]$discovery.schema -ne 'comparevi-history/changed-vi-discovery@v1') {
+  throw "Unsupported discovery schema in '$discoveryPathResolved': $($discovery.schema)"
+}
+
+$targetManifest = $null
+if ($null -ne $targetRunsManifestPathResolved -and (Test-Path -LiteralPath $targetRunsManifestPathResolved -PathType Leaf)) {
+  $targetManifest = Read-JsonFile -Path $targetRunsManifestPathResolved
+}
+
+$discoveryStatus = [string]$discovery.summary.executionStatus
+$discoveryReason = [string]$discovery.summary.executionReason
+$changedViCount = [int]$discovery.summary.changedViCount
+$matchedTargetCount = [int]$discovery.summary.matchedTargetCount
+
+$targets = @()
+$executedTargetCount = 0
+$failedTargetCount = 0
+$totalProcessed = 0
+$totalDiffs = 0
+
+if ($null -ne $targetManifest) {
+  $targets = @($targetManifest.targets | ForEach-Object { $_ })
+  $executedTargetCount = [int]$targetManifest.summary.executedTargetCount
+  $failedTargetCount = [int]$targetManifest.summary.failedTargetCount
+  foreach ($target in @($targets)) {
+    if ($null -ne $target.totalProcessed) {
+      $totalProcessed += [int]$target.totalProcessed
+    }
+    if ($null -ne $target.totalDiffs) {
+      $totalDiffs += [int]$target.totalDiffs
+    }
+  }
+}
+
+$finalStatus = 'unknown'
+$finalReason = 'unknown'
+if ($discoveryStatus -ne 'ready') {
+  $finalStatus = $discoveryStatus
+  $finalReason = $discoveryReason
+} elseif ($null -eq $targetManifest) {
+  $finalStatus = 'failed'
+  $finalReason = 'missing-target-runs-manifest'
+} elseif ($failedTargetCount -gt 0) {
+  $finalStatus = 'failed'
+  $finalReason = 'one-or-more-targets-failed'
+} elseif ($executedTargetCount -eq 0) {
+  $finalStatus = 'skipped'
+  $finalReason = 'no-targets-executed'
+} else {
+  $finalStatus = 'succeeded'
+  $finalReason = 'completed'
+}
+
+$commentLines = New-Object System.Collections.Generic.List[string]
+$commentLines.Add('## comparevi-history PR diagnostics') | Out-Null
+$commentLines.Add('') | Out-Null
+$commentLines.Add(('- Final status: `{0}`' -f $finalStatus)) | Out-Null
+$commentLines.Add(('- Final reason: `{0}`' -f $finalReason)) | Out-Null
+$commentLines.Add(('- Changed VIs: `{0}`' -f $changedViCount)) | Out-Null
+$commentLines.Add(('- Matched catalog targets: `{0}`' -f $matchedTargetCount)) | Out-Null
+$commentLines.Add(('- Executed targets: `{0}`' -f $executedTargetCount)) | Out-Null
+$commentLines.Add(('- Failed targets: `{0}`' -f $failedTargetCount)) | Out-Null
+$commentLines.Add(('- Total processed pairs: `{0}`' -f $totalProcessed)) | Out-Null
+$commentLines.Add(('- Total diffs: `{0}`' -f $totalDiffs)) | Out-Null
+$commentLines.Add('') | Out-Null
+
+if (@($discovery.changedViFiles).Count -gt 0) {
+  $commentLines.Add('### Changed VI files') | Out-Null
+  foreach ($change in @($discovery.changedViFiles)) {
+    $commentLines.Add(('- `{0}` ({1})' -f [string]$change.currentPath, [string]$change.status)) | Out-Null
+  }
+  $commentLines.Add('') | Out-Null
+}
+
+if (@($targets).Count -gt 0) {
+  $commentLines.Add('### Target results') | Out-Null
+  $commentLines.Add('') | Out-Null
+  $commentLines.Add('| Target | Status | Reason |') | Out-Null
+  $commentLines.Add('| --- | --- | --- |') | Out-Null
+  foreach ($target in @($targets)) {
+    $commentLines.Add(('| `{0}` | `{1}` | `{2}` |' -f [string]$target.targetPath, [string]$target.finalStatus, [string]$target.finalReason)) | Out-Null
+  }
+  $commentLines.Add('') | Out-Null
+} else {
+  $commentLines.Add('### Target results') | Out-Null
+  $commentLines.Add('No per-target runs were produced for this pull request.') | Out-Null
+  $commentLines.Add('') | Out-Null
+}
+
+$commentLines.Add('Artifacts in this run contain the discovery receipt, per-target public run receipts, shared evidence receipts, and reviewer-facing markdown/html surfaces.') | Out-Null
+$commentBody = $commentLines -join "`n"
+$commentBody | Set-Content -LiteralPath $publicCommentPath -Encoding utf8
+
+$stepSummaryLines = New-Object System.Collections.Generic.List[string]
+$stepSummaryLines.Add('## comparevi-history pull request run') | Out-Null
+$stepSummaryLines.Add('') | Out-Null
+$stepSummaryLines.Add(('- Final status: `{0}`' -f $finalStatus)) | Out-Null
+$stepSummaryLines.Add(('- Final reason: `{0}`' -f $finalReason)) | Out-Null
+$stepSummaryLines.Add(('- Discovery receipt: `{0}`' -f $discoveryPathResolved)) | Out-Null
+$stepSummaryLines.Add(('- Aggregate receipt: `{0}`' -f $prRunPath)) | Out-Null
+$stepSummaryLines.Add(('- Public comment body: `{0}`' -f $publicCommentPath)) | Out-Null
+$stepSummaryLines.Add(('- Public step summary: `{0}`' -f $publicStepSummaryPath)) | Out-Null
+if ($null -ne $targetManifest) {
+  $stepSummaryLines.Add(('- Target runs manifest: `{0}`' -f $targetRunsManifestPathResolved)) | Out-Null
+}
+$stepSummaryLines.Add('') | Out-Null
+$stepSummaryLines.Add($commentBody) | Out-Null
+$stepSummaryContent = $stepSummaryLines -join "`n"
+$stepSummaryContent | Set-Content -LiteralPath $publicStepSummaryPath -Encoding utf8
+
+$receiptTargets = New-Object System.Collections.Generic.List[object]
+foreach ($target in @($targets)) {
+  $receiptTargets.Add([ordered]@{
+      targetId = [string]$target.targetId
+      targetPath = [string]$target.targetPath
+      matchKind = Get-OptionalString -Value $target.matchKind
+      finalStatus = [string]$target.finalStatus
+      finalReason = [string]$target.finalReason
+      publicRunPath = Get-OptionalString -Value $target.publicRunPath
+      sharedEvidencePath = Get-OptionalString -Value $target.sharedEvidencePath
+      totalProcessed = if ($null -eq $target.totalProcessed) { $null } else { [int]$target.totalProcessed }
+      totalDiffs = if ($null -eq $target.totalDiffs) { $null } else { [int]$target.totalDiffs }
+    }) | Out-Null
+}
+
+$receipt = [ordered]@{
+  schema = 'comparevi-history/pr-run@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  pullRequest = [ordered]@{
+    number = [int]$discovery.pullRequest.number
+    htmlUrl = Get-OptionalString -Value $discovery.pullRequest.htmlUrl
+    baseRepository = [string]$discovery.pullRequest.baseRepository
+    baseRef = [string]$discovery.pullRequest.baseRef
+    baseSha = [string]$discovery.pullRequest.baseSha
+    headRepository = [string]$discovery.pullRequest.headRepository
+    headRef = [string]$discovery.pullRequest.headRef
+    headSha = [string]$discovery.pullRequest.headSha
+    isFork = [bool]$discovery.pullRequest.isFork
+  }
+  discovery = [ordered]@{
+    schema = 'comparevi-history/changed-vi-discovery@v1'
+    path = $discoveryPathResolved
+    status = $discoveryStatus
+    reason = $discoveryReason
+    changedViCount = $changedViCount
+    matchedTargetCount = $matchedTargetCount
+  }
+  outputs = [ordered]@{
+    resultsDir = $resultsDirResolved
+    prRunPath = $prRunPath
+    publicCommentPath = $publicCommentPath
+    publicStepSummaryPath = $publicStepSummaryPath
+    targetRunsManifestPath = if ($null -eq $targetManifest) { $null } else { $targetRunsManifestPathResolved }
+  }
+  summary = [ordered]@{
+    finalStatus = $finalStatus
+    finalReason = $finalReason
+    changedViCount = $changedViCount
+    matchedTargetCount = $matchedTargetCount
+    executedTargetCount = $executedTargetCount
+    failedTargetCount = $failedTargetCount
+    totalProcessed = $totalProcessed
+    totalDiffs = $totalDiffs
+  }
+  targets = @($receiptTargets | ForEach-Object { $_ })
+}
+
+$receipt | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $prRunPath -Encoding utf8
+
+Write-ActionOutput -Key 'pr-run-path' -Value $prRunPath
+Write-ActionOutput -Key 'public-comment-path' -Value $publicCommentPath
+Write-ActionOutput -Key 'public-step-summary-path' -Value $publicStepSummaryPath
+Write-ActionOutput -Key 'results-dir' -Value $resultsDirResolved
+Write-ActionOutput -Key 'final-status' -Value $finalStatus
+Write-ActionOutput -Key 'final-reason' -Value $finalReason
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  $stepSummaryContent | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+$receipt | ConvertTo-Json -Depth 32


### PR DESCRIPTION
## Summary
- add the reusable `pull-request-diagnostics.yml` workflow for changed-VI auto-discovery on trusted same-repo PRs
- add additive `changed-vi-discovery@v1` and `pr-run@v1` receipts plus per-target orchestration scripts and focused tests
- document and publish the thin consumer wrapper while keeping fork/cross-repo PRs blocked and comment publication out of scope for this slice

## Testing
- `pwsh -NoLogo -NoProfile -Command "& '.\scripts\Test-CompareVIHistoryPullRequestDiscovery.ps1'; & '.\scripts\Test-CompareVIHistoryPullRequestDiagnostics.ps1'; & '.\scripts\Test-CompareVIHistoryPullRequestRun.ps1'; & '.\scripts\Test-CompareVIHistoryTemplateContracts.ps1'"`
- `git diff --cached --check`
