### PR TITLE
#98 Add trusted fork fallback for PR diagnostics

### DIFF
--- a/.github/workflows/pull-request-diagnostics.yml
+++ b/.github/workflows/pull-request-diagnostics.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: ''
         type: string
+      allow_trusted_fork_execution:
+        description: Allow a maintainer-triggered run to execute against a fork head when the checked-in PR policy permits it.
+        required: false
+        default: false
+        type: boolean
       results_dir:
         description: Workflow-owned results root for aggregate PR diagnostics receipts and per-target runs.
         required: false
@@ -141,6 +146,7 @@ jobs:
             -Repository '${{ steps.defaults.outputs.consumer_repository }}' `
             -TargetSpecPath (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.target_spec_path }}') `
             -PrPolicyPath $(if ([string]::IsNullOrWhiteSpace('${{ inputs.pr_policy_path }}')) { '' } else { (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.pr_policy_path }}') }) `
+            -AllowTrustedForkExecution:('${{ inputs.allow_trusted_fork_execution }}' -eq 'true') `
             -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
             -GitHubToken $env:GITHUB_TOKEN `
             -GitHubOutputPath $env:GITHUB_OUTPUT `

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ The current first slice stays intentionally narrow:
 - only PR-policy-eligible catalog targets whose `path` matches a changed `.vi` path are executed
 - same-repo pull requests can auto-run immediately
 - cross-repository and fork pull requests fail closed by producing a blocked discovery receipt instead of executing the
-  backend
+  backend unless a maintainer-triggered caller explicitly sets `allow_trusted_fork_execution: true` and the checked-in
+  PR policy allows `trust.forkBehavior = maintainer-dispatch`
 - each matched target reuses the existing `request.json`, `public-run.json`, `shared-evidence.json`, and reviewer
   artifact path without inventing a second backend execution contract
 - the workflow aggregates those per-target runs into `pr-run.json`, `pr-comment.md`, and `pr-step-summary.md`
@@ -342,7 +343,7 @@ Automatic PR diagnostics consumers should also check in a PR policy using `compa
 - public mode narrowing for reviewer surfaces
 - branch-budget defaults and no-diff artifact policy
 - reviewer comment and step-summary emission toggles
-- trust defaults for fork PR blocking
+- trust defaults for fork PR blocking or maintainer-dispatched fallback eligibility
 
 ## Trust boundaries
 

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -78,7 +78,9 @@ Consumer repositories should not contain:
   there because the event does not prove a trusted runner or trusted refs.
 - Do not expect the automatic PR discovery template to execute on fork or other cross-repository PR heads. In this
   slice it should produce a blocked discovery receipt and leave trusted execution to the maintainer-dispatched or
-  comment-gated paths.
+  comment-gated paths. The reusable workflow only permits that fallback when the checked-in PR policy allows
+  `trust.forkBehavior = maintainer-dispatch` and the trusted caller explicitly passes `allow_trusted_fork_execution:
+  true`.
 - Do not use `pull_request_target` to run the action automatically against fork content with write-scoped tokens or
   secrets. That crosses the trust boundary the guard is designed to enforce.
 - Do not pin consumer workflows to branch refs such as `@main`, `@develop`, or unpublished SHAs. Use released facade

--- a/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
+++ b/docs/schemas/comparevi-history-changed-vi-discovery-v1.schema.json
@@ -11,6 +11,7 @@
     "eventName",
     "targetCatalog",
     "prPolicy",
+    "executionContext",
     "pullRequest",
     "changedViFiles",
     "excludedViFiles",
@@ -207,10 +208,31 @@
             "forkBehavior": {
               "type": "string",
               "enum": [
-                "block"
+                "block",
+                "maintainer-dispatch"
               ]
             }
           }
+        }
+      }
+    },
+    "executionContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustedForkExecutionRequested",
+        "trustedForkExecutionEligible",
+        "trustedForkExecutionApplied"
+      ],
+      "properties": {
+        "trustedForkExecutionRequested": {
+          "type": "boolean"
+        },
+        "trustedForkExecutionEligible": {
+          "type": "boolean"
+        },
+        "trustedForkExecutionApplied": {
+          "type": "boolean"
         }
       }
     },

--- a/docs/schemas/comparevi-history-pr-policy-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-policy-v1.schema.json
@@ -113,7 +113,8 @@
         "forkBehavior": {
           "type": "string",
           "enum": [
-            "block"
+            "block",
+            "maintainer-dispatch"
           ]
         }
       }

