### PR TITLE
#96 Define pr-policy contract for PR diagnostics

### DIFF
--- a/.github/workflows/pull-request-diagnostics.yml
+++ b/.github/workflows/pull-request-diagnostics.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: .github/comparevi-history-targets.json
         type: string
+      pr_policy_path:
+        description: Optional trusted PR policy path resolved from the pull request base checkout.
+        required: false
+        default: ''
+        type: string
       results_dir:
         description: Workflow-owned results root for aggregate PR diagnostics receipts and per-target runs.
         required: false
@@ -135,6 +140,7 @@ jobs:
             -EventPath $env:GITHUB_EVENT_PATH `
             -Repository '${{ steps.defaults.outputs.consumer_repository }}' `
             -TargetSpecPath (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.target_spec_path }}') `
+            -PrPolicyPath $(if ([string]::IsNullOrWhiteSpace('${{ inputs.pr_policy_path }}')) { '' } else { (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.pr_policy_path }}') }) `
             -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -GitHubToken $env:GITHUB_TOKEN `
             -GitHubOutputPath $env:GITHUB_OUTPUT `

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Legacy direct invocation remains available for maintainers:
 
 ## Public platform boundary
 
-- Consumer repositories define what to inspect through a checked-in target catalog.
+- Consumer repositories define what to inspect and what automatic PR behavior is allowed through checked-in target catalogs and PR policy files.
 - `comparevi-history` defines how the public history surface resolves requests, runs the backend, and renders reviewer
   artifacts.
 - `compare-vi-cli-action` defines how the backend tooling executes and keeps `comparevi-tools/history-facade@v1`
@@ -203,16 +203,18 @@ wrapper should keep `platform_ref` aligned with the same release ref used in the
 Trusted consumer repositories can expose automatic PR diagnostics for changed VIs through the reusable workflow
 [`./.github/workflows/pull-request-diagnostics.yml`](.github/workflows/pull-request-diagnostics.yml) plus a thin
 consumer wrapper such as
-[`docs/examples/comparevi-history-pull-request-diagnostics.yml`](docs/examples/comparevi-history-pull-request-diagnostics.yml).
+[`docs/examples/comparevi-history-pull-request-diagnostics.yml`](docs/examples/comparevi-history-pull-request-diagnostics.yml)
+and a checked-in PR policy such as
+[`docs/examples/comparevi-history-pr-policy.json`](docs/examples/comparevi-history-pr-policy.json).
 
 The current first slice stays intentionally narrow:
 
 - the platform discovers changed `.vi` files from the live pull request context and writes `changed-vi-discovery.json`
-- the trusted target catalog stays on the pull request base checkout, not the candidate head checkout
+- the trusted target catalog and trusted PR policy stay on the pull request base checkout, not the candidate head checkout
 - the trusted consumer-local hosted NI Linux adapter stays on the pull request base checkout, not the candidate head
   checkout
 - the candidate head checkout supplies the repository root and file content for execution
-- only catalog-declared targets whose `path` matches a changed `.vi` path are executed
+- only PR-policy-eligible catalog targets whose `path` matches a changed `.vi` path are executed
 - same-repo pull requests can auto-run immediately
 - cross-repository and fork pull requests fail closed by producing a blocked discovery receipt instead of executing the
   backend
@@ -224,7 +226,8 @@ The current first slice stays intentionally narrow:
 
 This keeps consumer repositories thin while the automatic PR surface stabilizes:
 
-- target allowlists still live in `.github/comparevi-history-targets.json`
+- target ids still live in `.github/comparevi-history-targets.json`
+- PR path filters, allowlists, mode narrowing, branch-budget defaults, and reviewer-surface toggles live in `.github/comparevi-history-pr-policy.json`
 - execution remains bundle-backed and platform-owned
 - reviewer-facing consumers get stable receipt and markdown paths before comment publication policy is widened
 
@@ -327,6 +330,19 @@ Consumer repos should copy that pattern into `.github/comparevi-history-targets.
 - optional reviewer-surface hints
 
 Do not copy backend renderers or repo-local history execution logic into consumer repositories.
+
+## Pull request policy
+
+Automatic PR diagnostics consumers should also check in a PR policy using `comparevi-history/pr-policy@v1`. The example source of truth in this repository is [`docs/examples/comparevi-history-pr-policy.json`](docs/examples/comparevi-history-pr-policy.json). Consumer repos should copy that pattern into `.github/comparevi-history-pr-policy.json` and keep automatic PR policy there:
+
+- include/exclude path globs for changed VI discovery
+- allowed target ids for automatic PR execution
+- maximum changed-VI count per run
+- unmatched changed-VI fail-closed behavior
+- public mode narrowing for reviewer surfaces
+- branch-budget defaults and no-diff artifact policy
+- reviewer comment and step-summary emission toggles
+- trust defaults for fork PR blocking
 
 ## Trust boundaries
 

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -14,6 +14,8 @@ of repo-local inline comment renderers.
   [comparevi-history-comment-gated.yml](examples/comparevi-history-comment-gated.yml)
 - Example consumer target catalog source:
   [comparevi-history-consumer-targets.json](examples/comparevi-history-consumer-targets.json)
+- Example consumer PR policy source:
+  [comparevi-history-pr-policy.json](examples/comparevi-history-pr-policy.json)
 
 ## Public Mode Contract
 
@@ -36,6 +38,7 @@ Aggregate aliases such as `default`, `full`, and `all` are not part of the publi
 Consumer repositories should contain only:
 
 - `.github/comparevi-history-targets.json` (checked-in target catalog)
+- `.github/comparevi-history-pr-policy.json` (checked-in automatic PR policy)
 - workflow trigger wiring and permissions policy
 - small repo-local docs explaining what target ids exist and when the history surface should run
 
@@ -57,8 +60,7 @@ Consumer repositories should not contain:
   to trigger diagnostics from a trusted maintainer comment.
 - Run both patterns on trusted maintainer-controlled workflows that pre-pull the hosted NI Linux image serially and use
   a repo-local adapter such as `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`.
-- Keep the target catalog checked in under `.github/comparevi-history-targets.json` so the consumer repo owns target
-  policy without owning execution logic.
+- Keep the target catalog checked in under `.github/comparevi-history-targets.json` and the automatic PR policy checked in under `.github/comparevi-history-pr-policy.json` so the consumer repo owns inspection policy without owning execution logic.
 
 ## Fork Adoption and Upstream Alignment
 
@@ -107,6 +109,7 @@ Consumer repositories should not contain:
   `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1` so consumers use the hosted NI Linux contract instead of a
   repo-specific self-hosted Windows assumption.
 - Both templates expect the consumer repo to define target ids in `.github/comparevi-history-targets.json`.
+- The automatic PR discovery template also expects `.github/comparevi-history-pr-policy.json` when a repo wants changed-VI filters, target allowlists, branch-budget defaults, or reviewer-surface toggles under source control.
 - The action owns reviewer-facing rendering. Consumers should publish PR comments from `public-comment-path` and append
   `public-step-summary-path` instead of rebuilding markdown inline.
 - The comment-gated template writes the action-owned step summary first, then attempts to publish the PR comment. If the
@@ -119,7 +122,7 @@ Consumer repositories should not contain:
 
 ## Recommended Adoption
 
-1. Check in `.github/comparevi-history-targets.json` first.
+1. Check in `.github/comparevi-history-targets.json` and `.github/comparevi-history-pr-policy.json` first.
 2. Start with the maintainer-dispatched template when your project is new to VI History diagnostics.
 3. Add the automatic PR discovery template when you want same-repo pull requests to run automatically from the checked-
    in target catalog.

--- a/docs/examples/comparevi-history-pr-policy.json
+++ b/docs/examples/comparevi-history-pr-policy.json
@@ -1,0 +1,38 @@
+{
+  "schema": "comparevi-history/pr-policy@v1",
+  "discovery": {
+    "includePaths": [
+      "Tooling/deployment/**/*.vi"
+    ],
+    "excludePaths": [
+      "Tooling/deployment/archive/**/*.vi"
+    ],
+    "allowedTargetIds": [
+      "vip-post-install",
+      "vip-pre-install"
+    ],
+    "maxChangedViCount": 4,
+    "unmatchedChangedViBehavior": "block"
+  },
+  "execution": {
+    "publicModes": [
+      "attributes",
+      "front-panel",
+      "block-diagram"
+    ],
+    "history": {
+      "branchBudget": {
+        "sourceBranchRef": "develop",
+        "maxCommitCount": 50
+      },
+      "keepArtifactsOnNoDiff": true
+    }
+  },
+  "reviewerSurface": {
+    "emitCommentBody": true,
+    "emitStepSummary": true
+  },
+  "trust": {
+    "forkBehavior": "block"
+  }
+}

--- a/docs/examples/comparevi-history-pull-request-diagnostics.yml
+++ b/docs/examples/comparevi-history-pull-request-diagnostics.yml
@@ -16,6 +16,7 @@ jobs:
     uses: LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics.yml@v1
     with:
       target_spec_path: .github/comparevi-history-targets.json
+      pr_policy_path: .github/comparevi-history-pr-policy.json
       results_dir: tests/results/pr-diagnostics/history
       max_pairs: '5'
       max_signal_pairs: '5'

--- a/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
+++ b/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
@@ -10,8 +10,10 @@
     "repository",
     "eventName",
     "targetCatalog",
+    "prPolicy",
     "pullRequest",
     "changedViFiles",
+    "excludedViFiles",
     "matchedTargets",
     "summary"
   ],
@@ -29,12 +31,18 @@
     },
     "eventName": {
       "type": "string",
-      "enum": ["pull_request", "pull_request_target"]
+      "enum": [
+        "pull_request",
+        "pull_request_target"
+      ]
     },
     "targetCatalog": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["schema", "path"],
+      "required": [
+        "schema",
+        "path"
+      ],
       "properties": {
         "schema": {
           "const": "comparevi-history/consumer-targets@v1"
@@ -42,6 +50,167 @@
         "path": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "prPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "applied",
+        "discovery",
+        "execution",
+        "reviewerSurface",
+        "trust"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/pr-policy@v1"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "applied": {
+          "type": "boolean"
+        },
+        "discovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "includePaths",
+            "excludePaths",
+            "allowedTargetIds",
+            "unmatchedChangedViBehavior"
+          ],
+          "properties": {
+            "includePaths": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "excludePaths": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "allowedTargetIds": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "maxChangedViCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 1
+            },
+            "unmatchedChangedViBehavior": {
+              "type": "string",
+              "enum": [
+                "ignore",
+                "block"
+              ]
+            }
+          }
+        },
+        "execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "publicModes",
+            "history"
+          ],
+          "properties": {
+            "publicModes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "attributes",
+                  "front-panel",
+                  "block-diagram"
+                ]
+              }
+            },
+            "history": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "branchBudget",
+                "keepArtifactsOnNoDiff"
+              ],
+              "properties": {
+                "branchBudget": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "sourceBranchRef",
+                    "maxCommitCount"
+                  ],
+                  "properties": {
+                    "sourceBranchRef": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "maxCommitCount": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
+                      "minimum": 1
+                    }
+                  }
+                },
+                "keepArtifactsOnNoDiff": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "reviewerSurface": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "emitCommentBody",
+            "emitStepSummary"
+          ],
+          "properties": {
+            "emitCommentBody": {
+              "type": "boolean"
+            },
+            "emitStepSummary": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trust": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "forkBehavior"
+          ],
+          "properties": {
+            "forkBehavior": {
+              "type": "string",
+              "enum": [
+                "block"
+              ]
+            }
+          }
         }
       }
     },
@@ -65,7 +234,10 @@
           "minimum": 1
         },
         "htmlUrl": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "baseRepository": {
           "type": "string",
@@ -105,7 +277,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["status", "currentPath"],
+        "required": [
+          "status",
+          "currentPath"
+        ],
         "properties": {
           "status": {
             "type": "string",
@@ -116,7 +291,48 @@
             "minLength": 1
           },
           "previousPath": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "excludedViFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "currentPath",
+          "exclusionReason"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "minLength": 1
+          },
+          "currentPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "previousPath": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exclusionReason": {
+            "type": "string",
+            "enum": [
+              "not-included-by-pr-policy",
+              "excluded-by-pr-policy",
+              "no-target-catalog-match",
+              "target-id-not-allowed",
+              "no-policy-allowed-public-modes"
+            ]
           }
         }
       }
@@ -126,7 +342,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["targetId", "targetPath", "matchKind", "changeStatus"],
+        "required": [
+          "targetId",
+          "targetPath",
+          "publicModes",
+          "requestedModes",
+          "requestedModeSource",
+          "history",
+          "keepArtifactsOnNoDiff",
+          "matchKind",
+          "changeStatus"
+        ],
         "properties": {
           "targetId": {
             "type": "string",
@@ -140,19 +366,92 @@
             "type": "array",
             "items": {
               "type": "string",
-              "minLength": 1
+              "enum": [
+                "attributes",
+                "front-panel",
+                "block-diagram"
+              ]
             }
+          },
+          "requestedModes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "attributes",
+                "front-panel",
+                "block-diagram"
+              ]
+            }
+          },
+          "requestedModeSource": {
+            "type": "string",
+            "enum": [
+              "target-public-modes",
+              "pr-policy"
+            ]
+          },
+          "history": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "branchBudget"
+            ],
+            "properties": {
+              "branchBudget": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "sourceBranchRef",
+                  "maxCommitCount",
+                  "source"
+                ],
+                "properties": {
+                  "sourceBranchRef": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "maxCommitCount": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "minimum": 1
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "none",
+                      "target-catalog",
+                      "pr-policy"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "keepArtifactsOnNoDiff": {
+            "type": "boolean"
           },
           "matchKind": {
             "type": "string",
-            "enum": ["current-path", "previous-path"]
+            "enum": [
+              "current-path",
+              "previous-path"
+            ]
           },
           "currentPath": {
             "type": "string",
             "minLength": 1
           },
           "previousPath": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "changeStatus": {
             "type": "string",
@@ -164,17 +463,50 @@
     "summary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["executionStatus", "executionReason", "changedViCount", "matchedTargetCount"],
+      "required": [
+        "executionStatus",
+        "executionReason",
+        "changedViCount",
+        "eligibleChangedViCount",
+        "excludedViCount",
+        "unmatchedViCount",
+        "matchedTargetCount"
+      ],
       "properties": {
         "executionStatus": {
           "type": "string",
-          "enum": ["ready", "skipped", "blocked"]
+          "enum": [
+            "ready",
+            "skipped",
+            "blocked"
+          ]
         },
         "executionReason": {
           "type": "string",
-          "minLength": 1
+          "enum": [
+            "matched-targets",
+            "untrusted-cross-repository-pull-request",
+            "pr-files-api-limit-exceeded",
+            "max-changed-vi-count-exceeded",
+            "unmatched-changed-vi-detected",
+            "no-vi-files-changed",
+            "no-policy-eligible-vi-files",
+            "no-target-catalog-matches"
+          ]
         },
         "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eligibleChangedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excludedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unmatchedViCount": {
           "type": "integer",
           "minimum": 0
         },

--- a/docs/schemas/comparevi-history-pr-policy-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-policy-v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-pr-policy-v1.schema.json",
+  "title": "comparevi-history pull request policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/pr-policy@v1"
+    },
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "includePaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "excludePaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "allowedTargetIds": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "maxChangedViCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "unmatchedChangedViBehavior": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "block"
+          ]
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "publicModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "attributes",
+              "front-panel",
+              "block-diagram"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "history": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "branchBudget": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "sourceBranchRef": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "maxCommitCount": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "keepArtifactsOnNoDiff": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "reviewerSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "emitCommentBody": {
+          "type": "boolean"
+        },
+        "emitStepSummary": {
+          "type": "boolean"
+        }
+      }
+    },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "forkBehavior": {
+          "type": "string",
+          "enum": [
+            "block"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/comparevi-history-pr-run-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-run-v1.schema.json
@@ -8,9 +8,11 @@
     "schema",
     "generatedAtUtc",
     "pullRequest",
+    "prPolicy",
     "discovery",
     "outputs",
     "summary",
+    "excludedViFiles",
     "targets"
   ],
   "properties": {
@@ -40,7 +42,10 @@
           "minimum": 1
         },
         "htmlUrl": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "baseRepository": {
           "type": "string",
@@ -71,10 +76,71 @@
         }
       }
     },
+    "prPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "applied",
+        "discovery",
+        "execution",
+        "reviewerSurface",
+        "trust"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/pr-policy@v1"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "applied": {
+          "type": "boolean"
+        },
+        "discovery": {
+          "type": "object"
+        },
+        "execution": {
+          "type": "object"
+        },
+        "reviewerSurface": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "emitCommentBody",
+            "emitStepSummary"
+          ],
+          "properties": {
+            "emitCommentBody": {
+              "type": "boolean"
+            },
+            "emitStepSummary": {
+              "type": "boolean"
+            }
+          }
+        },
+        "trust": {
+          "type": "object"
+        }
+      }
+    },
     "discovery": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["schema", "path", "status", "reason", "changedViCount", "matchedTargetCount"],
+      "required": [
+        "schema",
+        "path",
+        "status",
+        "reason",
+        "changedViCount",
+        "eligibleChangedViCount",
+        "excludedViCount",
+        "unmatchedViCount",
+        "matchedTargetCount"
+      ],
       "properties": {
         "schema": {
           "const": "comparevi-history/changed-vi-discovery@v1"
@@ -85,13 +151,29 @@
         },
         "status": {
           "type": "string",
-          "enum": ["ready", "skipped", "blocked"]
+          "enum": [
+            "ready",
+            "skipped",
+            "blocked"
+          ]
         },
         "reason": {
           "type": "string",
           "minLength": 1
         },
         "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eligibleChangedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excludedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unmatchedViCount": {
           "type": "integer",
           "minimum": 0
         },
@@ -104,7 +186,12 @@
     "outputs": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["resultsDir", "prRunPath", "publicCommentPath", "publicStepSummaryPath"],
+      "required": [
+        "resultsDir",
+        "prRunPath",
+        "publicCommentPath",
+        "publicStepSummaryPath"
+      ],
       "properties": {
         "resultsDir": {
           "type": "string",
@@ -115,15 +202,22 @@
           "minLength": 1
         },
         "publicCommentPath": {
-          "type": "string",
-          "minLength": 1
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "publicStepSummaryPath": {
-          "type": "string",
-          "minLength": 1
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "targetRunsManifestPath": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
@@ -134,6 +228,9 @@
         "finalStatus",
         "finalReason",
         "changedViCount",
+        "eligibleChangedViCount",
+        "excludedViCount",
+        "unmatchedViCount",
         "matchedTargetCount",
         "executedTargetCount",
         "failedTargetCount",
@@ -143,13 +240,30 @@
       "properties": {
         "finalStatus": {
           "type": "string",
-          "enum": ["succeeded", "skipped", "blocked", "failed"]
+          "enum": [
+            "succeeded",
+            "skipped",
+            "blocked",
+            "failed"
+          ]
         },
         "finalReason": {
           "type": "string",
           "minLength": 1
         },
         "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eligibleChangedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excludedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unmatchedViCount": {
           "type": "integer",
           "minimum": 0
         },
@@ -175,12 +289,51 @@
         }
       }
     },
+    "excludedViFiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "currentPath",
+          "exclusionReason"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "minLength": 1
+          },
+          "currentPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "previousPath": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exclusionReason": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "targets": {
       "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["targetId", "targetPath", "finalStatus", "finalReason"],
+        "required": [
+          "targetId",
+          "targetPath",
+          "requestedModes",
+          "keepArtifactsOnNoDiff",
+          "finalStatus",
+          "finalReason"
+        ],
         "properties": {
           "targetId": {
             "type": "string",
@@ -190,29 +343,82 @@
             "type": "string",
             "minLength": 1
           },
+          "requestedModes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "attributes",
+                "front-panel",
+                "block-diagram"
+              ]
+            }
+          },
+          "requestedModeSource": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceBranchRef": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "maxBranchCommits": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1
+          },
+          "keepArtifactsOnNoDiff": {
+            "type": "boolean"
+          },
           "matchKind": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "finalStatus": {
             "type": "string",
-            "enum": ["succeeded", "failed", "cancelled", "unknown"]
+            "enum": [
+              "succeeded",
+              "failed",
+              "cancelled",
+              "unknown"
+            ]
           },
           "finalReason": {
             "type": "string",
             "minLength": 1
           },
           "publicRunPath": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "sharedEvidencePath": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "totalProcessed": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           },
           "totalDiffs": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0
           }
         }

--- a/scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1
+++ b/scripts/Invoke-CompareVIHistoryPullRequestDiagnostics.ps1
@@ -121,6 +121,99 @@ function Get-OptionalString {
   return $stringValue.Trim()
 }
 
+function Get-OptionalInt {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return [int]$stringValue
+}
+
+function Get-NestedValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+    [AllowNull()]
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function ConvertTo-ObjectArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable]) {
+    return @($Value)
+  }
+
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($item in ([System.Collections.IEnumerable]$Value)) {
+    $items.Add($item) | Out-Null
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function ConvertTo-StringArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  $items = New-Object System.Collections.Generic.List[string]
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($entry in @(ConvertTo-ObjectArray -Value $Value)) {
+    $normalized = Get-OptionalString -Value $entry
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+      continue
+    }
+
+    if ($seen.Add($normalized)) {
+      $items.Add($normalized) | Out-Null
+    }
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
 function Resolve-DefaultInvokeScriptPath {
   param(
     [Parameter(Mandatory = $true)]
@@ -275,6 +368,14 @@ foreach ($matchedTarget in @($discovery.matchedTargets)) {
   $requestError = $null
   $runError = $null
   $publicRunError = $null
+  $requestedModes = @(ConvertTo-StringArray -Value (Get-NestedValue -Object $matchedTarget -Path @('requestedModes')))
+  $requestedModeList = if ($requestedModes.Count -eq 0) { $null } else { $requestedModes -join ',' }
+  $effectiveSourceBranchRef = Get-OptionalString -Value (Get-NestedValue -Object $matchedTarget -Path @('history', 'branchBudget', 'sourceBranchRef'))
+  if ([string]::IsNullOrWhiteSpace($effectiveSourceBranchRef)) {
+    $effectiveSourceBranchRef = $HeadRef
+  }
+  $effectiveMaxBranchCommits = Get-OptionalInt -Value (Get-NestedValue -Object $matchedTarget -Path @('history', 'branchBudget', 'maxCommitCount'))
+  $keepArtifactsOnNoDiff = [bool](Get-NestedValue -Object $matchedTarget -Path @('keepArtifactsOnNoDiff') -Default $false)
 
   try {
     $requestArgs = @{
@@ -289,12 +390,23 @@ foreach ($matchedTarget in @($discovery.matchedTargets)) {
       Detailed = $true
       ConsumerRepository = $HeadRepository
       ConsumerRef = $HeadSha
-      SourceBranchRef = $HeadRef
       ReviewerSurface = 'manual'
       ReviewerPullRequestNumber = $PullRequestNumber
       ReviewerIsFork = $ReviewerIsFork
       ContainerImage = $ContainerImage
       GitHubOutputPath = $requestOutputPath
+    }
+    if (-not [string]::IsNullOrWhiteSpace($requestedModeList)) {
+      $requestArgs.Mode = $requestedModeList
+    }
+    if (-not [string]::IsNullOrWhiteSpace($effectiveSourceBranchRef)) {
+      $requestArgs.SourceBranchRef = $effectiveSourceBranchRef
+    }
+    if ($null -ne $effectiveMaxBranchCommits) {
+      $requestArgs.MaxBranchCommits = [int]$effectiveMaxBranchCommits
+    }
+    if ($keepArtifactsOnNoDiff) {
+      $requestArgs.KeepArtifactsOnNoDiff = $true
     }
     if ($null -ne $MaxPairs) {
       $requestArgs.MaxPairs = [int]$MaxPairs
@@ -437,6 +549,12 @@ foreach ($matchedTarget in @($discovery.matchedTargets)) {
   $targetRuns.Add([ordered]@{
       targetId = $targetId
       targetPath = $targetPath
+      publicModes = @(ConvertTo-StringArray -Value (Get-NestedValue -Object $matchedTarget -Path @('publicModes')))
+      requestedModes = @($requestedModes)
+      requestedModeSource = Get-OptionalString -Value (Get-NestedValue -Object $matchedTarget -Path @('requestedModeSource'))
+      sourceBranchRef = if ([string]::IsNullOrWhiteSpace($effectiveSourceBranchRef)) { $null } else { $effectiveSourceBranchRef }
+      maxBranchCommits = if ($null -eq $effectiveMaxBranchCommits) { $null } else { [int]$effectiveMaxBranchCommits }
+      keepArtifactsOnNoDiff = $keepArtifactsOnNoDiff
       matchKind = Get-OptionalString -Value $matchedTarget.matchKind
       currentPath = Get-OptionalString -Value $matchedTarget.currentPath
       previousPath = Get-OptionalString -Value $matchedTarget.previousPath

--- a/scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1
@@ -19,7 +19,7 @@ try {
 
   $targetSpecPath = Join-Path $trustedRoot '.github/comparevi-history-targets.json'
   New-Item -ItemType Directory -Path (Split-Path -Parent $targetSpecPath) -Force | Out-Null
-  @'
+  @"
 {
   "schema": "comparevi-history/consumer-targets@v1",
   "targets": [
@@ -35,10 +35,10 @@ try {
     }
   ]
 }
-'@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
+"@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
 
   $discoveryPath = Join-Path $resultsDir 'changed-vi-discovery.json'
-  @'
+  @"
 {
   "schema": "comparevi-history/changed-vi-discovery@v1",
   "generatedAtUtc": "2026-03-17T00:00:00Z",
@@ -47,6 +47,35 @@ try {
   "targetCatalog": {
     "schema": "comparevi-history/consumer-targets@v1",
     "path": "placeholder"
+  },
+  "prPolicy": {
+    "schema": "comparevi-history/pr-policy@v1",
+    "path": "C:/repo/.github/comparevi-history-pr-policy.json",
+    "applied": true,
+    "discovery": {
+      "includePaths": ["Tooling/deployment/**/*.vi"],
+      "excludePaths": [],
+      "allowedTargetIds": [],
+      "maxChangedViCount": 4,
+      "unmatchedChangedViBehavior": "ignore"
+    },
+    "execution": {
+      "publicModes": ["attributes", "front-panel"],
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": 25
+        },
+        "keepArtifactsOnNoDiff": true
+      }
+    },
+    "reviewerSurface": {
+      "emitCommentBody": true,
+      "emitStepSummary": true
+    },
+    "trust": {
+      "forkBehavior": "block"
+    }
   },
   "pullRequest": {
     "number": 22,
@@ -72,10 +101,22 @@ try {
       "previousPath": null
     }
   ],
+  "excludedViFiles": [],
   "matchedTargets": [
     {
       "targetId": "target-success",
       "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"],
+      "requestedModes": ["attributes", "front-panel"],
+      "requestedModeSource": "pr-policy",
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": 25,
+          "source": "pr-policy"
+        }
+      },
+      "keepArtifactsOnNoDiff": true,
       "matchKind": "current-path",
       "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
       "previousPath": null,
@@ -84,6 +125,17 @@ try {
     {
       "targetId": "target-fail",
       "targetPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "publicModes": ["attributes", "front-panel", "block-diagram"],
+      "requestedModes": ["attributes", "front-panel"],
+      "requestedModeSource": "pr-policy",
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": 25,
+          "source": "pr-policy"
+        }
+      },
+      "keepArtifactsOnNoDiff": true,
       "matchKind": "current-path",
       "currentPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
       "previousPath": null,
@@ -94,10 +146,13 @@ try {
     "executionStatus": "ready",
     "executionReason": "matched-targets",
     "changedViCount": 2,
+    "eligibleChangedViCount": 2,
+    "excludedViCount": 0,
+    "unmatchedViCount": 0,
     "matchedTargetCount": 2
   }
 }
-'@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
+"@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
 
   @'
 param(
@@ -106,10 +161,13 @@ param(
   [string]$TargetId,
   [string]$StartRef,
   [string]$NoisePolicy,
+  [string]$Mode,
   [string]$ResultsDir,
   [string]$ConsumerRepository,
   [string]$ConsumerRef,
   [string]$SourceBranchRef,
+  [int]$MaxBranchCommits,
+  [switch]$KeepArtifactsOnNoDiff,
   [string]$ReviewerSurface,
   [string]$ReviewerPullRequestNumber,
   [string]$ReviewerIsFork,
@@ -138,10 +196,13 @@ $requestPath = Join-Path $publicRoot 'request.json'
   target = [ordered]@{
     id = $TargetId
     path = $targetPath
-    requestedModes = @('attributes', 'front-panel', 'block-diagram')
+    requestedModes = @($Mode -split ',')
     publicModes = @('attributes', 'front-panel', 'block-diagram')
   }
   history = [ordered]@{
+    sourceBranchRef = $SourceBranchRef
+    maxBranchCommits = $MaxBranchCommits
+    keepArtifactsOnNoDiff = [bool]$KeepArtifactsOnNoDiff.IsPresent
     renderReport = $true
   }
   results = [ordered]@{
@@ -154,8 +215,9 @@ $requestPath = Join-Path $publicRoot 'request.json'
 "target-path=$targetPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "request-path=$requestPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "results-dir=$ResultsDir" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
-"requested-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"requested-mode-list=$Mode" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "source-branch-ref=$SourceBranchRef" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"max-branch-commits=$MaxBranchCommits" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 '@ | Set-Content -LiteralPath (Join-Path $platformRoot 'scripts/Resolve-CompareVIHistoryRequest.ps1') -Encoding utf8
 
   @'
@@ -184,9 +246,9 @@ $reportHtmlPath = Join-Path $ResultsDir 'history-report.html'
 "results-dir=$ResultsDir" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "history-report-md=$reportMdPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "history-report-html=$reportHtmlPath" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
-"requested-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
-"executed-mode-list=attributes,front-panel,block-diagram" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
-"mode-count=3" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"requested-mode-list=attributes,front-panel" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"executed-mode-list=attributes,front-panel" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+"mode-count=2" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 "stop-reason=completed" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
 if ($TargetPath -like '*Pre-Install*') {
   "total-processed=0" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
@@ -213,21 +275,21 @@ $ErrorActionPreference = 'Stop'
 
 @"
 {
-  ""schema"": ""comparevi-history/mode-summary@v1"",
-  ""requestedModes"": [""attributes"", ""front-panel"", ""block-diagram""],
-  ""executedModes"": [""attributes"", ""front-panel"", ""block-diagram""],
-  ""totalProcessed"": $TotalProcessed,
-  ""totalDiffs"": $TotalDiffs,
-  ""stopReason"": ""$StopReason"",
-  ""categoryCounts"": {},
-  ""comparisonPairs"": [],
-  ""bucketCounts"": {},
-  ""previewImages"": [],
-  ""metadata"": {
-    ""comparisonArtifactCount"": 0,
-    ""captureCount"": 0,
-    ""imageArtifactCount"": 0,
-    ""imageMimeTypes"": []
+  "schema": "comparevi-history/mode-summary@v1",
+  "requestedModes": ["attributes", "front-panel"],
+  "executedModes": ["attributes", "front-panel"],
+  "totalProcessed": $TotalProcessed,
+  "totalDiffs": $TotalDiffs,
+  "stopReason": "$StopReason",
+  "categoryCounts": {},
+  "comparisonPairs": [],
+  "bucketCounts": {},
+  "previewImages": [],
+  "metadata": {
+    "comparisonArtifactCount": 0,
+    "captureCount": 0,
+    "imageArtifactCount": 0,
+    "imageMimeTypes": []
   }
 }
 "@ | Set-Content -LiteralPath $JsonOutputPath -Encoding utf8
@@ -335,10 +397,23 @@ $finalReason = if ($RunOutcome -eq 'success') { 'completed' } else { 'facade-ste
   if ($manifest.summary.executedTargetCount -ne 2) {
     throw 'Executed target count mismatch.'
   }
-  if (-not ($manifest.targets | Where-Object { $_.targetId -eq 'target-success' -and $_.finalStatus -eq 'succeeded' })) {
+
+  $successTarget = $manifest.targets | Where-Object { $_.targetId -eq 'target-success' } | Select-Object -First 1
+  if ($null -eq $successTarget -or $successTarget.finalStatus -ne 'succeeded') {
     throw 'Successful target was not recorded.'
   }
-  if (-not ($manifest.targets | Where-Object { $_.targetId -eq 'target-fail' -and $_.finalStatus -eq 'failed' })) {
+  if (($successTarget.requestedModes -join ',') -ne 'attributes,front-panel') {
+    throw 'Requested modes were not preserved on the target manifest.'
+  }
+  if ($successTarget.sourceBranchRef -ne 'develop' -or $successTarget.maxBranchCommits -ne 25) {
+    throw 'Branch budget policy did not flow into the target manifest.'
+  }
+  if ($successTarget.keepArtifactsOnNoDiff -ne $true) {
+    throw 'Keep-artifacts policy did not flow into the target manifest.'
+  }
+
+  $failedTarget = $manifest.targets | Where-Object { $_.targetId -eq 'target-fail' } | Select-Object -First 1
+  if ($null -eq $failedTarget -or $failedTarget.finalStatus -ne 'failed') {
     throw 'Failed target was not recorded.'
   }
 

--- a/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
@@ -7,14 +7,20 @@ New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
 try {
   $targetSpecPath = Join-Path $tempRoot 'comparevi-history-targets.json'
-  @'
+  @"
 {
   "schema": "comparevi-history/consumer-targets@v1",
   "targets": [
     {
       "id": "vip-post-install",
       "path": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
-      "publicModes": ["attributes", "front-panel", "block-diagram"]
+      "publicModes": ["attributes", "front-panel", "block-diagram"],
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "release/2026-q1",
+          "maxCommitCount": 15
+        }
+      }
     },
     {
       "id": "vip-pre-install",
@@ -23,15 +29,55 @@ try {
     }
   ]
 }
-'@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
+"@ | Set-Content -LiteralPath $targetSpecPath -Encoding utf8
+
+  $prPolicyPath = Join-Path $tempRoot 'comparevi-history-pr-policy.json'
+  @"
+{
+  "schema": "comparevi-history/pr-policy@v1",
+  "discovery": {
+    "includePaths": [
+      "Tooling/deployment/**/*.vi"
+    ],
+    "excludePaths": [
+      "Tooling/deployment/archive/**/*.vi"
+    ],
+    "allowedTargetIds": [
+      "vip-post-install"
+    ],
+    "maxChangedViCount": 2,
+    "unmatchedChangedViBehavior": "ignore"
+  },
+  "execution": {
+    "publicModes": [
+      "attributes",
+      "front-panel"
+    ],
+    "history": {
+      "branchBudget": {
+        "sourceBranchRef": "develop",
+        "maxCommitCount": 50
+      },
+      "keepArtifactsOnNoDiff": true
+    }
+  },
+  "reviewerSurface": {
+    "emitCommentBody": false,
+    "emitStepSummary": true
+  },
+  "trust": {
+    "forkBehavior": "block"
+  }
+}
+"@ | Set-Content -LiteralPath $prPolicyPath -Encoding utf8
 
   $eventPath = Join-Path $tempRoot 'event.json'
-  @'
+  @"
 {
   "pull_request": {
     "number": 42,
     "html_url": "https://github.com/example/repo/pull/42",
-    "changed_files": 3,
+    "changed_files": 4,
     "base": {
       "ref": "develop",
       "sha": "base-sha",
@@ -49,10 +95,10 @@ try {
     }
   }
 }
-'@ | Set-Content -LiteralPath $eventPath -Encoding utf8
+"@ | Set-Content -LiteralPath $eventPath -Encoding utf8
 
   $filesPayloadPath = Join-Path $tempRoot 'files.json'
-  @'
+  @"
 [
   {
     "filename": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
@@ -60,15 +106,18 @@ try {
   },
   {
     "filename": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
-    "previous_filename": "Tooling/deployment/VIP_Pre-Install Legacy.vi",
-    "status": "renamed"
+    "status": "modified"
+  },
+  {
+    "filename": "Tooling/deployment/archive/Legacy.vi",
+    "status": "modified"
   },
   {
     "filename": "README.md",
     "status": "modified"
   }
 ]
-'@ | Set-Content -LiteralPath $filesPayloadPath -Encoding utf8
+"@ | Set-Content -LiteralPath $filesPayloadPath -Encoding utf8
 
   $outputPath = Join-Path $tempRoot 'discovery.out'
   $resultsDir = Join-Path $tempRoot 'results'
@@ -76,37 +125,101 @@ try {
     -EventName 'pull_request' `
     -EventPath $eventPath `
     -TargetSpecPath $targetSpecPath `
+    -PrPolicyPath $prPolicyPath `
     -ResultsDir $resultsDir `
     -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
     -FilesPayloadPath $filesPayloadPath `
     -GitHubOutputPath $outputPath
 
-  $receipt = $receiptJson | ConvertFrom-Json -Depth 50
+  $receipt = $receiptJson | ConvertFrom-Json -Depth 64
   if ($receipt.schema -ne 'comparevi-history/changed-vi-discovery@v1') {
     throw 'Discovery schema mismatch.'
   }
-  if ($receipt.summary.executionStatus -ne 'ready') {
-    throw 'Discovery should be ready for same-repo VI changes.'
+  if (-not $receipt.prPolicy.applied) {
+    throw 'Discovery should record the applied PR policy.'
   }
-  if ($receipt.summary.changedViCount -ne 2) {
+  if ($receipt.summary.executionStatus -ne 'ready') {
+    throw 'Discovery should stay ready for same-repo VI changes within policy limits.'
+  }
+  if ($receipt.summary.changedViCount -ne 3) {
     throw 'Changed VI count mismatch.'
   }
-  if ($receipt.summary.matchedTargetCount -ne 2) {
+  if ($receipt.summary.eligibleChangedViCount -ne 2) {
+    throw 'Policy-eligible changed VI count mismatch.'
+  }
+  if ($receipt.summary.excludedViCount -ne 2) {
+    throw 'Excluded VI count mismatch.'
+  }
+  if ($receipt.summary.unmatchedViCount -ne 1) {
+    throw 'Unmatched VI count mismatch.'
+  }
+  if ($receipt.summary.matchedTargetCount -ne 1) {
     throw 'Matched target count mismatch.'
   }
-  if ($receipt.matchedTargets[1].matchKind -ne 'current-path') {
-    throw 'Expected current-path match for renamed current target path.'
+  if ($receipt.matchedTargets[0].requestedModes.Count -ne 2) {
+    throw 'Discovery should narrow requested modes through PR policy.'
+  }
+  if ($receipt.matchedTargets[0].requestedModes[0] -ne 'attributes' -or $receipt.matchedTargets[0].requestedModes[1] -ne 'front-panel') {
+    throw 'Requested modes order mismatch.'
+  }
+  if ($receipt.matchedTargets[0].history.branchBudget.source -ne 'pr-policy') {
+    throw 'Branch budget source mismatch.'
+  }
+  if ($receipt.matchedTargets[0].history.branchBudget.sourceBranchRef -ne 'develop') {
+    throw 'Policy branch-budget source branch mismatch.'
+  }
+  if ($receipt.matchedTargets[0].keepArtifactsOnNoDiff -ne $true) {
+    throw 'PR policy keepArtifactsOnNoDiff was not surfaced.'
+  }
+  if (-not ($receipt.excludedViFiles | Where-Object { $_.currentPath -eq 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -and $_.exclusionReason -eq 'target-id-not-allowed' })) {
+    throw 'Expected target-id exclusion for the pre-install VI.'
+  }
+  if (-not ($receipt.excludedViFiles | Where-Object { $_.currentPath -eq 'Tooling/deployment/archive/Legacy.vi' -and $_.exclusionReason -eq 'excluded-by-pr-policy' })) {
+    throw 'Expected archive exclusion from the PR policy.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw
-  foreach ($requiredKey in @('changed-vi-discovery-path=', 'execution-status=ready', 'matched-target-count=2', 'pull-request-number=42')) {
+  foreach ($requiredKey in @('pr-policy-applied=true', 'eligible-changed-vi-count=2', 'excluded-vi-count=2', 'matched-target-count=1', 'pull-request-number=42')) {
     if ($outputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."
     }
   }
 
+  $strictPolicyPath = Join-Path $tempRoot 'strict-pr-policy.json'
+  @"
+{
+  "schema": "comparevi-history/pr-policy@v1",
+  "discovery": {
+    "includePaths": [
+      "Tooling/deployment/**/*.vi"
+    ],
+    "maxChangedViCount": 1,
+    "unmatchedChangedViBehavior": "block"
+  },
+  "trust": {
+    "forkBehavior": "block"
+  }
+}
+"@ | Set-Content -LiteralPath $strictPolicyPath -Encoding utf8
+
+  $strictReceiptJson = & $scriptPath `
+    -EventName 'pull_request' `
+    -EventPath $eventPath `
+    -TargetSpecPath $targetSpecPath `
+    -PrPolicyPath $strictPolicyPath `
+    -ResultsDir (Join-Path $tempRoot 'strict-results') `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -FilesPayloadPath $filesPayloadPath
+  $strictReceipt = $strictReceiptJson | ConvertFrom-Json -Depth 64
+  if ($strictReceipt.summary.executionStatus -ne 'blocked') {
+    throw 'Strict PR policy should block oversized changed-VI sets.'
+  }
+  if ($strictReceipt.summary.executionReason -ne 'max-changed-vi-count-exceeded') {
+    throw 'Strict PR policy block reason mismatch.'
+  }
+
   $forkEventPath = Join-Path $tempRoot 'fork-event.json'
-  @'
+  @"
 {
   "pull_request": {
     "number": 7,
@@ -128,16 +241,17 @@ try {
     }
   }
 }
-'@ | Set-Content -LiteralPath $forkEventPath -Encoding utf8
+"@ | Set-Content -LiteralPath $forkEventPath -Encoding utf8
 
   $forkReceiptJson = & $scriptPath `
     -EventName 'pull_request' `
     -EventPath $forkEventPath `
     -TargetSpecPath $targetSpecPath `
+    -PrPolicyPath $prPolicyPath `
     -ResultsDir (Join-Path $tempRoot 'fork-results') `
     -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
     -FilesPayloadPath $filesPayloadPath
-  $forkReceipt = $forkReceiptJson | ConvertFrom-Json -Depth 50
+  $forkReceipt = $forkReceiptJson | ConvertFrom-Json -Depth 64
   if ($forkReceipt.summary.executionStatus -ne 'blocked') {
     throw 'Fork pull request must be blocked.'
   }

--- a/scripts/Test-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestRun.ps1
@@ -10,7 +10,7 @@ try {
   New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
 
   $discoveryPath = Join-Path $resultsDir 'changed-vi-discovery.json'
-  @'
+  @"
 {
   "schema": "comparevi-history/changed-vi-discovery@v1",
   "generatedAtUtc": "2026-03-17T00:00:00Z",
@@ -19,6 +19,35 @@ try {
   "targetCatalog": {
     "schema": "comparevi-history/consumer-targets@v1",
     "path": "C:/repo/.github/comparevi-history-targets.json"
+  },
+  "prPolicy": {
+    "schema": "comparevi-history/pr-policy@v1",
+    "path": "C:/repo/.github/comparevi-history-pr-policy.json",
+    "applied": true,
+    "discovery": {
+      "includePaths": ["Tooling/deployment/**/*.vi"],
+      "excludePaths": [],
+      "allowedTargetIds": ["vip-post-install"],
+      "maxChangedViCount": 4,
+      "unmatchedChangedViBehavior": "ignore"
+    },
+    "execution": {
+      "publicModes": ["attributes", "front-panel"],
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": 25
+        },
+        "keepArtifactsOnNoDiff": true
+      }
+    },
+    "reviewerSurface": {
+      "emitCommentBody": false,
+      "emitStepSummary": true
+    },
+    "trust": {
+      "forkBehavior": "block"
+    }
   },
   "pullRequest": {
     "number": 22,
@@ -37,6 +66,19 @@ try {
       "status": "modified",
       "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
       "previousPath": null
+    },
+    {
+      "status": "modified",
+      "currentPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "previousPath": null
+    }
+  ],
+  "excludedViFiles": [
+    {
+      "status": "modified",
+      "currentPath": "Tooling/deployment/VIP_Pre-Install Custom Action.vi",
+      "previousPath": null,
+      "exclusionReason": "target-id-not-allowed"
     }
   ],
   "matchedTargets": [
@@ -44,6 +86,16 @@ try {
       "targetId": "vip-post-install",
       "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
       "publicModes": ["attributes", "front-panel", "block-diagram"],
+      "requestedModes": ["attributes", "front-panel"],
+      "requestedModeSource": "pr-policy",
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": 25,
+          "source": "pr-policy"
+        }
+      },
+      "keepArtifactsOnNoDiff": true,
       "matchKind": "current-path",
       "currentPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
       "previousPath": null,
@@ -53,14 +105,17 @@ try {
   "summary": {
     "executionStatus": "ready",
     "executionReason": "matched-targets",
-    "changedViCount": 1,
+    "changedViCount": 2,
+    "eligibleChangedViCount": 2,
+    "excludedViCount": 1,
+    "unmatchedViCount": 1,
     "matchedTargetCount": 1
   }
 }
-'@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
+"@ | Set-Content -LiteralPath $discoveryPath -Encoding utf8
 
   $manifestPath = Join-Path $resultsDir 'pr-target-runs-manifest.json'
-  @'
+  @"
 {
   "schema": "comparevi-history/pr-target-runs-manifest@v1",
   "generatedAtUtc": "2026-03-17T00:01:00Z",
@@ -76,6 +131,11 @@ try {
     {
       "targetId": "vip-post-install",
       "targetPath": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "requestedModes": ["attributes", "front-panel"],
+      "requestedModeSource": "pr-policy",
+      "sourceBranchRef": "develop",
+      "maxBranchCommits": 25,
+      "keepArtifactsOnNoDiff": true,
       "matchKind": "current-path",
       "finalStatus": "succeeded",
       "finalReason": "completed",
@@ -86,7 +146,7 @@ try {
     }
   ]
 }
-'@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
 
   $outputPath = Join-Path $tempRoot 'pr-run.out'
   $receiptJson = & $scriptPath `
@@ -105,16 +165,25 @@ try {
   if ($receipt.summary.totalProcessed -ne 5) {
     throw 'PR run total processed mismatch.'
   }
-  if (-not (Test-Path -LiteralPath $receipt.outputs.publicCommentPath -PathType Leaf)) {
-    throw 'PR run comment body was not written.'
+  if ($receipt.summary.excludedViCount -ne 1 -or $receipt.summary.unmatchedViCount -ne 1) {
+    throw 'PR run policy counts mismatch.'
+  }
+  if ($null -ne $receipt.outputs.publicCommentPath) {
+    throw 'PR policy should disable the reviewer comment body output.'
   }
   if (-not (Test-Path -LiteralPath $receipt.outputs.publicStepSummaryPath -PathType Leaf)) {
     throw 'PR run step summary was not written.'
   }
+  if ($receipt.targets[0].keepArtifactsOnNoDiff -ne $true) {
+    throw 'PR run receipt did not retain keep-artifacts policy.'
+  }
+  if (($receipt.targets[0].requestedModes -join ',') -ne 'attributes,front-panel') {
+    throw 'PR run receipt did not preserve requested modes.'
+  }
 
-  $commentBody = Get-Content -LiteralPath $receipt.outputs.publicCommentPath -Raw
-  if ($commentBody -notmatch 'comparevi-history PR diagnostics') {
-    throw 'PR run comment body did not include the heading.'
+  $stepSummary = Get-Content -LiteralPath $receipt.outputs.publicStepSummaryPath -Raw
+  if ($stepSummary -notmatch 'Excluded VI files') {
+    throw 'PR run step summary did not include the excluded VI section.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw
@@ -125,7 +194,7 @@ try {
   }
 
   $blockedDiscoveryPath = Join-Path $resultsDir 'blocked-discovery.json'
-  @'
+  @"
 {
   "schema": "comparevi-history/changed-vi-discovery@v1",
   "generatedAtUtc": "2026-03-17T00:00:00Z",
@@ -134,6 +203,35 @@ try {
   "targetCatalog": {
     "schema": "comparevi-history/consumer-targets@v1",
     "path": "C:/repo/.github/comparevi-history-targets.json"
+  },
+  "prPolicy": {
+    "schema": "comparevi-history/pr-policy@v1",
+    "path": null,
+    "applied": false,
+    "discovery": {
+      "includePaths": [],
+      "excludePaths": [],
+      "allowedTargetIds": [],
+      "maxChangedViCount": null,
+      "unmatchedChangedViBehavior": "ignore"
+    },
+    "execution": {
+      "publicModes": [],
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": null,
+          "maxCommitCount": null
+        },
+        "keepArtifactsOnNoDiff": false
+      }
+    },
+    "reviewerSurface": {
+      "emitCommentBody": true,
+      "emitStepSummary": true
+    },
+    "trust": {
+      "forkBehavior": "block"
+    }
   },
   "pullRequest": {
     "number": 23,
@@ -148,15 +246,19 @@ try {
     "changedFileCount": 1
   },
   "changedViFiles": [],
+  "excludedViFiles": [],
   "matchedTargets": [],
   "summary": {
     "executionStatus": "blocked",
     "executionReason": "untrusted-cross-repository-pull-request",
     "changedViCount": 0,
+    "eligibleChangedViCount": 0,
+    "excludedViCount": 0,
+    "unmatchedViCount": 0,
     "matchedTargetCount": 0
   }
 }
-'@ | Set-Content -LiteralPath $blockedDiscoveryPath -Encoding utf8
+"@ | Set-Content -LiteralPath $blockedDiscoveryPath -Encoding utf8
 
   $blockedReceiptJson = & $scriptPath `
     -DiscoveryPath $blockedDiscoveryPath `

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -15,6 +15,7 @@ $releaseWorkflowPath = Join-Path $repoRoot '.github/workflows/release.yml'
 $releaseReadinessScriptPath = Join-Path $repoRoot 'scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1'
 $readmePath = Join-Path $repoRoot 'README.md'
 $exampleTargetsPath = Join-Path $repoRoot 'docs/examples/comparevi-history-consumer-targets.json'
+$examplePrPolicyPath = Join-Path $repoRoot 'docs/examples/comparevi-history-pr-policy.json'
 $actionPath = Join-Path $repoRoot 'action.yml'
 
 function Assert-Match {
@@ -93,6 +94,7 @@ $releaseWorkflow = Get-Content -LiteralPath $releaseWorkflowPath -Raw
 $releaseReadinessScript = Get-Content -LiteralPath $releaseReadinessScriptPath -Raw
 $readme = Get-Content -LiteralPath $readmePath -Raw
 $exampleTargets = Get-Content -LiteralPath $exampleTargetsPath -Raw
+$examplePrPolicy = Get-Content -LiteralPath $examplePrPolicyPath -Raw
 $actionYaml = Get-Content -LiteralPath $actionPath -Raw
 
 Assert-Match -Content $manualTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Manual template must use ubuntu-latest.'
@@ -107,6 +109,7 @@ Assert-NotMatch -Content $manualTemplate -Pattern '## comparevi-history manual P
 
 Assert-Match -Content $pullRequestTemplate -Pattern 'LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/pull-request-diagnostics\.yml@v1' -Message 'Pull request template must call the reusable workflow surface.'
 Assert-Match -Content $pullRequestTemplate -Pattern 'target_spec_path:\s+\.github/comparevi-history-targets\.json' -Message 'Pull request template must consume the checked-in target catalog.'
+Assert-Match -Content $pullRequestTemplate -Pattern 'pr_policy_path:\s+\.github/comparevi-history-pr-policy\.json' -Message 'Pull request template must consume the checked-in PR policy.'
 Assert-Match -Content $pullRequestTemplate -Pattern 'results_dir:\s+tests/results/pr-diagnostics/history' -Message 'Pull request template must keep the standard PR diagnostics results root.'
 Assert-Match -Content $pullRequestTemplate -Pattern 'platform_ref:\s+v1' -Message 'Pull request template must keep platform_ref aligned with the workflow pin.'
 Assert-NotMatch -Content $pullRequestTemplate -Pattern 'invoke_script_path:' -Message 'Pull request template must not own the hosted invoke adapter path.'
@@ -155,6 +158,7 @@ Assert-Match -Content $manualExplorationWorkflow -Pattern "steps\.exploration\.o
 
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*workflow_call:\s*$' -Message 'Pull request workflow must be reusable.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*target_spec_path:\s*$' -Message 'Pull request workflow must accept target_spec_path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*pr_policy_path:\s*$' -Message 'Pull request workflow must accept pr_policy_path.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*default:\s+\.github/comparevi-history-targets\.json\s*$' -Message 'Pull request workflow must default to the checked-in target catalog path.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*COMPAREVI_NI_LINUX_IMAGE:\s+nationalinstruments/labview:2026q1-linux\s*$' -Message 'Pull request workflow must pin the NI Linux image.'
 Assert-Match -Content $pullRequestWorkflow -Pattern 'Write-CompareVIHistoryPullRequestDiscovery\.ps1' -Message 'Pull request workflow must discover changed VI targets.'
@@ -189,8 +193,12 @@ Assert-NotMatch -Content $commentTemplate -Pattern '(?m)^\s*DEFAULT_COMPARE_MODE
 
 Assert-Match -Content $exampleTargets -Pattern 'comparevi-history/consumer-targets@v1' -Message 'Example targets file must declare the consumer-targets schema.'
 Assert-Match -Content $exampleTargets -Pattern '"publicModes"' -Message 'Example targets file must declare public modes.'
+Assert-Match -Content $examplePrPolicy -Pattern 'comparevi-history/pr-policy@v1' -Message 'Example PR policy file must declare the pr-policy schema.'
+Assert-Match -Content $examplePrPolicy -Pattern '"allowedTargetIds"' -Message 'Example PR policy file must declare target allowlists.'
+Assert-Match -Content $examplePrPolicy -Pattern '"publicModes"' -Message 'Example PR policy file must declare public mode policy.'
 Assert-Match -Content $safeTemplates -Pattern 'attributes,front-panel,block-diagram' -Message 'Safe template docs must document the explicit public mode contract.'
 Assert-Match -Content $safeTemplates -Pattern '\.github/comparevi-history-targets\.json' -Message 'Safe template docs must document the checked-in target catalog path.'
+Assert-Match -Content $safeTemplates -Pattern '\.github/comparevi-history-pr-policy\.json' -Message 'Safe template docs must document the checked-in PR policy path.'
 Assert-Match -Content $safeTemplates -Pattern 'public-comment-path' -Message 'Safe template docs must point consumers at the action-owned comment output.'
 Assert-Match -Content $safeTemplates -Pattern 'public-step-summary-path' -Message 'Safe template docs must point consumers at the action-owned step summary output.'
 Assert-Match -Content $publishedValidationWorkflow -Pattern '\.github/comparevi-history-targets\.json' -Message 'Published validation must synthesize a checked-in-style target catalog path.'
@@ -220,6 +228,7 @@ Assert-Match -Content $readme -Pattern 'comparevi-history/consumer-targets@v1' -
 Assert-Match -Content $readme -Pattern 'comparevi-history/public-run@v1' -Message 'README must document the public run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/shared-evidence@v1' -Message 'README must document the shared evidence contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/changed-vi-discovery@v1' -Message 'README must document the changed-VI discovery contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/pr-policy@v1' -Message 'README must document the PR policy contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-run@v1' -Message 'README must document the aggregate pull-request run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/revision-catalog@v1' -Message 'README must document the revision catalog contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/exploration-run@v1' -Message 'README must document the exploration run contract.'
@@ -249,6 +258,7 @@ Assert-Match -Content $readme -Pattern 'VIP_Pre-Install Custom Action\.vi' -Mess
 Assert-Match -Content $readme -Pattern 'bounded teaser surface' -Message 'README must document that the step summary remains bounded.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-manual-vi-exploration\.yml' -Message 'README must point to the manual exploration wrapper example.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pull-request-diagnostics\.yml' -Message 'README must point to the pull request diagnostics wrapper example.'
+Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pr-policy\.json' -Message 'README must point to the PR policy example.'
 Assert-Match -Content $readme -Pattern 'hosted NI Linux container path wired by a repo-local adapter' -Message 'README must document the hosted NI Linux adapter path.'
 Assert-Match -Content $readme -Pattern 'public-comment-path' -Message 'README must document the action-owned public comment output.'
 Assert-Match -Content $readme -Pattern 'shared-evidence\.json' -Message 'README must document the shared evidence output.'

--- a/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
@@ -5,6 +5,7 @@ param(
   [string]$EventPath,
   [Parameter(Mandatory = $true)]
   [string]$TargetSpecPath,
+  [string]$PrPolicyPath,
   [Parameter(Mandatory = $true)]
   [string]$ResultsDir,
   [string]$Repository,
@@ -16,6 +17,12 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+$publicModesAllowed = @('attributes', 'front-panel', 'block-diagram')
+$publicModeSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($modeName in $publicModesAllowed) {
+  [void]$publicModeSet.Add($modeName)
+}
 
 function Write-ActionOutput {
   param(
@@ -119,6 +126,24 @@ function Get-OptionalString {
   return $stringValue.Trim()
 }
 
+function Get-OptionalInt {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return [int]$stringValue
+}
+
 function Read-JsonFile {
   param(
     [Parameter(Mandatory = $true)]
@@ -173,6 +198,267 @@ function Invoke-PullRequestFilesApi {
   return @($files | ForEach-Object { $_ })
 }
 
+function Normalize-RepositoryPath {
+  param(
+    [AllowNull()]
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $normalized = $Path.Trim() -replace '\\', '/'
+  while ($normalized.Contains('//')) {
+    $normalized = $normalized.Replace('//', '/')
+  }
+
+  return $normalized.TrimStart([char[]]@('.', '/')).Trim([char[]]@('/'))
+}
+
+function ConvertTo-NormalizedStringArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  $items = New-Object System.Collections.Generic.List[string]
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($entry in @(ConvertTo-ObjectArray -Value $Value)) {
+    $normalized = Normalize-RepositoryPath -Path (Get-OptionalString -Value $entry)
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+      continue
+    }
+
+    if ($seen.Add($normalized)) {
+      $items.Add($normalized) | Out-Null
+    }
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function ConvertTo-NormalizedModeList {
+  param(
+    [AllowNull()]
+    $Value,
+    [Parameter(Mandatory = $true)]
+    [string]$ContextLabel
+  )
+
+  $items = New-Object System.Collections.Generic.List[string]
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($entry in @(ConvertTo-ObjectArray -Value $Value)) {
+    $normalized = Get-OptionalString -Value $entry
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+      continue
+    }
+
+    $normalized = $normalized.ToLowerInvariant()
+    if (-not $publicModeSet.Contains($normalized)) {
+      throw "$ContextLabel included unsupported public mode '$normalized'. Allowed values: $($publicModesAllowed -join ', ')."
+    }
+
+    if ($seen.Add($normalized)) {
+      $items.Add($normalized) | Out-Null
+    }
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function Convert-GlobToRegex {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Pattern
+  )
+
+  $normalized = Normalize-RepositoryPath -Path $Pattern
+  if ([string]::IsNullOrWhiteSpace($normalized)) {
+    return '^(?!)$'
+  }
+
+  $builder = New-Object System.Text.StringBuilder
+  [void]$builder.Append('^')
+  $index = 0
+  while ($index -lt $normalized.Length) {
+    $char = $normalized[$index]
+    if ($char -eq '*') {
+      if (($index + 1) -lt $normalized.Length -and $normalized[$index + 1] -eq '*') {
+        if (($index + 2) -lt $normalized.Length -and $normalized[$index + 2] -eq '/') {
+          [void]$builder.Append('(?:.*/)?')
+          $index += 3
+        } else {
+          [void]$builder.Append('.*')
+          $index += 2
+        }
+      } else {
+        [void]$builder.Append('[^/]*')
+        $index += 1
+      }
+      continue
+    }
+
+    if ($char -eq '?') {
+      [void]$builder.Append('[^/]')
+      $index += 1
+      continue
+    }
+
+    [void]$builder.Append([regex]::Escape([string]$char))
+    $index += 1
+  }
+
+  [void]$builder.Append('$')
+  return $builder.ToString()
+}
+
+function Test-PathMatchesPatterns {
+  param(
+    [AllowNull()]
+    [string]$Path,
+    [string[]]$Patterns
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path) -or $Patterns.Count -eq 0) {
+    return $false
+  }
+
+  $normalizedPath = Normalize-RepositoryPath -Path $Path
+  foreach ($pattern in $Patterns) {
+    if ($normalizedPath -match (Convert-GlobToRegex -Pattern $pattern)) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Test-ChangeMatchesPatterns {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Change,
+    [string[]]$Patterns
+  )
+
+  if ($Patterns.Count -eq 0) {
+    return $false
+  }
+
+  foreach ($candidatePath in @([string]$Change.currentPath, [string]$Change.previousPath)) {
+    if (Test-PathMatchesPatterns -Path $candidatePath -Patterns $Patterns) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Resolve-RequestedModes {
+  param(
+    [string[]]$TargetPublicModes,
+    [string[]]$PolicyPublicModes
+  )
+
+  if ($PolicyPublicModes.Count -eq 0) {
+    return [ordered]@{
+      requestedModes = @($TargetPublicModes)
+      source = 'target-public-modes'
+    }
+  }
+
+  $targetModeSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($targetMode in $TargetPublicModes) {
+    [void]$targetModeSet.Add($targetMode)
+  }
+
+  $requestedModes = New-Object System.Collections.Generic.List[string]
+  foreach ($policyMode in $PolicyPublicModes) {
+    if ($targetModeSet.Contains($policyMode)) {
+      $requestedModes.Add($policyMode) | Out-Null
+    }
+  }
+
+  return [ordered]@{
+    requestedModes = @($requestedModes | ForEach-Object { $_ })
+    source = 'pr-policy'
+  }
+}
+
+function Resolve-PrPolicy {
+  param(
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  $resolvedPath = $null
+  $applied = $false
+  $rawPolicy = $null
+  if (-not [string]::IsNullOrWhiteSpace($Path)) {
+    $resolvedPath = Resolve-AbsolutePath -Path $Path -BasePath $BasePath
+    if (-not (Test-Path -LiteralPath $resolvedPath -PathType Leaf)) {
+      throw "PR policy not found: $resolvedPath"
+    }
+
+    $rawPolicy = Read-JsonFile -Path $resolvedPath
+    if ([string]$rawPolicy.schema -ne 'comparevi-history/pr-policy@v1') {
+      throw "Unsupported PR policy schema in '$resolvedPath': $($rawPolicy.schema)"
+    }
+
+    $applied = $true
+  }
+
+  $discovery = Get-NestedValue -Object $rawPolicy -Path @('discovery')
+  $execution = Get-NestedValue -Object $rawPolicy -Path @('execution')
+  $history = Get-NestedValue -Object $execution -Path @('history')
+  $branchBudget = Get-NestedValue -Object $history -Path @('branchBudget')
+  $reviewerSurface = Get-NestedValue -Object $rawPolicy -Path @('reviewerSurface')
+  $trust = Get-NestedValue -Object $rawPolicy -Path @('trust')
+
+  return [ordered]@{
+    schema = 'comparevi-history/pr-policy@v1'
+    path = $resolvedPath
+    applied = $applied
+    discovery = [ordered]@{
+      includePaths = @(ConvertTo-NormalizedStringArray -Value (Get-NestedValue -Object $discovery -Path @('includePaths')))
+      excludePaths = @(ConvertTo-NormalizedStringArray -Value (Get-NestedValue -Object $discovery -Path @('excludePaths')))
+      allowedTargetIds = @(
+        @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $discovery -Path @('allowedTargetIds'))) |
+          ForEach-Object { Get-OptionalString -Value $_ } |
+          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+      )
+      maxChangedViCount = Get-OptionalInt -Value (Get-NestedValue -Object $discovery -Path @('maxChangedViCount'))
+      unmatchedChangedViBehavior = if ([string]::IsNullOrWhiteSpace([string](Get-NestedValue -Object $discovery -Path @('unmatchedChangedViBehavior')))) {
+        'ignore'
+      } else {
+        [string](Get-NestedValue -Object $discovery -Path @('unmatchedChangedViBehavior'))
+      }
+    }
+    execution = [ordered]@{
+      publicModes = @(ConvertTo-NormalizedModeList -Value (Get-NestedValue -Object $execution -Path @('publicModes')) -ContextLabel 'PR policy execution.publicModes')
+      history = [ordered]@{
+        branchBudget = [ordered]@{
+          sourceBranchRef = Get-OptionalString -Value (Get-NestedValue -Object $branchBudget -Path @('sourceBranchRef'))
+          maxCommitCount = Get-OptionalInt -Value (Get-NestedValue -Object $branchBudget -Path @('maxCommitCount'))
+        }
+        keepArtifactsOnNoDiff = [bool](Get-NestedValue -Object $history -Path @('keepArtifactsOnNoDiff') -Default $false)
+      }
+    }
+    reviewerSurface = [ordered]@{
+      emitCommentBody = [bool](Get-NestedValue -Object $reviewerSurface -Path @('emitCommentBody') -Default $true)
+      emitStepSummary = [bool](Get-NestedValue -Object $reviewerSurface -Path @('emitStepSummary') -Default $true)
+    }
+    trust = [ordered]@{
+      forkBehavior = if ([string]::IsNullOrWhiteSpace([string](Get-NestedValue -Object $trust -Path @('forkBehavior')))) {
+        'block'
+      } else {
+        [string](Get-NestedValue -Object $trust -Path @('forkBehavior'))
+      }
+    }
+  }
+}
+
 if ($EventName -notin @('pull_request', 'pull_request_target')) {
   throw "comparevi-history pull-request discovery requires pull_request or pull_request_target events. Actual: $EventName"
 }
@@ -203,6 +489,38 @@ if ([string]$targetCatalog.schema -ne 'comparevi-history/consumer-targets@v1') {
   throw "Unsupported target catalog schema in '$targetSpecPathResolved': $($targetCatalog.schema)"
 }
 
+$prPolicy = Resolve-PrPolicy -Path $PrPolicyPath -BasePath $basePath
+$allowedTargetIdSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($allowedTargetId in @($prPolicy.discovery.allowedTargetIds)) {
+  [void]$allowedTargetIdSet.Add([string]$allowedTargetId)
+}
+
+$catalogTargets = New-Object System.Collections.Generic.List[object]
+foreach ($target in @($targetCatalog.targets)) {
+  $targetId = Get-OptionalString -Value $target.id
+  $targetPath = Normalize-RepositoryPath -Path (Get-OptionalString -Value $target.path)
+  if ([string]::IsNullOrWhiteSpace($targetId) -or [string]::IsNullOrWhiteSpace($targetPath)) {
+    continue
+  }
+
+  $targetPublicModes = @(ConvertTo-NormalizedModeList -Value $target.publicModes -ContextLabel "Target '$targetId' publicModes")
+  if ($targetPublicModes.Count -eq 0) {
+    throw "Target '$targetId' in '$targetSpecPathResolved' must declare at least one explicit public mode."
+  }
+
+  $catalogTargets.Add([pscustomobject][ordered]@{
+      targetId = $targetId
+      targetPath = $targetPath
+      publicModes = @($targetPublicModes)
+      history = [ordered]@{
+        branchBudget = [ordered]@{
+          sourceBranchRef = Get-OptionalString -Value (Get-NestedValue -Object $target -Path @('history', 'branchBudget', 'sourceBranchRef'))
+          maxCommitCount = Get-OptionalInt -Value (Get-NestedValue -Object $target -Path @('history', 'branchBudget', 'maxCommitCount'))
+        }
+      }
+    }) | Out-Null
+}
+
 $pullRequestNumber = [int](Get-NestedValue -Object $pullRequest -Path @('number') -Default 0)
 $baseRepository = [string](Get-NestedValue -Object $pullRequest -Path @('base', 'repo', 'full_name') -Default '')
 $baseRef = [string](Get-NestedValue -Object $pullRequest -Path @('base', 'ref') -Default '')
@@ -228,7 +546,7 @@ $repositorySlug = if (-not [string]::IsNullOrWhiteSpace($Repository)) {
 
 $executionStatus = 'ready'
 $executionReason = 'matched-targets'
-if ($isFork) {
+if ($isFork -and $prPolicy.trust.forkBehavior -eq 'block') {
   $executionStatus = 'blocked'
   $executionReason = 'untrusted-cross-repository-pull-request'
 } elseif ($reportedChangedFileCount -gt 3000) {
@@ -250,8 +568,8 @@ if (-not [string]::IsNullOrWhiteSpace($FilesPayloadPath)) {
 $changedViFiles = New-Object System.Collections.Generic.List[object]
 $seenChanges = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 foreach ($file in $rawFiles) {
-  $currentPath = Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('filename'))
-  $previousPath = Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('previous_filename'))
+  $currentPath = Normalize-RepositoryPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('filename')))
+  $previousPath = Normalize-RepositoryPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $file -Path @('previous_filename')))
   if ([string]::IsNullOrWhiteSpace($currentPath) -and [string]::IsNullOrWhiteSpace($previousPath)) {
     continue
   }
@@ -267,60 +585,159 @@ foreach ($file in $rawFiles) {
     $changeStatus = 'unknown'
   }
 
-  $signature = '{0}|{1}|{2}' -f $changeStatus, $currentPath, $previousPath
+  $effectiveCurrentPath = if ([string]::IsNullOrWhiteSpace($currentPath)) { $previousPath } else { $currentPath }
+  $signature = '{0}|{1}|{2}' -f $changeStatus, $effectiveCurrentPath, $previousPath
   if (-not $seenChanges.Add($signature)) {
     continue
   }
 
   $changedViFiles.Add([pscustomobject][ordered]@{
       status = $changeStatus
-      currentPath = if ([string]::IsNullOrWhiteSpace($currentPath)) { $previousPath } else { $currentPath }
-      previousPath = $previousPath
+      currentPath = $effectiveCurrentPath
+      previousPath = if ([string]::IsNullOrWhiteSpace($previousPath)) { $null } else { $previousPath }
     }) | Out-Null
 }
 
 $matchedTargets = New-Object System.Collections.Generic.List[object]
-foreach ($target in $targetCatalog.targets) {
-  $targetId = Get-OptionalString -Value $target.id
-  $targetPath = Get-OptionalString -Value $target.path
-  if ([string]::IsNullOrWhiteSpace($targetId) -or [string]::IsNullOrWhiteSpace($targetPath)) {
+$matchedTargetSignatures = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$excludedViFiles = New-Object System.Collections.Generic.List[object]
+$policyEligibleChangedViCount = 0
+$unmatchedViCount = 0
+
+foreach ($change in $changedViFiles) {
+  $includeMatched = $true
+  if ($prPolicy.discovery.includePaths.Count -gt 0) {
+    $includeMatched = Test-ChangeMatchesPatterns -Change $change -Patterns $prPolicy.discovery.includePaths
+  }
+  if (-not $includeMatched) {
+    $excludedViFiles.Add([pscustomobject][ordered]@{
+        status = [string]$change.status
+        currentPath = [string]$change.currentPath
+        previousPath = if ([string]::IsNullOrWhiteSpace([string]$change.previousPath)) { $null } else { [string]$change.previousPath }
+        exclusionReason = 'not-included-by-pr-policy'
+      }) | Out-Null
     continue
   }
 
-  $match = $null
-  $matchKind = $null
-  foreach ($change in $changedViFiles) {
-    if ([string]$change.currentPath -eq $targetPath) {
-      $match = $change
-      $matchKind = 'current-path'
-      break
-    }
-    if (-not [string]::IsNullOrWhiteSpace([string]$change.previousPath) -and [string]$change.previousPath -eq $targetPath) {
-      $match = $change
-      $matchKind = 'previous-path'
-      break
-    }
-  }
-
-  if ($null -eq $match) {
+  if (Test-ChangeMatchesPatterns -Change $change -Patterns $prPolicy.discovery.excludePaths) {
+    $excludedViFiles.Add([pscustomobject][ordered]@{
+        status = [string]$change.status
+        currentPath = [string]$change.currentPath
+        previousPath = if ([string]::IsNullOrWhiteSpace([string]$change.previousPath)) { $null } else { [string]$change.previousPath }
+        exclusionReason = 'excluded-by-pr-policy'
+      }) | Out-Null
     continue
   }
 
-  $publicModes = @(
-    @(ConvertTo-ObjectArray -Value $target.publicModes) |
-      ForEach-Object { Get-OptionalString -Value $_ } |
-      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-  )
+  $policyEligibleChangedViCount += 1
 
-  $matchedTargets.Add([pscustomobject][ordered]@{
-      targetId = $targetId
-      targetPath = $targetPath
-      publicModes = @($publicModes)
-      matchKind = $matchKind
-      currentPath = [string]$match.currentPath
-      previousPath = if ([string]::IsNullOrWhiteSpace([string]$match.previousPath)) { $null } else { [string]$match.previousPath }
-      changeStatus = [string]$match.status
-    }) | Out-Null
+  $candidateTargets = New-Object System.Collections.Generic.List[object]
+  foreach ($target in $catalogTargets) {
+    if ([string]$change.currentPath -eq [string]$target.targetPath) {
+      $candidateTargets.Add([pscustomobject][ordered]@{
+          target = $target
+          matchKind = 'current-path'
+        }) | Out-Null
+      continue
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace([string]$change.previousPath) -and [string]$change.previousPath -eq [string]$target.targetPath) {
+      $candidateTargets.Add([pscustomobject][ordered]@{
+          target = $target
+          matchKind = 'previous-path'
+        }) | Out-Null
+    }
+  }
+
+  if ($candidateTargets.Count -eq 0) {
+    $excludedViFiles.Add([pscustomobject][ordered]@{
+        status = [string]$change.status
+        currentPath = [string]$change.currentPath
+        previousPath = if ([string]::IsNullOrWhiteSpace([string]$change.previousPath)) { $null } else { [string]$change.previousPath }
+        exclusionReason = 'no-target-catalog-match'
+      }) | Out-Null
+    $unmatchedViCount += 1
+    continue
+  }
+
+  $effectiveTargets = New-Object System.Collections.Generic.List[object]
+  foreach ($candidateTarget in $candidateTargets) {
+    $target = $candidateTarget.target
+    if ($allowedTargetIdSet.Count -gt 0 -and -not $allowedTargetIdSet.Contains([string]$target.targetId)) {
+      continue
+    }
+
+    $modeResolution = Resolve-RequestedModes -TargetPublicModes @($target.publicModes) -PolicyPublicModes @($prPolicy.execution.publicModes)
+    if (@($modeResolution.requestedModes).Count -eq 0) {
+      continue
+    }
+
+    $branchBudgetSourceBranchRef = if (-not [string]::IsNullOrWhiteSpace([string]$prPolicy.execution.history.branchBudget.sourceBranchRef)) {
+      [string]$prPolicy.execution.history.branchBudget.sourceBranchRef
+    } else {
+      Get-OptionalString -Value $target.history.branchBudget.sourceBranchRef
+    }
+    $branchBudgetMaxCommitCount = if ($null -ne $prPolicy.execution.history.branchBudget.maxCommitCount) {
+      [int]$prPolicy.execution.history.branchBudget.maxCommitCount
+    } else {
+      Get-OptionalInt -Value $target.history.branchBudget.maxCommitCount
+    }
+    $branchBudgetSource = if (-not [string]::IsNullOrWhiteSpace([string]$prPolicy.execution.history.branchBudget.sourceBranchRef) -or $null -ne $prPolicy.execution.history.branchBudget.maxCommitCount) {
+      'pr-policy'
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$target.history.branchBudget.sourceBranchRef) -or $null -ne $target.history.branchBudget.maxCommitCount) {
+      'target-catalog'
+    } else {
+      'none'
+    }
+
+    $entrySignature = '{0}|{1}|{2}|{3}' -f [string]$target.targetId, [string]$change.currentPath, [string]$change.previousPath, [string]$candidateTarget.matchKind
+    if (-not $matchedTargetSignatures.Add($entrySignature)) {
+      continue
+    }
+
+    $effectiveTargets.Add([pscustomobject][ordered]@{
+        targetId = [string]$target.targetId
+        targetPath = [string]$target.targetPath
+        publicModes = @($target.publicModes)
+        requestedModes = @($modeResolution.requestedModes)
+        requestedModeSource = [string]$modeResolution.source
+        history = [ordered]@{
+          branchBudget = [ordered]@{
+            sourceBranchRef = if ([string]::IsNullOrWhiteSpace($branchBudgetSourceBranchRef)) { $null } else { $branchBudgetSourceBranchRef }
+            maxCommitCount = if ($null -eq $branchBudgetMaxCommitCount) { $null } else { [int]$branchBudgetMaxCommitCount }
+            source = $branchBudgetSource
+          }
+        }
+        keepArtifactsOnNoDiff = [bool]$prPolicy.execution.history.keepArtifactsOnNoDiff
+        matchKind = [string]$candidateTarget.matchKind
+        currentPath = [string]$change.currentPath
+        previousPath = if ([string]::IsNullOrWhiteSpace([string]$change.previousPath)) { $null } else { [string]$change.previousPath }
+        changeStatus = [string]$change.status
+      }) | Out-Null
+  }
+
+  if ($effectiveTargets.Count -eq 0) {
+    $exclusionReason = if ($allowedTargetIdSet.Count -gt 0) {
+      'target-id-not-allowed'
+    } elseif ($prPolicy.execution.publicModes.Count -gt 0) {
+      'no-policy-allowed-public-modes'
+    } else {
+      'no-target-catalog-match'
+    }
+
+    $excludedViFiles.Add([pscustomobject][ordered]@{
+        status = [string]$change.status
+        currentPath = [string]$change.currentPath
+        previousPath = if ([string]::IsNullOrWhiteSpace([string]$change.previousPath)) { $null } else { [string]$change.previousPath }
+        exclusionReason = $exclusionReason
+      }) | Out-Null
+    $unmatchedViCount += 1
+    continue
+  }
+
+  foreach ($effectiveTarget in $effectiveTargets) {
+    $matchedTargets.Add($effectiveTarget) | Out-Null
+  }
 }
 
 $changedViArray = @(
@@ -330,17 +747,36 @@ $changedViArray = @(
 )
 $matchedTargetArray = @(
   $matchedTargets |
-    Sort-Object { [string]$_.targetPath }, { [string]$_.targetId } |
+    Sort-Object { [string]$_.targetPath }, { [string]$_.targetId }, { [string]$_.currentPath }, { [string]$_.previousPath } |
     ForEach-Object { $_ }
 )
+$excludedViArray = @(
+  $excludedViFiles |
+    Sort-Object { [string]$_.currentPath }, { [string]$_.previousPath }, { [string]$_.exclusionReason }, { [string]$_.status } |
+    ForEach-Object { $_ }
+)
+
+if ($executionStatus -eq 'ready' -and $null -ne $prPolicy.discovery.maxChangedViCount -and $policyEligibleChangedViCount -gt [int]$prPolicy.discovery.maxChangedViCount) {
+  $executionStatus = 'blocked'
+  $executionReason = 'max-changed-vi-count-exceeded'
+}
+if ($executionStatus -eq 'ready' -and $prPolicy.discovery.unmatchedChangedViBehavior -eq 'block' -and $unmatchedViCount -gt 0) {
+  $executionStatus = 'blocked'
+  $executionReason = 'unmatched-changed-vi-detected'
+}
 
 if ($executionStatus -eq 'ready') {
   if ($changedViArray.Count -eq 0) {
     $executionStatus = 'skipped'
     $executionReason = 'no-vi-files-changed'
   } elseif ($matchedTargetArray.Count -eq 0) {
-    $executionStatus = 'skipped'
-    $executionReason = 'no-target-catalog-matches'
+    if ($policyEligibleChangedViCount -eq 0) {
+      $executionStatus = 'skipped'
+      $executionReason = 'no-policy-eligible-vi-files'
+    } else {
+      $executionStatus = 'skipped'
+      $executionReason = 'no-target-catalog-matches'
+    }
   }
 }
 
@@ -353,6 +789,7 @@ $receipt = [ordered]@{
     schema = 'comparevi-history/consumer-targets@v1'
     path = $targetSpecPathResolved
   }
+  prPolicy = $prPolicy
   pullRequest = [ordered]@{
     number = $pullRequestNumber
     htmlUrl = $pullRequestUrl
@@ -366,23 +803,32 @@ $receipt = [ordered]@{
     changedFileCount = $reportedChangedFileCount
   }
   changedViFiles = @($changedViArray)
+  excludedViFiles = @($excludedViArray)
   matchedTargets = @($matchedTargetArray)
   summary = [ordered]@{
     executionStatus = $executionStatus
     executionReason = $executionReason
     changedViCount = $changedViArray.Count
+    eligibleChangedViCount = $policyEligibleChangedViCount
+    excludedViCount = $excludedViArray.Count
+    unmatchedViCount = $unmatchedViCount
     matchedTargetCount = $matchedTargetArray.Count
   }
 }
 
-$receipt | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $receiptPath -Encoding utf8
+$receipt | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $receiptPath -Encoding utf8
 
 Write-ActionOutput -Key 'changed-vi-discovery-path' -Value $receiptPath
+Write-ActionOutput -Key 'pr-policy-path' -Value $(if ([string]::IsNullOrWhiteSpace([string]$prPolicy.path)) { '' } else { [string]$prPolicy.path })
+Write-ActionOutput -Key 'pr-policy-applied' -Value ($prPolicy.applied.ToString().ToLowerInvariant())
 Write-ActionOutput -Key 'changed-vi-count' -Value ([string]$changedViArray.Count)
+Write-ActionOutput -Key 'eligible-changed-vi-count' -Value ([string]$policyEligibleChangedViCount)
+Write-ActionOutput -Key 'excluded-vi-count' -Value ([string]$excludedViArray.Count)
+Write-ActionOutput -Key 'unmatched-vi-count' -Value ([string]$unmatchedViCount)
 Write-ActionOutput -Key 'matched-target-count' -Value ([string]$matchedTargetArray.Count)
 Write-ActionOutput -Key 'execution-status' -Value $executionStatus
 Write-ActionOutput -Key 'execution-reason' -Value $executionReason
-Write-ActionOutput -Key 'matched-targets-json' -Value (($matchedTargetArray | ConvertTo-Json -Depth 20 -Compress))
+Write-ActionOutput -Key 'matched-targets-json' -Value (($matchedTargetArray | ConvertTo-Json -Depth 32 -Compress))
 Write-ActionOutput -Key 'base-repo' -Value $baseRepository
 Write-ActionOutput -Key 'base-ref' -Value $baseRef
 Write-ActionOutput -Key 'base-sha' -Value $baseSha
@@ -399,8 +845,13 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ('- Pull request: `#{0}`' -f $pullRequestNumber)
     ('- Base repository: `{0}`' -f $baseRepository)
     ('- Head repository: `{0}`' -f $headRepository)
+    ('- PR policy: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$prPolicy.path)) { 'platform defaults' } else { [string]$prPolicy.path }))
+    ('- PR policy applied: `{0}`' -f $prPolicy.applied.ToString().ToLowerInvariant())
     ('- Fork PR: `{0}`' -f $isFork.ToString().ToLowerInvariant())
     ('- Changed VI count: `{0}`' -f $changedViArray.Count)
+    ('- Policy-eligible changed VI count: `{0}`' -f $policyEligibleChangedViCount)
+    ('- Excluded VI count: `{0}`' -f $excludedViArray.Count)
+    ('- Unmatched VI count: `{0}`' -f $unmatchedViCount)
     ('- Matched target count: `{0}`' -f $matchedTargetArray.Count)
     ('- Execution status: `{0}`' -f $executionStatus)
     ('- Execution reason: `{0}`' -f $executionReason)
@@ -408,4 +859,4 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
   ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
 }
 
-$receipt | ConvertTo-Json -Depth 20
+$receipt | ConvertTo-Json -Depth 32

--- a/scripts/Write-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestRun.ps1
@@ -74,6 +74,59 @@ function Get-OptionalString {
   return $stringValue.Trim()
 }
 
+function Get-NestedValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+    [AllowNull()]
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function ConvertTo-ObjectArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable]) {
+    return @($Value)
+  }
+
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($item in ([System.Collections.IEnumerable]$Value)) {
+    $items.Add($item) | Out-Null
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
 $basePath = (Get-Location).Path
 $discoveryPathResolved = Resolve-AbsolutePath -Path $DiscoveryPath -BasePath $basePath
 $resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
@@ -98,10 +151,20 @@ if ($null -ne $targetRunsManifestPathResolved -and (Test-Path -LiteralPath $targ
   $targetManifest = Read-JsonFile -Path $targetRunsManifestPathResolved
 }
 
+$policy = Get-NestedValue -Object $discovery -Path @('prPolicy')
+$emitCommentBody = [bool](Get-NestedValue -Object $policy -Path @('reviewerSurface', 'emitCommentBody') -Default $true)
+$emitStepSummary = [bool](Get-NestedValue -Object $policy -Path @('reviewerSurface', 'emitStepSummary') -Default $true)
+$policyPath = Get-OptionalString -Value (Get-NestedValue -Object $policy -Path @('path'))
+$policyApplied = [bool](Get-NestedValue -Object $policy -Path @('applied') -Default $false)
+
 $discoveryStatus = [string]$discovery.summary.executionStatus
 $discoveryReason = [string]$discovery.summary.executionReason
 $changedViCount = [int]$discovery.summary.changedViCount
+$eligibleChangedViCount = if ($null -eq $discovery.summary.eligibleChangedViCount) { $changedViCount } else { [int]$discovery.summary.eligibleChangedViCount }
+$excludedViCount = if ($null -eq $discovery.summary.excludedViCount) { 0 } else { [int]$discovery.summary.excludedViCount }
+$unmatchedViCount = if ($null -eq $discovery.summary.unmatchedViCount) { 0 } else { [int]$discovery.summary.unmatchedViCount }
 $matchedTargetCount = [int]$discovery.summary.matchedTargetCount
+$excludedViFiles = @($discovery.excludedViFiles | ForEach-Object { $_ })
 
 $targets = @()
 $executedTargetCount = 0
@@ -147,7 +210,12 @@ $commentLines.Add('## comparevi-history PR diagnostics') | Out-Null
 $commentLines.Add('') | Out-Null
 $commentLines.Add(('- Final status: `{0}`' -f $finalStatus)) | Out-Null
 $commentLines.Add(('- Final reason: `{0}`' -f $finalReason)) | Out-Null
+$commentLines.Add(('- PR policy: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace($policyPath)) { 'platform defaults' } else { $policyPath }))) | Out-Null
+$commentLines.Add(('- PR policy applied: `{0}`' -f $policyApplied.ToString().ToLowerInvariant())) | Out-Null
 $commentLines.Add(('- Changed VIs: `{0}`' -f $changedViCount)) | Out-Null
+$commentLines.Add(('- Policy-eligible changed VIs: `{0}`' -f $eligibleChangedViCount)) | Out-Null
+$commentLines.Add(('- Excluded changed VIs: `{0}`' -f $excludedViCount)) | Out-Null
+$commentLines.Add(('- Unmatched changed VIs: `{0}`' -f $unmatchedViCount)) | Out-Null
 $commentLines.Add(('- Matched catalog targets: `{0}`' -f $matchedTargetCount)) | Out-Null
 $commentLines.Add(('- Executed targets: `{0}`' -f $executedTargetCount)) | Out-Null
 $commentLines.Add(('- Failed targets: `{0}`' -f $failedTargetCount)) | Out-Null
@@ -163,13 +231,27 @@ if (@($discovery.changedViFiles).Count -gt 0) {
   $commentLines.Add('') | Out-Null
 }
 
+if (@($excludedViFiles).Count -gt 0) {
+  $commentLines.Add('### Excluded VI files') | Out-Null
+  foreach ($excluded in @($excludedViFiles)) {
+    $commentLines.Add(('- `{0}` ({1}) reason=`{2}`' -f [string]$excluded.currentPath, [string]$excluded.status, [string]$excluded.exclusionReason)) | Out-Null
+  }
+  $commentLines.Add('') | Out-Null
+}
+
 if (@($targets).Count -gt 0) {
   $commentLines.Add('### Target results') | Out-Null
   $commentLines.Add('') | Out-Null
-  $commentLines.Add('| Target | Status | Reason |') | Out-Null
-  $commentLines.Add('| --- | --- | --- |') | Out-Null
+  $commentLines.Add('| Target | Requested modes | Status | Reason |') | Out-Null
+  $commentLines.Add('| --- | --- | --- | --- |') | Out-Null
   foreach ($target in @($targets)) {
-    $commentLines.Add(('| `{0}` | `{1}` | `{2}` |' -f [string]$target.targetPath, [string]$target.finalStatus, [string]$target.finalReason)) | Out-Null
+    $requestedModes = @(
+      @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $target -Path @('requestedModes'))) |
+        ForEach-Object { Get-OptionalString -Value $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    $requestedModeLabel = if ($requestedModes.Count -eq 0) { 'n/a' } else { $requestedModes -join ', ' }
+    $commentLines.Add(('| `{0}` | `{1}` | `{2}` | `{3}` |' -f [string]$target.targetPath, $requestedModeLabel, [string]$target.finalStatus, [string]$target.finalReason)) | Out-Null
   }
   $commentLines.Add('') | Out-Null
 } else {
@@ -180,7 +262,9 @@ if (@($targets).Count -gt 0) {
 
 $commentLines.Add('Artifacts in this run contain the discovery receipt, per-target public run receipts, shared evidence receipts, and reviewer-facing markdown/html surfaces.') | Out-Null
 $commentBody = $commentLines -join "`n"
-$commentBody | Set-Content -LiteralPath $publicCommentPath -Encoding utf8
+if ($emitCommentBody) {
+  $commentBody | Set-Content -LiteralPath $publicCommentPath -Encoding utf8
+}
 
 $stepSummaryLines = New-Object System.Collections.Generic.List[string]
 $stepSummaryLines.Add('## comparevi-history pull request run') | Out-Null
@@ -189,21 +273,34 @@ $stepSummaryLines.Add(('- Final status: `{0}`' -f $finalStatus)) | Out-Null
 $stepSummaryLines.Add(('- Final reason: `{0}`' -f $finalReason)) | Out-Null
 $stepSummaryLines.Add(('- Discovery receipt: `{0}`' -f $discoveryPathResolved)) | Out-Null
 $stepSummaryLines.Add(('- Aggregate receipt: `{0}`' -f $prRunPath)) | Out-Null
-$stepSummaryLines.Add(('- Public comment body: `{0}`' -f $publicCommentPath)) | Out-Null
-$stepSummaryLines.Add(('- Public step summary: `{0}`' -f $publicStepSummaryPath)) | Out-Null
+$stepSummaryLines.Add(('- Public comment body enabled: `{0}`' -f $emitCommentBody.ToString().ToLowerInvariant())) | Out-Null
+$stepSummaryLines.Add(('- Public step summary enabled: `{0}`' -f $emitStepSummary.ToString().ToLowerInvariant())) | Out-Null
+$stepSummaryLines.Add(('- Public comment body: `{0}`' -f $(if ($emitCommentBody) { $publicCommentPath } else { 'disabled-by-pr-policy' }))) | Out-Null
+$stepSummaryLines.Add(('- Public step summary: `{0}`' -f $(if ($emitStepSummary) { $publicStepSummaryPath } else { 'disabled-by-pr-policy' }))) | Out-Null
 if ($null -ne $targetManifest) {
   $stepSummaryLines.Add(('- Target runs manifest: `{0}`' -f $targetRunsManifestPathResolved)) | Out-Null
 }
 $stepSummaryLines.Add('') | Out-Null
 $stepSummaryLines.Add($commentBody) | Out-Null
 $stepSummaryContent = $stepSummaryLines -join "`n"
-$stepSummaryContent | Set-Content -LiteralPath $publicStepSummaryPath -Encoding utf8
+if ($emitStepSummary) {
+  $stepSummaryContent | Set-Content -LiteralPath $publicStepSummaryPath -Encoding utf8
+}
 
 $receiptTargets = New-Object System.Collections.Generic.List[object]
 foreach ($target in @($targets)) {
   $receiptTargets.Add([ordered]@{
       targetId = [string]$target.targetId
       targetPath = [string]$target.targetPath
+      requestedModes = @(
+        @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $target -Path @('requestedModes'))) |
+          ForEach-Object { Get-OptionalString -Value $_ } |
+          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+      )
+      requestedModeSource = Get-OptionalString -Value (Get-NestedValue -Object $target -Path @('requestedModeSource'))
+      sourceBranchRef = Get-OptionalString -Value (Get-NestedValue -Object $target -Path @('sourceBranchRef'))
+      maxBranchCommits = if ($null -eq (Get-NestedValue -Object $target -Path @('maxBranchCommits'))) { $null } else { [int](Get-NestedValue -Object $target -Path @('maxBranchCommits')) }
+      keepArtifactsOnNoDiff = [bool](Get-NestedValue -Object $target -Path @('keepArtifactsOnNoDiff') -Default $false)
       matchKind = Get-OptionalString -Value $target.matchKind
       finalStatus = [string]$target.finalStatus
       finalReason = [string]$target.finalReason
@@ -228,44 +325,52 @@ $receipt = [ordered]@{
     headSha = [string]$discovery.pullRequest.headSha
     isFork = [bool]$discovery.pullRequest.isFork
   }
+  prPolicy = $policy
   discovery = [ordered]@{
     schema = 'comparevi-history/changed-vi-discovery@v1'
     path = $discoveryPathResolved
     status = $discoveryStatus
     reason = $discoveryReason
     changedViCount = $changedViCount
+    eligibleChangedViCount = $eligibleChangedViCount
+    excludedViCount = $excludedViCount
+    unmatchedViCount = $unmatchedViCount
     matchedTargetCount = $matchedTargetCount
   }
   outputs = [ordered]@{
     resultsDir = $resultsDirResolved
     prRunPath = $prRunPath
-    publicCommentPath = $publicCommentPath
-    publicStepSummaryPath = $publicStepSummaryPath
+    publicCommentPath = if ($emitCommentBody) { $publicCommentPath } else { $null }
+    publicStepSummaryPath = if ($emitStepSummary) { $publicStepSummaryPath } else { $null }
     targetRunsManifestPath = if ($null -eq $targetManifest) { $null } else { $targetRunsManifestPathResolved }
   }
   summary = [ordered]@{
     finalStatus = $finalStatus
     finalReason = $finalReason
     changedViCount = $changedViCount
+    eligibleChangedViCount = $eligibleChangedViCount
+    excludedViCount = $excludedViCount
+    unmatchedViCount = $unmatchedViCount
     matchedTargetCount = $matchedTargetCount
     executedTargetCount = $executedTargetCount
     failedTargetCount = $failedTargetCount
     totalProcessed = $totalProcessed
     totalDiffs = $totalDiffs
   }
+  excludedViFiles = @($excludedViFiles | ForEach-Object { $_ })
   targets = @($receiptTargets | ForEach-Object { $_ })
 }
 
 $receipt | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $prRunPath -Encoding utf8
 
 Write-ActionOutput -Key 'pr-run-path' -Value $prRunPath
-Write-ActionOutput -Key 'public-comment-path' -Value $publicCommentPath
-Write-ActionOutput -Key 'public-step-summary-path' -Value $publicStepSummaryPath
+Write-ActionOutput -Key 'public-comment-path' -Value $(if ($emitCommentBody) { $publicCommentPath } else { '' })
+Write-ActionOutput -Key 'public-step-summary-path' -Value $(if ($emitStepSummary) { $publicStepSummaryPath } else { '' })
 Write-ActionOutput -Key 'results-dir' -Value $resultsDirResolved
 Write-ActionOutput -Key 'final-status' -Value $finalStatus
 Write-ActionOutput -Key 'final-reason' -Value $finalReason
 
-if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath) -and $emitStepSummary) {
   $stepSummaryContent | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
 }
 


### PR DESCRIPTION
## Summary
- add the additive `comparevi-history/pr-policy@v1` schema and checked-in example policy file
- teach pull-request discovery and orchestration to consume PR policy filters, allowlists, execution defaults, and reviewer-surface toggles
- extend discovery and PR aggregate receipts so consumers get stable policy-aware machine-readable outputs

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #96