--- a/docs/schemas/comparevi-history-pr-run-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-run-v1.schema.json
@@ -9,6 +9,7 @@
     "generatedAtUtc",
     "pullRequest",
     "prPolicy",
+    "executionContext",
     "discovery",
     "outputs",
     "summary",
@@ -124,6 +125,26 @@
         },
         "trust": {
           "type": "object"
+        }
+      }
+    },
+    "executionContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trustedForkExecutionRequested",
+        "trustedForkExecutionEligible",
+        "trustedForkExecutionApplied"
+      ],
+      "properties": {
+        "trustedForkExecutionRequested": {
+          "type": "boolean"
+        },
+        "trustedForkExecutionEligible": {
+          "type": "boolean"
+        },
+        "trustedForkExecutionApplied": {
+          "type": "boolean"
         }
       }
     },

--- a/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1
@@ -171,6 +171,11 @@ try {
   if ($receipt.matchedTargets[0].keepArtifactsOnNoDiff -ne $true) {
     throw 'PR policy keepArtifactsOnNoDiff was not surfaced.'
   }
+  if ($receipt.executionContext.trustedForkExecutionRequested -ne $false -or
+    $receipt.executionContext.trustedForkExecutionEligible -ne $false -or
+    $receipt.executionContext.trustedForkExecutionApplied -ne $false) {
+    throw 'Same-repo discovery should not mark trusted fork execution state.'
+  }
   if (-not ($receipt.excludedViFiles | Where-Object { $_.currentPath -eq 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' -and $_.exclusionReason -eq 'target-id-not-allowed' })) {
     throw 'Expected target-id exclusion for the pre-install VI.'
   }
@@ -257,6 +262,61 @@ try {
   }
   if ($forkReceipt.summary.executionReason -ne 'untrusted-cross-repository-pull-request') {
     throw 'Fork pull request block reason mismatch.'
+  }
+
+  $maintainerForkPolicyPath = Join-Path $tempRoot 'maintainer-fork-pr-policy.json'
+  @"
+{
+  "schema": "comparevi-history/pr-policy@v1",
+  "discovery": {
+    "includePaths": [
+      "Tooling/deployment/**/*.vi"
+    ]
+  },
+  "trust": {
+    "forkBehavior": "maintainer-dispatch"
+  }
+}
+"@ | Set-Content -LiteralPath $maintainerForkPolicyPath -Encoding utf8
+
+  $fallbackRequiredJson = & $scriptPath `
+    -EventName 'pull_request_target' `
+    -EventPath $forkEventPath `
+    -TargetSpecPath $targetSpecPath `
+    -PrPolicyPath $maintainerForkPolicyPath `
+    -ResultsDir (Join-Path $tempRoot 'fallback-required-results') `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -FilesPayloadPath $filesPayloadPath
+  $fallbackRequiredReceipt = $fallbackRequiredJson | ConvertFrom-Json -Depth 64
+  if ($fallbackRequiredReceipt.summary.executionStatus -ne 'blocked') {
+    throw 'Fork PR should stay blocked until trusted fallback is explicitly requested.'
+  }
+  if ($fallbackRequiredReceipt.summary.executionReason -ne 'trusted-fork-fallback-required') {
+    throw 'Trusted fork fallback block reason mismatch.'
+  }
+  if ($fallbackRequiredReceipt.executionContext.trustedForkExecutionEligible -ne $true -or
+    $fallbackRequiredReceipt.executionContext.trustedForkExecutionRequested -ne $false -or
+    $fallbackRequiredReceipt.executionContext.trustedForkExecutionApplied -ne $false) {
+    throw 'Fallback-required discovery execution context mismatch.'
+  }
+
+  $fallbackAppliedJson = & $scriptPath `
+    -EventName 'pull_request_target' `
+    -EventPath $forkEventPath `
+    -TargetSpecPath $targetSpecPath `
+    -PrPolicyPath $maintainerForkPolicyPath `
+    -AllowTrustedForkExecution $true `
+    -ResultsDir (Join-Path $tempRoot 'fallback-applied-results') `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -FilesPayloadPath $filesPayloadPath
+  $fallbackAppliedReceipt = $fallbackAppliedJson | ConvertFrom-Json -Depth 64
+  if ($fallbackAppliedReceipt.summary.executionStatus -ne 'ready') {
+    throw 'Trusted fallback should allow the fork PR discovery to proceed.'
+  }
+  if ($fallbackAppliedReceipt.executionContext.trustedForkExecutionEligible -ne $true -or
+    $fallbackAppliedReceipt.executionContext.trustedForkExecutionRequested -ne $true -or
+    $fallbackAppliedReceipt.executionContext.trustedForkExecutionApplied -ne $true) {
+    throw 'Trusted fallback applied execution context mismatch.'
   }
 } finally {
   Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/Test-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestRun.ps1
@@ -49,6 +49,11 @@ try {
       "forkBehavior": "block"
     }
   },
+  "executionContext": {
+    "trustedForkExecutionRequested": false,
+    "trustedForkExecutionEligible": false,
+    "trustedForkExecutionApplied": false
+  },
   "pullRequest": {
     "number": 22,
     "htmlUrl": "https://github.com/example/repo/pull/22",
@@ -177,6 +182,9 @@ try {
   if ($receipt.targets[0].keepArtifactsOnNoDiff -ne $true) {
     throw 'PR run receipt did not retain keep-artifacts policy.'
   }
+  if ($receipt.executionContext.trustedForkExecutionApplied -ne $false) {
+    throw 'Same-repo PR run should not mark trusted fork execution as applied.'
+  }
   if (($receipt.targets[0].requestedModes -join ',') -ne 'attributes,front-panel') {
     throw 'PR run receipt did not preserve requested modes.'
   }
@@ -233,6 +241,11 @@ try {
       "forkBehavior": "block"
     }
   },
+  "executionContext": {
+    "trustedForkExecutionRequested": false,
+    "trustedForkExecutionEligible": true,
+    "trustedForkExecutionApplied": false
+  },
   "pullRequest": {
     "number": 23,
     "htmlUrl": null,
@@ -250,7 +263,7 @@ try {
   "matchedTargets": [],
   "summary": {
     "executionStatus": "blocked",
-    "executionReason": "untrusted-cross-repository-pull-request",
+    "executionReason": "trusted-fork-fallback-required",
     "changedViCount": 0,
     "eligibleChangedViCount": 0,
     "excludedViCount": 0,
@@ -266,6 +279,10 @@ try {
   $blockedReceipt = $blockedReceiptJson | ConvertFrom-Json -Depth 64
   if ($blockedReceipt.summary.finalStatus -ne 'blocked') {
     throw 'Blocked discovery should remain blocked in PR run receipt.'
+  }
+  if ($blockedReceipt.executionContext.trustedForkExecutionEligible -ne $true -or
+    $blockedReceipt.executionContext.trustedForkExecutionApplied -ne $false) {
+    throw 'Blocked PR run should preserve trusted fork fallback state.'
   }
 } finally {
   Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -159,6 +159,7 @@ Assert-Match -Content $manualExplorationWorkflow -Pattern "steps\.exploration\.o
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*workflow_call:\s*$' -Message 'Pull request workflow must be reusable.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*target_spec_path:\s*$' -Message 'Pull request workflow must accept target_spec_path.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*pr_policy_path:\s*$' -Message 'Pull request workflow must accept pr_policy_path.'
+Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*allow_trusted_fork_execution:\s*$' -Message 'Pull request workflow must accept allow_trusted_fork_execution for maintainer-triggered fork fallback.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*default:\s+\.github/comparevi-history-targets\.json\s*$' -Message 'Pull request workflow must default to the checked-in target catalog path.'
 Assert-Match -Content $pullRequestWorkflow -Pattern '(?m)^\s*COMPAREVI_NI_LINUX_IMAGE:\s+nationalinstruments/labview:2026q1-linux\s*$' -Message 'Pull request workflow must pin the NI Linux image.'
 Assert-Match -Content $pullRequestWorkflow -Pattern 'Write-CompareVIHistoryPullRequestDiscovery\.ps1' -Message 'Pull request workflow must discover changed VI targets.'

--- a/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1
@@ -6,6 +6,7 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$TargetSpecPath,
   [string]$PrPolicyPath,
+  [bool]$AllowTrustedForkExecution = $false,
   [Parameter(Mandatory = $true)]
   [string]$ResultsDir,
   [string]$Repository,
@@ -415,6 +416,14 @@ function Resolve-PrPolicy {
   $branchBudget = Get-NestedValue -Object $history -Path @('branchBudget')
   $reviewerSurface = Get-NestedValue -Object $rawPolicy -Path @('reviewerSurface')
   $trust = Get-NestedValue -Object $rawPolicy -Path @('trust')
+  $forkBehavior = if ([string]::IsNullOrWhiteSpace([string](Get-NestedValue -Object $trust -Path @('forkBehavior')))) {
+    'block'
+  } else {
+    [string](Get-NestedValue -Object $trust -Path @('forkBehavior'))
+  }
+  if ($forkBehavior -notin @('block', 'maintainer-dispatch')) {
+    throw "PR policy trust.forkBehavior must be 'block' or 'maintainer-dispatch'. Actual: $forkBehavior"
+  }
 
   return [ordered]@{
     schema = 'comparevi-history/pr-policy@v1'
@@ -450,11 +459,7 @@ function Resolve-PrPolicy {
       emitStepSummary = [bool](Get-NestedValue -Object $reviewerSurface -Path @('emitStepSummary') -Default $true)
     }
     trust = [ordered]@{
-      forkBehavior = if ([string]::IsNullOrWhiteSpace([string](Get-NestedValue -Object $trust -Path @('forkBehavior')))) {
-        'block'
-      } else {
-        [string](Get-NestedValue -Object $trust -Path @('forkBehavior'))
-      }
+      forkBehavior = $forkBehavior
     }
   }
 }
@@ -546,9 +551,19 @@ $repositorySlug = if (-not [string]::IsNullOrWhiteSpace($Repository)) {
 
 $executionStatus = 'ready'
 $executionReason = 'matched-targets'
-if ($isFork -and $prPolicy.trust.forkBehavior -eq 'block') {
-  $executionStatus = 'blocked'
-  $executionReason = 'untrusted-cross-repository-pull-request'
+$trustedForkExecutionEligible = $isFork -and $prPolicy.trust.forkBehavior -eq 'maintainer-dispatch'
+$trustedForkExecutionApplied = $trustedForkExecutionEligible -and $AllowTrustedForkExecution
+if ($isFork) {
+  if ($trustedForkExecutionApplied) {
+    $executionStatus = 'ready'
+    $executionReason = 'matched-targets'
+  } elseif ($trustedForkExecutionEligible) {
+    $executionStatus = 'blocked'
+    $executionReason = 'trusted-fork-fallback-required'
+  } else {
+    $executionStatus = 'blocked'
+    $executionReason = 'untrusted-cross-repository-pull-request'
+  }
 } elseif ($reportedChangedFileCount -gt 3000) {
   $executionStatus = 'blocked'
   $executionReason = 'pr-files-api-limit-exceeded'
@@ -790,6 +805,11 @@ $receipt = [ordered]@{
     path = $targetSpecPathResolved
   }
   prPolicy = $prPolicy
+  executionContext = [ordered]@{
+    trustedForkExecutionRequested = [bool]$AllowTrustedForkExecution
+    trustedForkExecutionEligible = [bool]$trustedForkExecutionEligible
+    trustedForkExecutionApplied = [bool]$trustedForkExecutionApplied
+  }
   pullRequest = [ordered]@{
     number = $pullRequestNumber
     htmlUrl = $pullRequestUrl
@@ -821,6 +841,9 @@ $receipt | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $receiptPath -Enc
 Write-ActionOutput -Key 'changed-vi-discovery-path' -Value $receiptPath
 Write-ActionOutput -Key 'pr-policy-path' -Value $(if ([string]::IsNullOrWhiteSpace([string]$prPolicy.path)) { '' } else { [string]$prPolicy.path })
 Write-ActionOutput -Key 'pr-policy-applied' -Value ($prPolicy.applied.ToString().ToLowerInvariant())
+Write-ActionOutput -Key 'trusted-fork-execution-requested' -Value ($AllowTrustedForkExecution.ToString().ToLowerInvariant())
+Write-ActionOutput -Key 'trusted-fork-execution-eligible' -Value ($trustedForkExecutionEligible.ToString().ToLowerInvariant())
+Write-ActionOutput -Key 'trusted-fork-execution-applied' -Value ($trustedForkExecutionApplied.ToString().ToLowerInvariant())
 Write-ActionOutput -Key 'changed-vi-count' -Value ([string]$changedViArray.Count)
 Write-ActionOutput -Key 'eligible-changed-vi-count' -Value ([string]$policyEligibleChangedViCount)
 Write-ActionOutput -Key 'excluded-vi-count' -Value ([string]$excludedViArray.Count)
@@ -848,6 +871,9 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ('- PR policy: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$prPolicy.path)) { 'platform defaults' } else { [string]$prPolicy.path }))
     ('- PR policy applied: `{0}`' -f $prPolicy.applied.ToString().ToLowerInvariant())
     ('- Fork PR: `{0}`' -f $isFork.ToString().ToLowerInvariant())
+    ('- Trusted fork execution requested: `{0}`' -f $AllowTrustedForkExecution.ToString().ToLowerInvariant())
+    ('- Trusted fork execution eligible: `{0}`' -f $trustedForkExecutionEligible.ToString().ToLowerInvariant())
+    ('- Trusted fork execution applied: `{0}`' -f $trustedForkExecutionApplied.ToString().ToLowerInvariant())
     ('- Changed VI count: `{0}`' -f $changedViArray.Count)
     ('- Policy-eligible changed VI count: `{0}`' -f $policyEligibleChangedViCount)
     ('- Excluded VI count: `{0}`' -f $excludedViArray.Count)

--- a/scripts/Write-CompareVIHistoryPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestRun.ps1
@@ -152,10 +152,14 @@ if ($null -ne $targetRunsManifestPathResolved -and (Test-Path -LiteralPath $targ
 }
 
 $policy = Get-NestedValue -Object $discovery -Path @('prPolicy')
+$discoveryExecutionContext = Get-NestedValue -Object $discovery -Path @('executionContext')
 $emitCommentBody = [bool](Get-NestedValue -Object $policy -Path @('reviewerSurface', 'emitCommentBody') -Default $true)
 $emitStepSummary = [bool](Get-NestedValue -Object $policy -Path @('reviewerSurface', 'emitStepSummary') -Default $true)
 $policyPath = Get-OptionalString -Value (Get-NestedValue -Object $policy -Path @('path'))
 $policyApplied = [bool](Get-NestedValue -Object $policy -Path @('applied') -Default $false)
+$trustedForkExecutionRequested = [bool](Get-NestedValue -Object $discoveryExecutionContext -Path @('trustedForkExecutionRequested') -Default $false)
+$trustedForkExecutionEligible = [bool](Get-NestedValue -Object $discoveryExecutionContext -Path @('trustedForkExecutionEligible') -Default $false)
+$trustedForkExecutionApplied = [bool](Get-NestedValue -Object $discoveryExecutionContext -Path @('trustedForkExecutionApplied') -Default $false)
 
 $discoveryStatus = [string]$discovery.summary.executionStatus
 $discoveryReason = [string]$discovery.summary.executionReason
@@ -212,6 +216,9 @@ $commentLines.Add(('- Final status: `{0}`' -f $finalStatus)) | Out-Null
 $commentLines.Add(('- Final reason: `{0}`' -f $finalReason)) | Out-Null
 $commentLines.Add(('- PR policy: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace($policyPath)) { 'platform defaults' } else { $policyPath }))) | Out-Null
 $commentLines.Add(('- PR policy applied: `{0}`' -f $policyApplied.ToString().ToLowerInvariant())) | Out-Null
+$commentLines.Add(('- Trusted fork execution requested: `{0}`' -f $trustedForkExecutionRequested.ToString().ToLowerInvariant())) | Out-Null
+$commentLines.Add(('- Trusted fork execution eligible: `{0}`' -f $trustedForkExecutionEligible.ToString().ToLowerInvariant())) | Out-Null
+$commentLines.Add(('- Trusted fork execution applied: `{0}`' -f $trustedForkExecutionApplied.ToString().ToLowerInvariant())) | Out-Null
 $commentLines.Add(('- Changed VIs: `{0}`' -f $changedViCount)) | Out-Null
 $commentLines.Add(('- Policy-eligible changed VIs: `{0}`' -f $eligibleChangedViCount)) | Out-Null
 $commentLines.Add(('- Excluded changed VIs: `{0}`' -f $excludedViCount)) | Out-Null
@@ -326,6 +333,11 @@ $receipt = [ordered]@{
     isFork = [bool]$discovery.pullRequest.isFork
   }
   prPolicy = $policy
+  executionContext = [ordered]@{
+    trustedForkExecutionRequested = $trustedForkExecutionRequested
+    trustedForkExecutionEligible = $trustedForkExecutionEligible
+    trustedForkExecutionApplied = $trustedForkExecutionApplied
+  }
   discovery = [ordered]@{
     schema = 'comparevi-history/changed-vi-discovery@v1'
     path = $discoveryPathResolved


### PR DESCRIPTION
## Summary
- add a maintainer-only trusted fork fallback input to the reusable PR diagnostics workflow
- extend discovery and aggregate PR receipts with explicit trusted fork execution context
- document and test the policy-gated `maintainer-dispatch` fork behavior end to end

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestDiscovery.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestDiagnostics.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #98
