### PR TITLE
#105 Add agent-canary evaluation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           set -euo pipefail
           ./actionlint -color
           ./actionlint -color \
+            docs/examples/comparevi-history-agent-canary-evaluate.yml \
             docs/examples/comparevi-history-pull-request-diagnostics.yml \
             docs/examples/comparevi-history-pull-request-diagnostics-auto.yml \
             docs/examples/comparevi-history-pull-request-diagnostics-publish.yml \
@@ -124,6 +125,7 @@ jobs:
             'scripts/Write-CompareVIHistoryDownstreamProcessorSummary.ps1',
             'scripts/Write-CompareVIHistoryPullRequestRun.ps1',
             'scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1',
+            'scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Write-CompareVIHistoryPublicRun.ps1',
             'scripts/Publish-CompareVIHistoryPullRequestComment.ps1',
             'scripts/Assert-CompareVIHistoryPublishedRun.ps1',
@@ -144,6 +146,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiscovery.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiagnostics.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
+            'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryTemplateContracts.ps1'
           )) {
@@ -201,6 +204,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiscovery.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiagnostics.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
+            'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryRequest.ps1',
             'scripts/Test-CompareVIHistoryRevisionCatalog.ps1',

--- a/.github/workflows/pull-request-diagnostics-canary-evaluate.yml
+++ b/.github/workflows/pull-request-diagnostics-canary-evaluate.yml
@@ -1,0 +1,145 @@
+name: pull-request-diagnostics-canary-evaluate
+
+on:
+  workflow_call:
+    inputs:
+      consumer_repository:
+        description: Consumer repository that owns the agent-canary policy and pull request.
+        required: false
+        type: string
+      workflow_run_id:
+        description: Completed publication workflow run id whose artifact contains pr-comment-publication.json.
+        required: true
+        type: string
+      artifact_name:
+        description: Optional publication artifact name override.
+        required: false
+        default: ''
+        type: string
+      canary_policy_path:
+        description: Trusted canary policy path resolved from the consumer repository checkout.
+        required: false
+        default: .github/comparevi-history-agent-canary.json
+        type: string
+      results_dir:
+        description: Workflow-owned results root for canary evaluation receipts.
+        required: false
+        default: tests/results/pr-diagnostics/canary
+        type: string
+      platform_ref:
+        description: comparevi-history ref to checkout for the platform scripts. Keep aligned with the workflow ref.
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pull-request-diagnostics-canary-evaluate-${{ github.repository }}-${{ inputs.workflow_run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pull-request-diagnostics-canary-evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      evaluation-path: ${{ steps.evaluate.outputs['evaluation-path'] }}
+      evaluation-status: ${{ steps.evaluate.outputs['evaluation-status'] }}
+      evaluation-reason: ${{ steps.evaluate.outputs['evaluation-reason'] }}
+      matched-policy: ${{ steps.evaluate.outputs['matched-policy'] }}
+      artifact-name: ${{ steps.evaluate.outputs['artifact-name'] }}
+    steps:
+      - name: Resolve workflow defaults
+        id: defaults
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $consumerRepository = '${{ inputs.consumer_repository }}'
+          if ([string]::IsNullOrWhiteSpace($consumerRepository)) {
+            $consumerRepository = $env:GITHUB_REPOSITORY
+          }
+
+          $platformRef = '${{ inputs.platform_ref }}'
+          if ([string]::IsNullOrWhiteSpace($platformRef)) {
+            if ($env:GITHUB_REPOSITORY -eq 'LabVIEW-Community-CI-CD/comparevi-history') {
+              $platformRef = $env:GITHUB_SHA
+            } else {
+              $platformRef = 'v1'
+            }
+          }
+
+          @(
+            "consumer_repository=$consumerRepository"
+            "platform_ref=$platformRef"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Resolve workflow results root
+        id: results_root
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $resultsRoot = if ([System.IO.Path]::IsPathRooted('${{ inputs.results_dir }}')) {
+            [System.IO.Path]::GetFullPath('${{ inputs.results_dir }}')
+          } else {
+            [System.IO.Path]::GetFullPath((Join-Path $env:GITHUB_WORKSPACE '${{ inputs.results_dir }}'))
+          }
+
+          New-Item -ItemType Directory -Path $resultsRoot -Force | Out-Null
+          "results-root=$resultsRoot" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout trusted consumer repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.defaults.outputs.consumer_repository }}
+          path: trusted-consumer
+          fetch-depth: 1
+
+      - name: Checkout comparevi-history platform repo
+        uses: actions/checkout@v5
+        with:
+          repository: LabVIEW-Community-CI-CD/comparevi-history
+          ref: ${{ steps.defaults.outputs.platform_ref }}
+          path: platform
+          fetch-depth: 1
+
+      - name: Evaluate agent canary publication
+        id: evaluate
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          & "$env:GITHUB_WORKSPACE/platform/scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1" `
+            -Repository '${{ steps.defaults.outputs.consumer_repository }}' `
+            -WorkflowRunId '${{ inputs.workflow_run_id }}' `
+            -ArtifactName '${{ inputs.artifact_name }}' `
+            -CanaryPolicyPath (Join-Path $env:GITHUB_WORKSPACE 'trusted-consumer' '${{ inputs.canary_policy_path }}') `
+            -ResultsDir '${{ steps.results_root.outputs['results-root'] }}' `
+            -GitHubToken $env:GITHUB_TOKEN `
+            -GitHubOutputPath $env:GITHUB_OUTPUT `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+      - name: Upload canary evaluation receipts
+        if: ${{ always() && steps.results_root.outputs['results-root'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-diagnostics-canary-${{ inputs.workflow_run_id }}
+          path: ${{ steps.results_root.outputs['results-root'] }}/**
+          if-no-files-found: error
+
+      - name: Fail closed on canary evaluation failure
+        if: ${{ always() && (steps.evaluate.outcome == 'failure' || steps.evaluate.outputs['evaluation-status'] == 'failed') }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          throw "comparevi-history agent canary evaluation failed closed with status '${{ steps.evaluate.outputs['evaluation-status'] }}' and reason '${{ steps.evaluate.outputs['evaluation-reason'] }}'. Review the uploaded evaluation receipts."

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Legacy direct invocation remains available for maintainers:
 - Emits `comparevi-history/pr-run@v2` as the aggregate pull-request diagnostics receipt for the dynamic changed-VI PR
   surface, including `selectedTargets`, artifact index paths, and sticky-comment publication inputs.
 - Emits `comparevi-history/pr-comment-publication@v1` as the `workflow_run` publication receipt for sticky PR comments.
+- Emits `comparevi-history/agent-canary-policy@v1` as the repo-owned governance contract for same-repo canary proof
+  lanes that exercise the PR diagnostics surface without touching production VIs.
+- Emits `comparevi-history/agent-canary-evaluation@v1` as the `workflow_run` evaluation receipt for agent-canary
+  publication proofs.
 - Renders reviewer-facing markdown from the bundled helper resolved through `tooling-path` instead of copied inline
   consumer scripts.
 - Verifies the downloaded bundle against the published release digest before extraction.
@@ -160,6 +164,10 @@ Automatic pull-request diagnostics workflows emit additive PR-scope receipts alo
 - `pr-comment.md`
 - `pr-step-summary.md`
 
+Agent-canary proof workflows emit one additive publication-evaluation receipt alongside the action outputs:
+
+- `agent-canary-evaluation.json` (`comparevi-history/agent-canary-evaluation@v1`)
+
 Corpus/downstream-processing pilots can also emit additive processing receipts:
 
 - `downstream-processor-summary.json` (`comparevi-history/downstream-processor-summary@v1`)
@@ -249,6 +257,43 @@ This keeps consumer repositories thin while giving reviewers one stable entrypoi
 - the full unsuppressed review surface stays in the artifact-hosted `index.md` and `index.html`
 - execution remains bundle-backed and platform-owned
 - consumer repositories own only the checked-in policy file, branch trigger wiring, and permissions policy
+
+## Agent-canary evaluation workflow
+
+Trusted consumer repositories can add one governed same-repo-only canary proof lane on top of the automatic PR
+diagnostics/publication surface:
+
+- evaluator reusable workflow:
+  [`./.github/workflows/pull-request-diagnostics-canary-evaluate.yml`](.github/workflows/pull-request-diagnostics-canary-evaluate.yml)
+- thin consumer evaluation wrapper:
+  [`docs/examples/comparevi-history-agent-canary-evaluate.yml`](docs/examples/comparevi-history-agent-canary-evaluate.yml)
+- checked-in canary policy source:
+  [`docs/examples/comparevi-history-agent-canary-policy.json`](docs/examples/comparevi-history-agent-canary-policy.json)
+
+The canary lane is intentionally narrow:
+
+- same-repo only
+- one long-lived draft PR, not a stream of throwaway PRs
+- branch prefix `agent-canary/`
+- required label `agent-canary`
+- a dedicated canary VI path instead of production VIs
+- no auto-merge
+
+The evaluator consumes publication receipts and artifact contents only:
+
+- it downloads the publication artifact from `CompareVI History Pull Request Diagnostics Publish`
+- it reads `pr-comment-publication.json`, `pr-run.json`, `changed-vi-discovery.json`, `index.md`, and `index.html`
+- it verifies the changed-VI count, selected-target count, canonical canary path, explicit public modes, raw
+  `noisePolicy = include`, sticky comment publication, and `artifact-index` reviewer surface
+- it emits `agent-canary-evaluation.json` (`comparevi-history/agent-canary-evaluation@v1`)
+- it fails closed for canary regressions and skips cleanly for non-canary PRs
+
+This keeps the canary lane machine-readable and bounded:
+
+- the long-lived draft PR remains the durable proof surface
+- the sticky PR comment remains the reviewer entrypoint
+- the full evidence stays artifact-hosted
+- human feature PRs remain unaffected by autonomous mutation in this pilot
 
 ### Legacy catalog-matched PR diagnostics workflow
 

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -14,6 +14,8 @@ of repo-local inline comment renderers.
   [comparevi-history-pull-request-diagnostics-auto.yml](examples/comparevi-history-pull-request-diagnostics-auto.yml)
 - Automatic changed-VI publication template:
   [comparevi-history-pull-request-diagnostics-publish.yml](examples/comparevi-history-pull-request-diagnostics-publish.yml)
+- Agent-canary evaluation template:
+  [comparevi-history-agent-canary-evaluate.yml](examples/comparevi-history-agent-canary-evaluate.yml)
 - Comment-gated template:
   [comparevi-history-comment-gated.yml](examples/comparevi-history-comment-gated.yml)
 - Example consumer target catalog source:
@@ -22,6 +24,8 @@ of repo-local inline comment renderers.
   [comparevi-history-pr-policy.json](examples/comparevi-history-pr-policy.json)
 - Example dynamic consumer PR policy source:
   [comparevi-history-pr-policy-v2.json](examples/comparevi-history-pr-policy-v2.json)
+- Example agent-canary policy source:
+  [comparevi-history-agent-canary-policy.json](examples/comparevi-history-agent-canary-policy.json)
 
 ## Public Mode Contract
 
@@ -64,6 +68,8 @@ Consumer repositories should not contain:
 - The standard dynamic PR policy uses `discovery.selectionMode = dynamic-paths`.
 - Pair that execution template with the automatic changed-VI publication template so a privileged `workflow_run`
   publisher can create or update one sticky comment from the prepared `pr-comment.md` artifact.
+- Add the agent-canary evaluation template only when you want one long-lived draft PR to keep proving the full
+  execution plus publication surface through a dedicated same-repo canary lane.
 - Use the legacy automatic PR discovery template when you still want catalog-matched target ids to gate the automatic PR
   surface.
 - Use the comment-gated template when you want a slash command such as
@@ -72,6 +78,8 @@ Consumer repositories should not contain:
 - Run both patterns on trusted maintainer-controlled workflows that pre-pull the hosted NI Linux image serially and use
   a repo-local adapter such as `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1`.
 - Keep the target catalog checked in under `.github/comparevi-history-targets.json` and the automatic PR policy checked in under `.github/comparevi-history-pr-policy.json` so the consumer repo owns inspection policy without owning execution logic.
+- Keep the agent-canary policy checked in under `.github/comparevi-history-agent-canary.json` so the repo-owned canary
+  lane stays deterministic and machine-readable.
 
 ## Fork Adoption and Upstream Alignment
 
@@ -118,6 +126,10 @@ Consumer repositories should not contain:
   `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics-publish.yml@v1`. It exists so
   `workflow_run` can publish the sticky comment with `actions: read`, `contents: read`, and `pull-requests: write`
   without widening the execution workflow token.
+- The agent-canary evaluation template uses the reusable workflow surface
+  `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics-canary-evaluate.yml@v1`. It
+  exists so a same-repo `workflow_run` can evaluate the publication artifact, confirm the PR is an `agent-canary`
+  draft lane, and fail closed without re-running execution or checking out candidate PR code.
 - The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.9`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
@@ -139,6 +151,10 @@ Consumer repositories should not contain:
 - The automatic changed-VI publication template expects the execution artifact to contain `pr-run.json` and
   `pr-comment.md`, then updates one sticky comment identified by the stable marker
   `<!-- comparevi-history:pull-request-diagnostics -->`.
+- The agent-canary evaluation template expects the publication artifact to contain `pr-comment-publication.json` plus
+  the expanded execution artifact with `pr-run.json`, `changed-vi-discovery.json`, `index.md`, and `index.html`.
+- The agent-canary lane is same-repo only, uses branch prefix `agent-canary/`, requires the `agent-canary` label, and
+  expects one long-lived draft PR instead of a stream of throwaway proof branches.
 - The action owns reviewer-facing rendering. Consumers should publish PR comments from `public-comment-path` and append
   `public-step-summary-path` instead of rebuilding markdown inline.
 - The comment-gated template writes the action-owned step summary first, then attempts to publish the PR comment. If the
@@ -155,9 +171,11 @@ Consumer repositories should not contain:
 2. Start with the maintainer-dispatched template when your project is new to VI History diagnostics.
 3. Add the automatic changed-VI execution template plus the `workflow_run` publication template when you want pull
    requests to run automatically for every changed `.vi`.
-4. Keep the default explicit public mode bundle unless you have a documented reason to narrow it.
-5. Add the legacy catalog-matched automatic PR template only if your repo still needs target-id allowlists for
+4. Add the agent-canary evaluation template plus `.github/comparevi-history-agent-canary.json` when you want one
+   governed same-repo canary PR to keep proving the automatic review surface.
+5. Keep the default explicit public mode bundle unless you have a documented reason to narrow it.
+6. Add the legacy catalog-matched automatic PR template only if your repo still needs target-id allowlists for
    automatic PR execution.
-6. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
+7. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
    comments on a trusted hosted runner.
-7. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
+8. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.

--- a/docs/examples/comparevi-history-agent-canary-evaluate.yml
+++ b/docs/examples/comparevi-history-agent-canary-evaluate.yml
@@ -1,0 +1,24 @@
+name: CompareVI History Agent Canary Evaluate
+
+on:
+  workflow_run:
+    workflows:
+      - CompareVI History Pull Request Diagnostics Publish
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  comparevi-history-agent-canary-evaluate:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    uses: LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics-canary-evaluate.yml@v1
+    with:
+      consumer_repository: ${{ github.repository }}
+      workflow_run_id: ${{ github.event.workflow_run.id }}
+      artifact_name: comparevi-history-pr-diagnostics-publish-${{ github.event.workflow_run.id }}
+      canary_policy_path: .github/comparevi-history-agent-canary.json
+      platform_ref: v1

--- a/docs/examples/comparevi-history-agent-canary-policy.json
+++ b/docs/examples/comparevi-history-agent-canary-policy.json
@@ -1,0 +1,31 @@
+{
+  "schema": "comparevi-history/agent-canary-policy@v1",
+  "prIdentification": {
+    "branchPrefix": "agent-canary/",
+    "requiredLabels": [
+      "agent-canary"
+    ]
+  },
+  "targetContract": {
+    "canonicalPath": "Tooling/comparevi-history-canary/CanaryProbe.vi",
+    "expectedChangedViCount": 1,
+    "expectedSelectedTargetCount": 1
+  },
+  "executionContract": {
+    "expectedPublicModes": [
+      "attributes",
+      "front-panel",
+      "block-diagram"
+    ],
+    "expectedNoisePolicy": "include",
+    "expectedFullSurface": "artifact-index"
+  },
+  "publicationContract": {
+    "stickyCommentRequired": true,
+    "requiredStatus": "succeeded"
+  },
+  "promotionContract": {
+    "mergePolicy": "manual-only",
+    "prMode": "draft"
+  }
+}

--- a/docs/schemas/comparevi-history-agent-canary-evaluation-v1.schema.json
+++ b/docs/schemas/comparevi-history-agent-canary-evaluation-v1.schema.json
@@ -1,0 +1,507 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-agent-canary-evaluation-v1.schema.json",
+  "title": "comparevi-history agent canary evaluation receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "repository",
+    "workflowRunId",
+    "artifactName",
+    "canaryPolicy",
+    "pullRequest",
+    "trustContext",
+    "discovery",
+    "execution",
+    "publication",
+    "outputs",
+    "checks",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/agent-canary-evaluation@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workflowRunId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifactName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "canaryPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "path",
+        "prIdentification",
+        "targetContract",
+        "executionContract",
+        "publicationContract",
+        "promotionContract"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/agent-canary-policy@v1"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prIdentification": {
+          "type": "object"
+        },
+        "targetContract": {
+          "type": "object"
+        },
+        "executionContract": {
+          "type": "object"
+        },
+        "publicationContract": {
+          "type": "object"
+        },
+        "promotionContract": {
+          "type": "object"
+        }
+      }
+    },
+    "pullRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "number",
+        "baseRepository",
+        "baseRef",
+        "baseSha",
+        "headRepository",
+        "headRef",
+        "headSha",
+        "isFork",
+        "draft",
+        "labels"
+      ],
+      "properties": {
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "htmlUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "baseRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRepository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "headSha": {
+          "type": "string",
+          "minLength": 1
+        },
+        "isFork": {
+          "type": "boolean"
+        },
+        "draft": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "trustContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sameRepository",
+        "forkBehavior",
+        "fullSurface"
+      ],
+      "properties": {
+        "sameRepository": {
+          "type": "boolean"
+        },
+        "forkBehavior": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fullSurface": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "path",
+        "status",
+        "reason",
+        "changedViCount",
+        "selectedTargetCount",
+        "selectedTargetPaths"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/changed-vi-discovery@v2"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ready",
+            "skipped",
+            "blocked"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "selectedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "selectedTargetPaths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "path",
+        "finalStatus",
+        "finalReason",
+        "publicModes",
+        "noisePolicy",
+        "fullSurface"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/pr-run@v2"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "finalStatus": {
+          "type": "string",
+          "enum": [
+            "succeeded",
+            "skipped",
+            "blocked",
+            "failed"
+          ]
+        },
+        "finalReason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "noisePolicy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fullSurface": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "path",
+        "status",
+        "reason",
+        "commentAction",
+        "commentId",
+        "commentUrl"
+      ],
+      "properties": {
+        "schema": {
+          "const": "comparevi-history/pr-comment-publication@v1"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "succeeded",
+            "failed"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commentAction": {
+          "type": "string",
+          "enum": [
+            "none",
+            "created",
+            "updated",
+            "unchanged"
+          ]
+        },
+        "commentId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "commentUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resultsDir",
+        "evaluationPath",
+        "publicationArtifactRoot",
+        "publicationReceiptPath",
+        "prRunPath",
+        "discoveryPath",
+        "indexMarkdownPath",
+        "indexHtmlPath"
+      ],
+      "properties": {
+        "resultsDir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evaluationPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicationArtifactRoot": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicationReceiptPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prRunPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "discoveryPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "indexMarkdownPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "indexHtmlPath": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identification",
+        "targetContract",
+        "executionContract",
+        "publicationContract",
+        "artifactContract"
+      ],
+      "properties": {
+        "identification": {
+          "$ref": "#/$defs/checkResult"
+        },
+        "targetContract": {
+          "$ref": "#/$defs/checkResult"
+        },
+        "executionContract": {
+          "$ref": "#/$defs/checkResult"
+        },
+        "publicationContract": {
+          "$ref": "#/$defs/checkResult"
+        },
+        "artifactContract": {
+          "$ref": "#/$defs/checkResult"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "matchedPolicy",
+        "status",
+        "reason",
+        "failureReasons",
+        "changedViCount",
+        "selectedTargetCount",
+        "executionFinalStatus",
+        "executionFinalReason",
+        "publicationStatus",
+        "publicationReason"
+      ],
+      "properties": {
+        "matchedPolicy": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "succeeded",
+            "failed",
+            "skipped"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "failureReasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "changedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "selectedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "executionFinalStatus": {
+          "type": "string",
+          "enum": [
+            "succeeded",
+            "skipped",
+            "blocked",
+            "failed"
+          ]
+        },
+        "executionFinalReason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "publicationStatus": {
+          "type": "string",
+          "enum": [
+            "succeeded",
+            "failed"
+          ]
+        },
+        "publicationReason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "checkResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "matched",
+        "reasons"
+      ],
+      "properties": {
+        "matched": {
+          "type": "boolean"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/comparevi-history-agent-canary-policy-v1.schema.json
+++ b/docs/schemas/comparevi-history-agent-canary-policy-v1.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-agent-canary-policy-v1.schema.json",
+  "title": "comparevi-history agent canary policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "prIdentification",
+    "targetContract",
+    "executionContract",
+    "publicationContract",
+    "promotionContract"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/agent-canary-policy@v1"
+    },
+    "prIdentification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "branchPrefix",
+        "requiredLabels"
+      ],
+      "properties": {
+        "branchPrefix": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredLabels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "targetContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonicalPath",
+        "expectedChangedViCount",
+        "expectedSelectedTargetCount"
+      ],
+      "properties": {
+        "canonicalPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expectedChangedViCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "expectedSelectedTargetCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "executionContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expectedPublicModes",
+        "expectedNoisePolicy",
+        "expectedFullSurface"
+      ],
+      "properties": {
+        "expectedPublicModes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "attributes",
+              "front-panel",
+              "block-diagram"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "expectedNoisePolicy": {
+          "type": "string",
+          "enum": [
+            "include",
+            "collapse",
+            "skip"
+          ]
+        },
+        "expectedFullSurface": {
+          "type": "string",
+          "enum": [
+            "artifact-index"
+          ]
+        }
+      }
+    },
+    "publicationContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stickyCommentRequired",
+        "requiredStatus"
+      ],
+      "properties": {
+        "stickyCommentRequired": {
+          "type": "boolean"
+        },
+        "requiredStatus": {
+          "type": "string",
+          "enum": [
+            "succeeded"
+          ]
+        }
+      }
+    },
+    "promotionContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mergePolicy",
+        "prMode"
+      ],
+      "properties": {
+        "mergePolicy": {
+          "type": "string",
+          "enum": [
+            "manual-only"
+          ]
+        },
+        "prMode": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "ready-for-review"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
+++ b/scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
@@ -1,0 +1,622 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryAgentCanaryEvaluation.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-agent-canary-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+function New-CanaryPolicyFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RootPath
+  )
+
+  $policyPath = Join-Path $RootPath 'comparevi-history-agent-canary.json'
+  @'
+{
+  "schema": "comparevi-history/agent-canary-policy@v1",
+  "prIdentification": {
+    "branchPrefix": "agent-canary/",
+    "requiredLabels": ["agent-canary"]
+  },
+  "targetContract": {
+    "canonicalPath": "Tooling/comparevi-history-canary/CanaryProbe.vi",
+    "expectedChangedViCount": 1,
+    "expectedSelectedTargetCount": 1
+  },
+  "executionContract": {
+    "expectedPublicModes": ["attributes", "front-panel", "block-diagram"],
+    "expectedNoisePolicy": "include",
+    "expectedFullSurface": "artifact-index"
+  },
+  "publicationContract": {
+    "stickyCommentRequired": true,
+    "requiredStatus": "succeeded"
+  },
+  "promotionContract": {
+    "mergePolicy": "manual-only",
+    "prMode": "draft"
+  }
+}
+'@ | Set-Content -LiteralPath $policyPath -Encoding utf8
+
+  return $policyPath
+}
+
+function New-PublicationArtifactZip {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RootPath,
+    [string]$HeadRef = 'agent-canary/comparevi-history-pr-diagnostics',
+    [string]$TargetPath = 'Tooling/comparevi-history-canary/CanaryProbe.vi',
+    [int]$ChangedViCount = 1,
+    [int]$SelectedTargetCount = 1,
+    [string]$ExecutionFinalStatus = 'succeeded',
+    [string]$ExecutionFinalReason = 'completed',
+    [string]$PublicationStatus = 'succeeded',
+    [string]$PublicationReason = 'comment-created',
+    [string]$CommentAction = 'created',
+    [bool]$Draft = $true,
+    [string[]]$Labels = @('agent-canary'),
+    [bool]$IncludePublicationReceipt = $true,
+    [bool]$IncludePrRun = $true,
+    [bool]$IncludeDiscovery = $true,
+    [bool]$IncludeIndex = $true,
+    [string[]]$PublicModes = @('attributes', 'front-panel', 'block-diagram'),
+    [string]$NoisePolicy = 'include',
+    [string]$FullSurface = 'artifact-index'
+  )
+
+  $artifactRoot = Join-Path $RootPath 'artifact-src'
+  $executionRoot = Join-Path $artifactRoot 'artifact'
+  $zipPath = Join-Path $RootPath 'artifact.zip'
+  New-Item -ItemType Directory -Path $executionRoot -Force | Out-Null
+
+  $labelsJson = ($Labels | ForEach-Object { '"{0}"' -f $_ }) -join ', '
+  $modesJson = ($PublicModes | ForEach-Object { '"{0}"' -f $_ }) -join ', '
+  $draftLiteral = if ($Draft) { 'true' } else { 'false' }
+
+  if ($IncludePublicationReceipt) {
+    @"
+{
+  "schema": "comparevi-history/pr-comment-publication@v1",
+  "generatedAtUtc": "2026-03-17T00:05:00Z",
+  "repository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+  "workflowRunId": "444",
+  "artifactName": "comparevi-history-pr-diagnostics-publish-444",
+  "artifactZipPath": "C:/results/publish/artifact.zip",
+  "artifactRoot": "C:/results/publish/artifact",
+  "prRunPath": "C:/results/publish/artifact/pr-run.json",
+  "commentBodyPath": "C:/results/publish/artifact/pr-comment.md",
+  "pullRequestNumber": 55,
+  "workflowRunUrl": "https://github.com/example/repo/actions/runs/444",
+  "summary": {
+    "status": "$PublicationStatus",
+    "reason": "$PublicationReason",
+    "commentAction": "$CommentAction",
+    "commentId": 991,
+    "commentUrl": "https://github.com/example/repo/pull/55#issuecomment-991"
+  }
+}
+"@ | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-comment-publication.json') -Encoding utf8
+  }
+
+  if ($IncludePrRun) {
+    @"
+{
+  "schema": "comparevi-history/pr-run@v2",
+  "generatedAtUtc": "2026-03-17T00:00:00Z",
+  "pullRequest": {
+    "number": 55,
+    "htmlUrl": "https://github.com/example/repo/pull/55",
+    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "baseRef": "develop",
+    "baseSha": "base-sha",
+    "headRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "headRef": "$HeadRef",
+    "headSha": "head-sha",
+    "isFork": false
+  },
+  "prPolicy": {
+    "schema": "comparevi-history/pr-policy@v2",
+    "path": "C:/repo/.github/comparevi-history-pr-policy.json",
+    "applied": true,
+    "discovery": {
+      "selectionMode": "dynamic-paths",
+      "includePaths": ["**/*.vi"],
+      "excludePaths": [],
+      "maxChangedViCount": 10,
+      "overflowBehavior": "block"
+    },
+    "execution": {
+      "publicModes": [$modesJson],
+      "noisePolicy": "$NoisePolicy",
+      "history": {
+        "sourceBranchRefStrategy": "pull-request-base",
+        "keepArtifactsOnNoDiff": true
+      }
+    },
+    "reviewerSurface": {
+      "emitCommentBody": true,
+      "emitStepSummary": true,
+      "fullSurface": "$FullSurface"
+    },
+    "trust": {
+      "forkBehavior": "hosted-auto"
+    }
+  },
+  "executionContext": {
+    "selectionMode": "dynamic-paths",
+    "forkBehavior": "hosted-auto",
+    "fullSurface": "$FullSurface"
+  },
+  "discovery": {
+    "schema": "comparevi-history/changed-vi-discovery@v2",
+    "path": "C:/results/changed-vi-discovery.json",
+    "status": "ready",
+    "reason": "selected-targets",
+    "changedViCount": $ChangedViCount,
+    "eligibleChangedViCount": $ChangedViCount,
+    "excludedViCount": 0,
+    "selectedTargetCount": $SelectedTargetCount,
+    "overflowed": false,
+    "overflowChangedViCount": 0
+  },
+  "outputs": {
+    "resultsDir": "C:/results",
+    "prRunPath": "C:/results/pr-run.json",
+    "publicCommentPath": "C:/results/pr-comment.md",
+    "publicStepSummaryPath": "C:/results/pr-step-summary.md",
+    "targetRunsManifestPath": "C:/results/pr-target-runs-manifest.json",
+    "indexMarkdownPath": "C:/results/index.md",
+    "indexHtmlPath": "C:/results/index.html",
+    "workflowRunUrl": "https://github.com/example/repo/actions/runs/333",
+    "artifactName": "comparevi-history-pr-diagnostics-333"
+  },
+  "summary": {
+    "finalStatus": "$ExecutionFinalStatus",
+    "finalReason": "$ExecutionFinalReason",
+    "changedViCount": $ChangedViCount,
+    "eligibleChangedViCount": $ChangedViCount,
+    "excludedViCount": 0,
+    "selectedTargetCount": $SelectedTargetCount,
+    "overflowed": false,
+    "overflowChangedViCount": 0,
+    "executedTargetCount": $SelectedTargetCount,
+    "failedTargetCount": 0,
+    "totalProcessed": 2,
+    "totalDiffs": 1
+  },
+  "excludedViFiles": [],
+  "targets": [
+    {
+      "targetId": "dynamic-canary-001",
+      "targetSource": "dynamic-path",
+      "targetPath": "$TargetPath",
+      "requestedModes": [$modesJson],
+      "requestedModeSource": "pr-policy",
+      "sourceBranchRef": "develop",
+      "keepArtifactsOnNoDiff": true,
+      "currentPath": "$TargetPath",
+      "previousPath": null,
+      "changeStatus": "modified",
+      "finalStatus": "$ExecutionFinalStatus",
+      "finalReason": "$ExecutionFinalReason",
+      "requestPath": "C:/results/targets/request.json",
+      "publicRunPath": "C:/results/targets/public-run.json",
+      "sharedEvidencePath": "C:/results/targets/shared-evidence.json",
+      "historySummaryJsonPath": "C:/results/targets/history-summary.json",
+      "historyReportMdPath": "C:/results/targets/history-report.md",
+      "historyReportHtmlPath": "C:/results/targets/history-report.html",
+      "modeSummaryJsonPath": "C:/results/targets/mode-summary.json",
+      "modeSummaryPath": "C:/results/targets/mode-summary.md",
+      "totalProcessed": 2,
+      "totalDiffs": 1
+    }
+  ]
+}
+"@ | Set-Content -LiteralPath (Join-Path $executionRoot 'pr-run.json') -Encoding utf8
+  }
+
+  if ($IncludeDiscovery) {
+    @"
+{
+  "schema": "comparevi-history/changed-vi-discovery@v2",
+  "generatedAtUtc": "2026-03-17T00:00:00Z",
+  "repository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+  "eventName": "pull_request",
+  "prPolicy": {
+    "schema": "comparevi-history/pr-policy@v2",
+    "path": "C:/repo/.github/comparevi-history-pr-policy.json",
+    "applied": true,
+    "discovery": {
+      "selectionMode": "dynamic-paths",
+      "includePaths": ["**/*.vi"],
+      "excludePaths": [],
+      "maxChangedViCount": 10,
+      "overflowBehavior": "block"
+    },
+    "execution": {
+      "publicModes": [$modesJson],
+      "noisePolicy": "$NoisePolicy",
+      "history": {
+        "sourceBranchRefStrategy": "pull-request-base",
+        "keepArtifactsOnNoDiff": true
+      }
+    },
+    "reviewerSurface": {
+      "emitCommentBody": true,
+      "emitStepSummary": true,
+      "fullSurface": "$FullSurface"
+    },
+    "trust": {
+      "forkBehavior": "hosted-auto"
+    }
+  },
+  "executionContext": {
+    "selectionMode": "dynamic-paths",
+    "forkBehavior": "hosted-auto",
+    "fullSurface": "$FullSurface"
+  },
+  "pullRequest": {
+    "number": 55,
+    "htmlUrl": "https://github.com/example/repo/pull/55",
+    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "baseRef": "develop",
+    "baseSha": "base-sha",
+    "headRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
+    "headRef": "$HeadRef",
+    "headSha": "head-sha",
+    "isFork": false,
+    "changedFileCount": $ChangedViCount
+  },
+  "changedViFiles": [
+    {
+      "status": "modified",
+      "currentPath": "$TargetPath",
+      "previousPath": null
+    }
+  ],
+  "excludedViFiles": [],
+  "selectedTargets": [
+    {
+      "targetId": "dynamic-canary-001",
+      "targetSource": "dynamic-path",
+      "targetPath": "$TargetPath",
+      "requestedModes": [$modesJson],
+      "requestedModeSource": "pr-policy",
+      "history": {
+        "branchBudget": {
+          "sourceBranchRef": "develop",
+          "maxCommitCount": null,
+          "source": "pull-request-base"
+        }
+      },
+      "keepArtifactsOnNoDiff": true,
+      "currentPath": "$TargetPath",
+      "previousPath": null,
+      "changeStatus": "modified"
+    }
+  ],
+  "summary": {
+    "selectionMode": "dynamic-paths",
+    "executionStatus": "ready",
+    "executionReason": "selected-targets",
+    "changedViCount": $ChangedViCount,
+    "eligibleChangedViCount": $ChangedViCount,
+    "excludedViCount": 0,
+    "selectedTargetCount": $SelectedTargetCount,
+    "overflowBehavior": "block",
+    "overflowed": false,
+    "overflowChangedViCount": 0
+  }
+}
+"@ | Set-Content -LiteralPath (Join-Path $executionRoot 'changed-vi-discovery.json') -Encoding utf8
+  }
+
+  if ($IncludeIndex) {
+    '# comparevi-history PR diagnostics index' | Set-Content -LiteralPath (Join-Path $executionRoot 'index.md') -Encoding utf8
+    '<html><body>index</body></html>' | Set-Content -LiteralPath (Join-Path $executionRoot 'index.html') -Encoding utf8
+  }
+
+  if (Test-Path -LiteralPath $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+  }
+  Compress-Archive -Path (Join-Path $artifactRoot '*') -DestinationPath $zipPath -Force
+
+  return @{
+    ZipPath = $zipPath
+    Draft = $Draft
+    Labels = @($Labels)
+  }
+}
+
+try {
+  $global:MockScenario = @{}
+
+  function Invoke-RestMethod {
+    param(
+      [string]$Method,
+      [string]$Uri,
+      [hashtable]$Headers
+    )
+
+    $methodKey = if ([string]::IsNullOrWhiteSpace($Method)) { 'Get' } else { $Method }
+    if ($methodKey -eq 'Get' -and $Uri -like 'https://api.github.com/repos/*/actions/runs/*/artifacts?per_page=100') {
+      return @{
+        artifacts = @(
+          @{
+            name = $global:MockScenario.ArtifactName
+            archive_download_url = 'https://example.test/publication-artifact.zip'
+          }
+        )
+      }
+    }
+
+    if ($methodKey -eq 'Get' -and $Uri -like 'https://api.github.com/repos/*/pulls/*') {
+      return @{
+        draft = $global:MockScenario.PullRequestDraft
+        labels = @(
+          $global:MockScenario.PullRequestLabels | ForEach-Object {
+            @{
+              name = $_
+            }
+          }
+        )
+      }
+    }
+
+    throw "Unexpected REST call: $methodKey $Uri"
+  }
+
+  function Invoke-WebRequest {
+    param(
+      [string]$Uri,
+      [hashtable]$Headers,
+      [string]$OutFile
+    )
+
+    Copy-Item -LiteralPath $global:MockScenario.ZipPath -Destination $OutFile -Force
+  }
+
+  $policyRoot = Join-Path $tempRoot 'policy'
+  New-Item -ItemType Directory -Path $policyRoot -Force | Out-Null
+  $policyPath = New-CanaryPolicyFile -RootPath $policyRoot
+
+  $successRoot = Join-Path $tempRoot 'success'
+  New-Item -ItemType Directory -Path $successRoot -Force | Out-Null
+  $successFixture = New-PublicationArtifactZip -RootPath $successRoot
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-444'
+    ZipPath = $successFixture.ZipPath
+    PullRequestDraft = $successFixture.Draft
+    PullRequestLabels = $successFixture.Labels
+  }
+
+  $successOutputPath = Join-Path $successRoot 'evaluate.out'
+  $successJson = & $scriptPath `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -WorkflowRunId '444' `
+    -CanaryPolicyPath $policyPath `
+    -GitHubToken 'token' `
+    -ResultsDir (Join-Path $successRoot 'results') `
+    -GitHubOutputPath $successOutputPath
+
+  $successReceipt = $successJson | ConvertFrom-Json -Depth 64
+  if ($successReceipt.schema -ne 'comparevi-history/agent-canary-evaluation@v1') {
+    throw 'Agent canary evaluation schema mismatch.'
+  }
+  if (-not $successReceipt.summary.matchedPolicy) {
+    throw 'Expected the success case to match the canary policy.'
+  }
+  if ($successReceipt.summary.status -ne 'succeeded' -or $successReceipt.summary.reason -ne 'canary-acceptance-satisfied') {
+    throw 'Expected the success case to satisfy canary acceptance.'
+  }
+  if ($successReceipt.summary.changedViCount -ne 1 -or $successReceipt.summary.selectedTargetCount -ne 1) {
+    throw 'Success case summary counts mismatch.'
+  }
+  if ($successReceipt.publication.status -ne 'succeeded' -or $successReceipt.execution.finalStatus -ne 'succeeded') {
+    throw 'Success case status propagation mismatch.'
+  }
+  if (-not (Test-Path -LiteralPath $successReceipt.outputs.indexMarkdownPath -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $successReceipt.outputs.indexHtmlPath -PathType Leaf)) {
+    throw 'Success case should preserve index surfaces.'
+  }
+  $successOutput = Get-Content -LiteralPath $successOutputPath -Raw
+  foreach ($requiredKey in @(
+      'evaluation-path=',
+      'evaluation-status=succeeded',
+      'evaluation-reason=canary-acceptance-satisfied',
+      'matched-policy=true'
+    )) {
+    if ($successOutput -notmatch [regex]::Escape($requiredKey)) {
+      throw "Expected GitHub output '$requiredKey'."
+    }
+  }
+
+  $skipRoot = Join-Path $tempRoot 'skip'
+  New-Item -ItemType Directory -Path $skipRoot -Force | Out-Null
+  $skipFixture = New-PublicationArtifactZip -RootPath $skipRoot -HeadRef 'feature/not-a-canary' -Draft $false -Labels @('triage')
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-445'
+    ZipPath = $skipFixture.ZipPath
+    PullRequestDraft = $skipFixture.Draft
+    PullRequestLabels = $skipFixture.Labels
+  }
+
+  $skipJson = & $scriptPath `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -WorkflowRunId '445' `
+    -ArtifactName 'comparevi-history-pr-diagnostics-publish-445' `
+    -CanaryPolicyPath $policyPath `
+    -GitHubToken 'token' `
+    -ResultsDir (Join-Path $skipRoot 'results')
+
+  $skipReceipt = $skipJson | ConvertFrom-Json -Depth 64
+  if ($skipReceipt.summary.status -ne 'skipped' -or $skipReceipt.summary.reason -ne 'non-canary-pr') {
+    throw 'Expected a non-canary PR to skip cleanly.'
+  }
+  if ($skipReceipt.summary.matchedPolicy) {
+    throw 'Non-canary PR should not match canary policy.'
+  }
+  if ($skipReceipt.summary.failureReasons -notcontains 'branch-prefix-mismatch' -or
+    $skipReceipt.summary.failureReasons -notcontains 'missing-required-label:agent-canary' -or
+    $skipReceipt.summary.failureReasons -notcontains 'pr-not-draft') {
+    throw 'Non-canary skip reasons mismatch.'
+  }
+
+  $wrongPathRoot = Join-Path $tempRoot 'wrong-path'
+  New-Item -ItemType Directory -Path $wrongPathRoot -Force | Out-Null
+  $wrongPathFixture = New-PublicationArtifactZip -RootPath $wrongPathRoot -TargetPath 'Tooling/deployment/VIP_Post-Install Custom Action.vi'
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-446'
+    ZipPath = $wrongPathFixture.ZipPath
+    PullRequestDraft = $wrongPathFixture.Draft
+    PullRequestLabels = $wrongPathFixture.Labels
+  }
+
+  $wrongPathFailed = $false
+  try {
+    & $scriptPath `
+      -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+      -WorkflowRunId '446' `
+      -ArtifactName 'comparevi-history-pr-diagnostics-publish-446' `
+      -CanaryPolicyPath $policyPath `
+      -GitHubToken 'token' `
+      -ResultsDir (Join-Path $wrongPathRoot 'results') | Out-Null
+  } catch {
+    $wrongPathFailed = $true
+  }
+  if (-not $wrongPathFailed) {
+    throw 'Wrong target path should fail closed.'
+  }
+  $wrongPathReceipt = Get-Content -LiteralPath (Join-Path $wrongPathRoot 'results/agent-canary-evaluation.json') -Raw | ConvertFrom-Json -Depth 64
+  if ($wrongPathReceipt.summary.status -ne 'failed' -or $wrongPathReceipt.summary.reason -ne 'wrong-target-path') {
+    throw 'Wrong target path failure reason mismatch.'
+  }
+
+  $publishFailureRoot = Join-Path $tempRoot 'publish-failure'
+  New-Item -ItemType Directory -Path $publishFailureRoot -Force | Out-Null
+  $publishFailureFixture = New-PublicationArtifactZip -RootPath $publishFailureRoot -PublicationStatus 'failed' -PublicationReason 'comment-create-denied' -CommentAction 'none'
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-447'
+    ZipPath = $publishFailureFixture.ZipPath
+    PullRequestDraft = $publishFailureFixture.Draft
+    PullRequestLabels = $publishFailureFixture.Labels
+  }
+
+  $publishFailedAsExpected = $false
+  try {
+    & $scriptPath `
+      -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+      -WorkflowRunId '447' `
+      -ArtifactName 'comparevi-history-pr-diagnostics-publish-447' `
+      -CanaryPolicyPath $policyPath `
+      -GitHubToken 'token' `
+      -ResultsDir (Join-Path $publishFailureRoot 'results') | Out-Null
+  } catch {
+    $publishFailedAsExpected = $true
+  }
+  if (-not $publishFailedAsExpected) {
+    throw 'Publication failure should fail closed.'
+  }
+  $publishFailureReceipt = Get-Content -LiteralPath (Join-Path $publishFailureRoot 'results/agent-canary-evaluation.json') -Raw | ConvertFrom-Json -Depth 64
+  if ($publishFailureReceipt.summary.reason -ne 'failed-publication') {
+    throw 'Publication failure reason mismatch.'
+  }
+
+  $missingIndexRoot = Join-Path $tempRoot 'missing-index'
+  New-Item -ItemType Directory -Path $missingIndexRoot -Force | Out-Null
+  $missingIndexFixture = New-PublicationArtifactZip -RootPath $missingIndexRoot -IncludeIndex:$false
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-448'
+    ZipPath = $missingIndexFixture.ZipPath
+    PullRequestDraft = $missingIndexFixture.Draft
+    PullRequestLabels = $missingIndexFixture.Labels
+  }
+
+  $missingIndexFailed = $false
+  try {
+    & $scriptPath `
+      -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+      -WorkflowRunId '448' `
+      -ArtifactName 'comparevi-history-pr-diagnostics-publish-448' `
+      -CanaryPolicyPath $policyPath `
+      -GitHubToken 'token' `
+      -ResultsDir (Join-Path $missingIndexRoot 'results') | Out-Null
+  } catch {
+    $missingIndexFailed = $true
+  }
+  if (-not $missingIndexFailed) {
+    throw 'Missing index surfaces should fail closed.'
+  }
+  $missingIndexReceipt = Get-Content -LiteralPath (Join-Path $missingIndexRoot 'results/agent-canary-evaluation.json') -Raw | ConvertFrom-Json -Depth 64
+  if ($missingIndexReceipt.summary.reason -ne 'missing-index-surface') {
+    throw 'Missing index failure reason mismatch.'
+  }
+
+  $missingPublicationRoot = Join-Path $tempRoot 'missing-publication'
+  New-Item -ItemType Directory -Path $missingPublicationRoot -Force | Out-Null
+  $missingPublicationFixture = New-PublicationArtifactZip -RootPath $missingPublicationRoot -IncludePublicationReceipt:$false
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-449'
+    ZipPath = $missingPublicationFixture.ZipPath
+    PullRequestDraft = $missingPublicationFixture.Draft
+    PullRequestLabels = $missingPublicationFixture.Labels
+  }
+
+  $missingPublicationFailed = $false
+  try {
+    & $scriptPath `
+      -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+      -WorkflowRunId '449' `
+      -ArtifactName 'comparevi-history-pr-diagnostics-publish-449' `
+      -CanaryPolicyPath $policyPath `
+      -GitHubToken 'token' `
+      -ResultsDir (Join-Path $missingPublicationRoot 'results') | Out-Null
+  } catch {
+    $missingPublicationFailed = $true
+  }
+  if (-not $missingPublicationFailed) {
+    throw 'Missing publication receipt should fail closed.'
+  }
+  $missingPublicationReceipt = Get-Content -LiteralPath (Join-Path $missingPublicationRoot 'results/agent-canary-evaluation.json') -Raw | ConvertFrom-Json -Depth 64
+  if ($missingPublicationReceipt.summary.reason -ne 'missing-pr-comment-publication') {
+    throw 'Missing publication receipt reason mismatch.'
+  }
+
+  $missingPrRunRoot = Join-Path $tempRoot 'missing-pr-run'
+  New-Item -ItemType Directory -Path $missingPrRunRoot -Force | Out-Null
+  $missingPrRunFixture = New-PublicationArtifactZip -RootPath $missingPrRunRoot -IncludePrRun:$false
+  $global:MockScenario = @{
+    ArtifactName = 'comparevi-history-pr-diagnostics-publish-450'
+    ZipPath = $missingPrRunFixture.ZipPath
+    PullRequestDraft = $missingPrRunFixture.Draft
+    PullRequestLabels = $missingPrRunFixture.Labels
+  }
+
+  $missingPrRunFailed = $false
+  try {
+    & $scriptPath `
+      -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+      -WorkflowRunId '450' `
+      -ArtifactName 'comparevi-history-pr-diagnostics-publish-450' `
+      -CanaryPolicyPath $policyPath `
+      -GitHubToken 'token' `
+      -ResultsDir (Join-Path $missingPrRunRoot 'results') | Out-Null
+  } catch {
+    $missingPrRunFailed = $true
+  }
+  if (-not $missingPrRunFailed) {
+    throw 'Missing PR run receipt should fail closed.'
+  }
+  $missingPrRunReceipt = Get-Content -LiteralPath (Join-Path $missingPrRunRoot 'results/agent-canary-evaluation.json') -Raw | ConvertFrom-Json -Depth 64
+  if ($missingPrRunReceipt.summary.reason -ne 'missing-pr-run') {
+    throw 'Missing PR run reason mismatch.'
+  }
+} finally {
+  Remove-Item function:Invoke-RestMethod -ErrorAction SilentlyContinue
+  Remove-Item function:Invoke-WebRequest -ErrorAction SilentlyContinue
+  Remove-Variable MockScenario -Scope Global -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -6,6 +6,7 @@ $manualTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-workf
 $pullRequestTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-pull-request-diagnostics.yml'
 $pullRequestAutoTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-pull-request-diagnostics-auto.yml'
 $pullRequestPublishTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-pull-request-diagnostics-publish.yml'
+$agentCanaryTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-agent-canary-evaluate.yml'
 $commentTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-comment-gated.yml'
 $manualExplorationTemplatePath = Join-Path $repoRoot 'docs/examples/comparevi-history-manual-vi-exploration.yml'
 $safeTemplatesPath = Join-Path $repoRoot 'docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md'
@@ -13,6 +14,7 @@ $publishedValidationWorkflowPath = Join-Path $repoRoot '.github/workflows/publis
 $pullRequestWorkflowPath = Join-Path $repoRoot '.github/workflows/pull-request-diagnostics.yml'
 $pullRequestAutoWorkflowPath = Join-Path $repoRoot '.github/workflows/pull-request-diagnostics-auto.yml'
 $pullRequestPublishWorkflowPath = Join-Path $repoRoot '.github/workflows/pull-request-diagnostics-publish.yml'
+$agentCanaryWorkflowPath = Join-Path $repoRoot '.github/workflows/pull-request-diagnostics-canary-evaluate.yml'
 $manualExplorationWorkflowPath = Join-Path $repoRoot '.github/workflows/manual-vi-exploration.yml'
 $smokeWorkflowPath = Join-Path $repoRoot '.github/workflows/smoke.yml'
 $releaseWorkflowPath = Join-Path $repoRoot '.github/workflows/release.yml'
@@ -21,6 +23,7 @@ $readmePath = Join-Path $repoRoot 'README.md'
 $exampleTargetsPath = Join-Path $repoRoot 'docs/examples/comparevi-history-consumer-targets.json'
 $examplePrPolicyPath = Join-Path $repoRoot 'docs/examples/comparevi-history-pr-policy.json'
 $examplePrPolicyV2Path = Join-Path $repoRoot 'docs/examples/comparevi-history-pr-policy-v2.json'
+$exampleAgentCanaryPolicyPath = Join-Path $repoRoot 'docs/examples/comparevi-history-agent-canary-policy.json'
 $actionPath = Join-Path $repoRoot 'action.yml'
 
 function Assert-Match {
@@ -90,6 +93,7 @@ $manualTemplate = Get-Content -LiteralPath $manualTemplatePath -Raw
 $pullRequestTemplate = Get-Content -LiteralPath $pullRequestTemplatePath -Raw
 $pullRequestAutoTemplate = Get-Content -LiteralPath $pullRequestAutoTemplatePath -Raw
 $pullRequestPublishTemplate = Get-Content -LiteralPath $pullRequestPublishTemplatePath -Raw
+$agentCanaryTemplate = Get-Content -LiteralPath $agentCanaryTemplatePath -Raw
 $commentTemplate = Get-Content -LiteralPath $commentTemplatePath -Raw
 $manualExplorationTemplate = Get-Content -LiteralPath $manualExplorationTemplatePath -Raw
 $safeTemplates = Get-Content -LiteralPath $safeTemplatesPath -Raw
@@ -97,6 +101,7 @@ $publishedValidationWorkflow = Get-Content -LiteralPath $publishedValidationWork
 $pullRequestWorkflow = Get-Content -LiteralPath $pullRequestWorkflowPath -Raw
 $pullRequestAutoWorkflow = Get-Content -LiteralPath $pullRequestAutoWorkflowPath -Raw
 $pullRequestPublishWorkflow = Get-Content -LiteralPath $pullRequestPublishWorkflowPath -Raw
+$agentCanaryWorkflow = Get-Content -LiteralPath $agentCanaryWorkflowPath -Raw
 $manualExplorationWorkflow = Get-Content -LiteralPath $manualExplorationWorkflowPath -Raw
 $smokeWorkflow = Get-Content -LiteralPath $smokeWorkflowPath -Raw
 $releaseWorkflow = Get-Content -LiteralPath $releaseWorkflowPath -Raw
@@ -105,6 +110,7 @@ $readme = Get-Content -LiteralPath $readmePath -Raw
 $exampleTargets = Get-Content -LiteralPath $exampleTargetsPath -Raw
 $examplePrPolicy = Get-Content -LiteralPath $examplePrPolicyPath -Raw
 $examplePrPolicyV2 = Get-Content -LiteralPath $examplePrPolicyV2Path -Raw
+$exampleAgentCanaryPolicy = Get-Content -LiteralPath $exampleAgentCanaryPolicyPath -Raw
 $actionYaml = Get-Content -LiteralPath $actionPath -Raw
 
 Assert-Match -Content $manualTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Manual template must use ubuntu-latest.'
@@ -140,6 +146,16 @@ Assert-Match -Content $pullRequestPublishTemplate -Pattern '(?m)^\s*actions:\s+r
 Assert-Match -Content $pullRequestPublishTemplate -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Publication template must request pull-requests: write.'
 Assert-Match -Content $pullRequestPublishTemplate -Pattern 'workflow_run_id:\s+\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Publication template must route workflow_run.id into the reusable workflow.'
 Assert-Match -Content $pullRequestPublishTemplate -Pattern 'artifact_name:\s+comparevi-history-pr-diagnostics-\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Publication template must resolve the deterministic execution artifact name.'
+
+Assert-Match -Content $agentCanaryTemplate -Pattern 'LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/pull-request-diagnostics-canary-evaluate\.yml@v1' -Message 'Agent canary template must call the reusable evaluation workflow surface.'
+Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*workflow_run:\s*$' -Message 'Agent canary template must trigger on workflow_run.'
+Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*actions:\s+read\s*$' -Message 'Agent canary template must request actions: read.'
+Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*contents:\s+read\s*$' -Message 'Agent canary template must request contents: read.'
+Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*pull-requests:\s+read\s*$' -Message 'Agent canary template must request pull-requests: read so labels and draft state can be evaluated deterministically.'
+Assert-Match -Content $agentCanaryTemplate -Pattern 'workflow_run_id:\s+\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Agent canary template must route workflow_run.id into the reusable evaluator.'
+Assert-Match -Content $agentCanaryTemplate -Pattern 'artifact_name:\s+comparevi-history-pr-diagnostics-publish-\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Agent canary template must resolve the deterministic publication artifact name.'
+Assert-Match -Content $agentCanaryTemplate -Pattern 'canary_policy_path:\s+\.github/comparevi-history-agent-canary\.json' -Message 'Agent canary template must consume the checked-in agent-canary policy.'
+Assert-Match -Content $agentCanaryTemplate -Pattern 'platform_ref:\s+v1' -Message 'Agent canary template must keep platform_ref aligned with the workflow pin.'
 
 Assert-Match -Content $manualExplorationTemplate -Pattern '(?m)^\s*vi_path:\s*$' -Message 'Manual exploration template must accept vi_path.'
 Assert-Match -Content $manualExplorationTemplate -Pattern '(?m)^\s*default:\s+develop\s*$' -Message 'Manual exploration template must default the consumer ref to develop.'
@@ -227,6 +243,17 @@ Assert-Match -Content $pullRequestPublishWorkflow -Pattern 'comparevi-history-pr
 Assert-Match -Content $pullRequestPublishWorkflow -Pattern "steps\.publish\.outcome == 'failure'" -Message 'Publication workflow must fail closed on publish failures after receipts upload.'
 Assert-NotMatch -Content $pullRequestPublishWorkflow -Pattern 'candidate-consumer' -Message 'Publication workflow must not check out or execute candidate PR code.'
 
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*workflow_call:\s*$' -Message 'Agent canary workflow must be reusable.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*workflow_run_id:\s*$' -Message 'Agent canary workflow must accept workflow_run_id.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*artifact_name:\s*$' -Message 'Agent canary workflow must accept artifact_name.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*canary_policy_path:\s*$' -Message 'Agent canary workflow must accept canary_policy_path.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*actions:\s+read\s*$' -Message 'Agent canary workflow must request actions: read.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern '(?m)^\s*pull-requests:\s+read\s*$' -Message 'Agent canary workflow must request pull-requests: read.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern 'Write-CompareVIHistoryAgentCanaryEvaluation\.ps1' -Message 'Agent canary workflow must use the agent canary evaluator script.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern 'comparevi-history-pr-diagnostics-canary-' -Message 'Agent canary workflow must upload canary evaluation receipts.'
+Assert-Match -Content $agentCanaryWorkflow -Pattern "steps\.evaluate\.outcome == 'failure'" -Message 'Agent canary workflow must fail closed on evaluator failures after receipts upload.'
+Assert-NotMatch -Content $agentCanaryWorkflow -Pattern 'candidate-consumer' -Message 'Agent canary workflow must not check out or execute candidate PR code.'
+
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*runs-on:\s+ubuntu-latest\s*$' -Message 'Comment-gated template must use ubuntu-latest.'
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*pull-requests:\s+write\s*$' -Message 'Comment-gated template must request pull-requests: write.'
 Assert-Match -Content $commentTemplate -Pattern '(?m)^\s*DEFAULT_COMPARE_MODES:\s+attributes,front-panel,block-diagram\s*$' -Message 'Comment-gated template must default to explicit public modes only.'
@@ -255,6 +282,11 @@ Assert-Match -Content $examplePrPolicyV2 -Pattern '"includePaths"\s*:\s*\[\s*"\*
 Assert-Match -Content $examplePrPolicyV2 -Pattern '"maxChangedViCount"\s*:\s*10' -Message 'Example dynamic PR policy file must fail closed at ten changed VIs.'
 Assert-Match -Content $examplePrPolicyV2 -Pattern '"noisePolicy"\s*:\s*"include"' -Message 'Example dynamic PR policy file must default to unsuppressed noise handling.'
 Assert-Match -Content $examplePrPolicyV2 -Pattern '"forkBehavior"\s*:\s*"hosted-auto"' -Message 'Example dynamic PR policy file must allow hosted automatic fork execution.'
+Assert-Match -Content $exampleAgentCanaryPolicy -Pattern 'comparevi-history/agent-canary-policy@v1' -Message 'Example agent canary policy file must declare the agent-canary policy schema.'
+Assert-Match -Content $exampleAgentCanaryPolicy -Pattern '"branchPrefix"\s*:\s*"agent-canary/' -Message 'Example agent canary policy file must declare the canary branch prefix.'
+Assert-Match -Content $exampleAgentCanaryPolicy -Pattern '"requiredLabels"\s*:\s*\[\s*"agent-canary"' -Message 'Example agent canary policy file must declare the required canary label.'
+Assert-Match -Content $exampleAgentCanaryPolicy -Pattern '"canonicalPath"\s*:\s*"Tooling/comparevi-history-canary/CanaryProbe\.vi"' -Message 'Example agent canary policy file must bind the dedicated canary VI path.'
+Assert-Match -Content $exampleAgentCanaryPolicy -Pattern '"prMode"\s*:\s*"draft"' -Message 'Example agent canary policy file must require a draft canary PR.'
 Assert-Match -Content $safeTemplates -Pattern 'attributes,front-panel,block-diagram' -Message 'Safe template docs must document the explicit public mode contract.'
 Assert-Match -Content $safeTemplates -Pattern '\.github/comparevi-history-targets\.json' -Message 'Safe template docs must document the checked-in target catalog path.'
 Assert-Match -Content $safeTemplates -Pattern '\.github/comparevi-history-pr-policy\.json' -Message 'Safe template docs must document the checked-in PR policy path.'
@@ -262,10 +294,13 @@ Assert-Match -Content $safeTemplates -Pattern 'public-comment-path' -Message 'Sa
 Assert-Match -Content $safeTemplates -Pattern 'public-step-summary-path' -Message 'Safe template docs must point consumers at the action-owned step summary output.'
 Assert-Match -Content $safeTemplates -Pattern 'comparevi-history-pull-request-diagnostics-auto\.yml' -Message 'Safe template docs must document the dynamic changed-VI execution template.'
 Assert-Match -Content $safeTemplates -Pattern 'comparevi-history-pull-request-diagnostics-publish\.yml' -Message 'Safe template docs must document the workflow_run publication template.'
+Assert-Match -Content $safeTemplates -Pattern 'comparevi-history-agent-canary-evaluate\.yml' -Message 'Safe template docs must document the agent canary evaluation template.'
+Assert-Match -Content $safeTemplates -Pattern 'comparevi-history-agent-canary-policy\.json' -Message 'Safe template docs must document the agent canary policy example.'
 Assert-Match -Content $safeTemplates -Pattern 'dynamic-paths' -Message 'Safe template docs must document dynamic-path discovery.'
 Assert-Match -Content $safeTemplates -Pattern 'workflow_run' -Message 'Safe template docs must document workflow_run publication.'
 Assert-Match -Content $safeTemplates -Pattern 'hosted-auto' -Message 'Safe template docs must document hosted automatic fork execution.'
 Assert-Match -Content $safeTemplates -Pattern 'sticky comment' -Message 'Safe template docs must document the sticky-comment publication surface.'
+Assert-Match -Content $safeTemplates -Pattern 'agent-canary' -Message 'Safe template docs must document the dedicated agent-canary proof lane.'
 Assert-Match -Content $publishedValidationWorkflow -Pattern '\.github/comparevi-history-targets\.json' -Message 'Published validation must synthesize a checked-in-style target catalog path.'
 Assert-Match -Content $publishedValidationWorkflow -Pattern 'target_spec_path:\s+\.github/comparevi-history-targets\.json' -Message 'Published validation must route target_spec_path into the action.'
 Assert-Match -Content $publishedValidationWorkflow -Pattern 'target_id:\s+published-consumer-target' -Message 'Published validation must route a stable target id into the action.'
@@ -299,6 +334,8 @@ Assert-Match -Content $readme -Pattern 'comparevi-history/changed-vi-discovery@v
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-policy@v2' -Message 'README must document the dynamic PR policy contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-run@v2' -Message 'README must document the dynamic aggregate pull-request run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-comment-publication@v1' -Message 'README must document the PR comment publication contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/agent-canary-policy@v1' -Message 'README must document the agent-canary policy contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/agent-canary-evaluation@v1' -Message 'README must document the agent-canary evaluation contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/revision-catalog@v1' -Message 'README must document the revision catalog contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/exploration-run@v1' -Message 'README must document the exploration run contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/evidence-graph@v1' -Message 'README must document the canonical evidence graph contract.'
@@ -329,8 +366,10 @@ Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-manual-v
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pull-request-diagnostics\.yml' -Message 'README must point to the pull request diagnostics wrapper example.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pull-request-diagnostics-auto\.yml' -Message 'README must point to the automatic changed-VI execution wrapper example.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pull-request-diagnostics-publish\.yml' -Message 'README must point to the PR comment publication wrapper example.'
+Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-agent-canary-evaluate\.yml' -Message 'README must point to the agent canary evaluation wrapper example.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pr-policy\.json' -Message 'README must point to the PR policy example.'
 Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-pr-policy-v2\.json' -Message 'README must point to the dynamic PR policy example.'
+Assert-Match -Content $readme -Pattern 'docs/examples/comparevi-history-agent-canary-policy\.json' -Message 'README must point to the agent canary policy example.'
 Assert-Match -Content $readme -Pattern 'hosted NI Linux container path wired by a repo-local adapter' -Message 'README must document the hosted NI Linux adapter path.'
 Assert-Match -Content $readme -Pattern 'public-comment-path' -Message 'README must document the action-owned public comment output.'
 Assert-Match -Content $readme -Pattern 'shared-evidence\.json' -Message 'README must document the shared evidence output.'
@@ -341,6 +380,10 @@ Assert-Match -Content $readme -Pattern 'cross-repository and fork pull requests 
 Assert-Match -Content $readme -Pattern 'dynamic-paths' -Message 'README must document dynamic-path discovery for changed VIs.'
 Assert-Match -Content $readme -Pattern 'sticky PR comment' -Message 'README must document sticky PR comment publication.'
 Assert-Match -Content $readme -Pattern 'workflow_run' -Message 'README must document workflow_run-based publication.'
+Assert-Match -Content $readme -Pattern 'long-lived draft PR' -Message 'README must document the long-lived draft PR canary operating model.'
+Assert-Match -Content $readme -Pattern 'same-repo only' -Message 'README must document the same-repo-only canary pilot boundary.'
+Assert-Match -Content $readme -Pattern 'agent-canary/' -Message 'README must document the canary branch prefix.'
+Assert-Match -Content $readme -Pattern 'CompareVI History Pull Request Diagnostics Publish' -Message 'README must document the publish workflow dependency for canary evaluation.'
 Assert-Match -Content $readme -Pattern 'selectedTargets' -Message 'README must document selectedTargets in the v2 discovery receipt.'
 Assert-Match -Content $readme -Pattern 'maxChangedViCount = 10' -Message 'README must document the ten-VI overflow contract for the dynamic PR surface.'
 Assert-Match -Content $readme -Pattern 'attributes`, `front-panel`, and `block-diagram' -Message 'README must document explicit public modes only.'

--- a/scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1
+++ b/scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1
@@ -1,0 +1,631 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Repository,
+  [Parameter(Mandatory = $true)]
+  [string]$WorkflowRunId,
+  [Parameter(Mandatory = $true)]
+  [string]$CanaryPolicyPath,
+  [Parameter(Mandatory = $true)]
+  [string]$GitHubToken,
+  [string]$ArtifactName,
+  [string]$ResultsDir = 'tests/results/pr-diagnostics/canary',
+  [string]$GitHubOutputPath,
+  [string]$StepSummaryPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionOutput {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    return
+  }
+
+  $safeValue = if ($null -eq $Value) { '' } else { [string]$Value }
+  "$Key=$safeValue" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Read-JsonFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $raw = Get-Content -LiteralPath $Path -Raw
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw "JSON file was empty: $Path"
+  }
+
+  return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Get-OptionalString {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+function ConvertTo-ObjectArray {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable]) {
+    return @($Value)
+  }
+
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($item in ([System.Collections.IEnumerable]$Value)) {
+    $items.Add($item) | Out-Null
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function ConvertTo-StringArray {
+  param([AllowNull()]$Value)
+
+  return @(
+    ConvertTo-ObjectArray -Value $Value |
+      ForEach-Object { Get-OptionalString -Value $_ } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+}
+
+function Get-NestedValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+    [AllowNull()]
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function Get-GitHubHeaders {
+  return @{
+    Accept = 'application/vnd.github+json'
+    Authorization = "Bearer $GitHubToken"
+    'User-Agent' = 'comparevi-history-agent-canary'
+    'X-GitHub-Api-Version' = '2022-11-28'
+  }
+}
+
+function Invoke-GitHubJson {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Method,
+    [Parameter(Mandatory = $true)]
+    [string]$Uri
+  )
+
+  return Invoke-RestMethod -Method $Method -Uri $Uri -Headers (Get-GitHubHeaders)
+}
+
+function Find-Artifact {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositorySlug,
+    [Parameter(Mandatory = $true)]
+    [string]$RunId,
+    [Parameter(Mandatory = $true)]
+    [string]$RequestedArtifactName
+  )
+
+  $uri = "https://api.github.com/repos/$RepositorySlug/actions/runs/$RunId/artifacts?per_page=100"
+  $response = Invoke-GitHubJson -Method Get -Uri $uri
+  $artifacts = @($response.artifacts | Where-Object { $null -ne $_ })
+  $exact = @($artifacts | Where-Object { [string]$_.name -eq $RequestedArtifactName } | Select-Object -First 1)
+  if ($exact) {
+    return $exact
+  }
+
+  return @($artifacts | Where-Object { [string]$_.name -like "$RequestedArtifactName*" } | Select-Object -First 1)
+}
+
+function Find-ExpandedArtifactFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  return Get-ChildItem -LiteralPath $ArtifactRoot -Recurse -Filter $Name -File | Select-Object -First 1
+}
+
+function Get-CheckResult {
+  param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
+    [string[]]$Reasons
+  )
+
+  return [ordered]@{
+    matched = ($Reasons.Count -eq 0)
+    reasons = @($Reasons)
+  }
+}
+
+function Get-PullRequestDetails {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$RepositorySlug,
+    [Parameter(Mandatory = $true)]
+    [int]$PullRequestNumber
+  )
+
+  $uri = "https://api.github.com/repos/$RepositorySlug/pulls/$PullRequestNumber"
+  return Invoke-GitHubJson -Method Get -Uri $uri
+}
+
+$basePath = (Get-Location).Path
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
+$canaryPolicyPathResolved = Resolve-AbsolutePath -Path $CanaryPolicyPath -BasePath $basePath
+if (-not (Test-Path -LiteralPath $canaryPolicyPathResolved -PathType Leaf)) {
+  throw "Canary policy not found: $canaryPolicyPathResolved"
+}
+
+New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
+
+$effectiveArtifactName = if ([string]::IsNullOrWhiteSpace($ArtifactName)) {
+  "comparevi-history-pr-diagnostics-publish-$WorkflowRunId"
+} else {
+  $ArtifactName.Trim()
+}
+
+$receiptPath = Join-Path $resultsDirResolved 'agent-canary-evaluation.json'
+$downloadZipPath = Join-Path $resultsDirResolved 'publication-artifact.zip'
+$publicationArtifactRoot = Join-Path $resultsDirResolved 'publication-artifact'
+if (Test-Path -LiteralPath $publicationArtifactRoot) {
+  Remove-Item -LiteralPath $publicationArtifactRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $publicationArtifactRoot -Force | Out-Null
+
+$status = 'failed'
+$reason = 'unknown'
+$matchedPolicy = $false
+$failureReasons = New-Object System.Collections.Generic.List[string]
+$canaryPolicy = $null
+$publicationReceipt = $null
+$prRun = $null
+$discovery = $null
+$pullRequestDetails = $null
+$publicationReceiptPath = $null
+$prRunPath = $null
+$discoveryPath = $null
+$indexMarkdownPath = $null
+$indexHtmlPath = $null
+$pullRequest = $null
+$trustContext = $null
+$checks = $null
+
+try {
+  $canaryPolicy = Read-JsonFile -Path $canaryPolicyPathResolved
+  if ([string]$canaryPolicy.schema -ne 'comparevi-history/agent-canary-policy@v1') {
+    throw "Unsupported canary policy schema in '$canaryPolicyPathResolved': $($canaryPolicy.schema)"
+  }
+
+  $artifact = Find-Artifact -RepositorySlug $Repository -RunId $WorkflowRunId -RequestedArtifactName $effectiveArtifactName
+  if (-not $artifact) {
+    throw "missing-publication-artifact:$effectiveArtifactName"
+  }
+
+  Invoke-WebRequest -Uri ([string]$artifact.archive_download_url) -Headers (Get-GitHubHeaders) -OutFile $downloadZipPath
+  Expand-Archive -Path $downloadZipPath -DestinationPath $publicationArtifactRoot -Force
+
+  $publicationReceiptFile = Find-ExpandedArtifactFile -ArtifactRoot $publicationArtifactRoot -Name 'pr-comment-publication.json'
+  if (-not $publicationReceiptFile) {
+    throw 'missing-pr-comment-publication'
+  }
+  $publicationReceiptPath = $publicationReceiptFile.FullName
+  $publicationReceipt = Read-JsonFile -Path $publicationReceiptPath
+  if ([string]$publicationReceipt.schema -ne 'comparevi-history/pr-comment-publication@v1') {
+    throw "Unsupported publication receipt schema in '$publicationReceiptPath': $($publicationReceipt.schema)"
+  }
+
+  $prRunFile = Find-ExpandedArtifactFile -ArtifactRoot $publicationArtifactRoot -Name 'pr-run.json'
+  if (-not $prRunFile) {
+    throw 'missing-pr-run'
+  }
+  $prRunPath = $prRunFile.FullName
+  $prRun = Read-JsonFile -Path $prRunPath
+  if ([string]$prRun.schema -ne 'comparevi-history/pr-run@v2') {
+    throw "Unsupported PR run schema in '$prRunPath': $($prRun.schema)"
+  }
+
+  $discoveryFile = Find-ExpandedArtifactFile -ArtifactRoot $publicationArtifactRoot -Name 'changed-vi-discovery.json'
+  if (-not $discoveryFile) {
+    throw 'missing-changed-vi-discovery'
+  }
+  $discoveryPath = $discoveryFile.FullName
+  $discovery = Read-JsonFile -Path $discoveryPath
+  if ([string]$discovery.schema -ne 'comparevi-history/changed-vi-discovery@v2') {
+    throw "Unsupported discovery schema in '$discoveryPath': $($discovery.schema)"
+  }
+
+  $indexMarkdownFile = Find-ExpandedArtifactFile -ArtifactRoot $publicationArtifactRoot -Name 'index.md'
+  $indexHtmlFile = Find-ExpandedArtifactFile -ArtifactRoot $publicationArtifactRoot -Name 'index.html'
+  $indexMarkdownPath = if ($indexMarkdownFile) { $indexMarkdownFile.FullName } else { $null }
+  $indexHtmlPath = if ($indexHtmlFile) { $indexHtmlFile.FullName } else { $null }
+
+  $pullRequestNumber = [int]$prRun.pullRequest.number
+  $pullRequestDetails = Get-PullRequestDetails -RepositorySlug $Repository -PullRequestNumber $pullRequestNumber
+  $pullRequestLabels = @(
+    ConvertTo-ObjectArray -Value $pullRequestDetails.labels |
+      ForEach-Object { Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('name')) } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $pullRequest = [ordered]@{
+    number = [int]$prRun.pullRequest.number
+    htmlUrl = Get-OptionalString -Value $prRun.pullRequest.htmlUrl
+    baseRepository = [string]$prRun.pullRequest.baseRepository
+    baseRef = [string]$prRun.pullRequest.baseRef
+    baseSha = [string]$prRun.pullRequest.baseSha
+    headRepository = [string]$prRun.pullRequest.headRepository
+    headRef = [string]$prRun.pullRequest.headRef
+    headSha = [string]$prRun.pullRequest.headSha
+    isFork = [bool]$prRun.pullRequest.isFork
+    draft = [bool]$pullRequestDetails.draft
+    labels = @($pullRequestLabels)
+  }
+
+  $trustContext = [ordered]@{
+    sameRepository = ($pullRequest.baseRepository -eq $pullRequest.headRepository -and -not $pullRequest.isFork)
+    forkBehavior = Get-OptionalString -Value $prRun.executionContext.forkBehavior
+    fullSurface = Get-OptionalString -Value $prRun.executionContext.fullSurface
+  }
+
+  $branchPrefix = [string]$canaryPolicy.prIdentification.branchPrefix
+  $requiredLabels = @(ConvertTo-StringArray -Value $canaryPolicy.prIdentification.requiredLabels)
+  $prMode = [string]$canaryPolicy.promotionContract.prMode
+  $expectedPath = [string]$canaryPolicy.targetContract.canonicalPath
+  $expectedChangedViCount = [int]$canaryPolicy.targetContract.expectedChangedViCount
+  $expectedSelectedTargetCount = [int]$canaryPolicy.targetContract.expectedSelectedTargetCount
+  $expectedPublicModes = @(ConvertTo-StringArray -Value $canaryPolicy.executionContract.expectedPublicModes)
+  $expectedNoisePolicy = [string]$canaryPolicy.executionContract.expectedNoisePolicy
+  $expectedFullSurface = [string]$canaryPolicy.executionContract.expectedFullSurface
+  $stickyCommentRequired = [bool]$canaryPolicy.publicationContract.stickyCommentRequired
+  $requiredPublicationStatus = [string]$canaryPolicy.publicationContract.requiredStatus
+
+  $identificationReasons = New-Object System.Collections.Generic.List[string]
+  if (-not $trustContext.sameRepository) {
+    $identificationReasons.Add('same-repo-required') | Out-Null
+  }
+  if (-not $pullRequest.headRef.StartsWith($branchPrefix, [System.StringComparison]::Ordinal)) {
+    $identificationReasons.Add('branch-prefix-mismatch') | Out-Null
+  }
+  foreach ($requiredLabel in $requiredLabels) {
+    if ($pullRequest.labels -notcontains $requiredLabel) {
+      $identificationReasons.Add(("missing-required-label:{0}" -f $requiredLabel)) | Out-Null
+    }
+  }
+  switch ($prMode) {
+    'draft' {
+      if (-not $pullRequest.draft) {
+        $identificationReasons.Add('pr-not-draft') | Out-Null
+      }
+    }
+    'ready-for-review' {
+      if ($pullRequest.draft) {
+        $identificationReasons.Add('pr-not-ready-for-review') | Out-Null
+      }
+    }
+  }
+
+  $selectedTargetPaths = @(
+    ConvertTo-ObjectArray -Value $discovery.selectedTargets |
+      ForEach-Object { Get-OptionalString -Value $_.targetPath } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $targetReasons = New-Object System.Collections.Generic.List[string]
+  if ([int]$discovery.summary.changedViCount -ne $expectedChangedViCount) {
+    $targetReasons.Add('wrong-changed-vi-count') | Out-Null
+  }
+  if ([int]$discovery.summary.selectedTargetCount -ne $expectedSelectedTargetCount) {
+    $targetReasons.Add('wrong-selected-target-count') | Out-Null
+  }
+  if ($selectedTargetPaths.Count -ne 1 -or [string]$selectedTargetPaths[0] -ne $expectedPath) {
+    $targetReasons.Add('wrong-target-path') | Out-Null
+  }
+
+  $observedPublicModes = @(
+    ConvertTo-StringArray -Value (Get-NestedValue -Object $prRun -Path @('prPolicy', 'execution', 'publicModes'))
+  )
+  $executionReasons = New-Object System.Collections.Generic.List[string]
+  if ([string]$prRun.summary.finalStatus -ne 'succeeded') {
+    $executionReasons.Add('failed-execution') | Out-Null
+  }
+  if (($observedPublicModes -join ',') -ne ($expectedPublicModes -join ',')) {
+    $executionReasons.Add('wrong-public-modes') | Out-Null
+  }
+  if ([string](Get-NestedValue -Object $prRun -Path @('prPolicy', 'execution', 'noisePolicy')) -ne $expectedNoisePolicy) {
+    $executionReasons.Add('wrong-noise-policy') | Out-Null
+  }
+  if ([string](Get-NestedValue -Object $prRun -Path @('executionContext', 'fullSurface')) -ne $expectedFullSurface) {
+    $executionReasons.Add('wrong-full-surface') | Out-Null
+  }
+
+  $publicationReasons = New-Object System.Collections.Generic.List[string]
+  if ([string]$publicationReceipt.summary.status -ne $requiredPublicationStatus) {
+    $publicationReasons.Add('failed-publication') | Out-Null
+  }
+  if ($stickyCommentRequired) {
+    $hasStickyComment = (
+      [string]$publicationReceipt.summary.commentAction -in @('created', 'updated', 'unchanged') -and
+      $null -ne $publicationReceipt.summary.commentId -and
+      -not [string]::IsNullOrWhiteSpace([string]$publicationReceipt.summary.commentUrl)
+    )
+    if (-not $hasStickyComment) {
+      $publicationReasons.Add('missing-sticky-comment') | Out-Null
+    }
+  }
+
+  $artifactReasons = New-Object System.Collections.Generic.List[string]
+  if (-not $indexMarkdownFile -or -not $indexHtmlFile) {
+    $artifactReasons.Add('missing-index-surface') | Out-Null
+  }
+
+  $checks = [ordered]@{
+    identification = Get-CheckResult -Reasons @($identificationReasons)
+    targetContract = Get-CheckResult -Reasons @($targetReasons)
+    executionContract = Get-CheckResult -Reasons @($executionReasons)
+    publicationContract = Get-CheckResult -Reasons @($publicationReasons)
+    artifactContract = Get-CheckResult -Reasons @($artifactReasons)
+  }
+
+  $matchedPolicy = [bool]$checks.identification.matched
+  if (-not $matchedPolicy) {
+    $status = 'skipped'
+    $reason = 'non-canary-pr'
+    foreach ($entry in @($checks.identification.reasons)) {
+      $failureReasons.Add([string]$entry) | Out-Null
+    }
+  } else {
+    foreach ($group in @($checks.targetContract.reasons, $checks.executionContract.reasons, $checks.publicationContract.reasons, $checks.artifactContract.reasons)) {
+      foreach ($entry in @($group)) {
+        $failureReasons.Add([string]$entry) | Out-Null
+      }
+    }
+
+    if ($failureReasons.Count -gt 0) {
+      $status = 'failed'
+      $reason = [string]$failureReasons[0]
+    } else {
+      $status = 'succeeded'
+      $reason = 'canary-acceptance-satisfied'
+    }
+  }
+} catch {
+  $status = 'failed'
+  $reason = $_.Exception.Message
+  if ($failureReasons.Count -eq 0 -and -not [string]::IsNullOrWhiteSpace($reason)) {
+    $failureReasons.Add($reason) | Out-Null
+  }
+}
+
+$policyReceipt = if ($null -eq $canaryPolicy) {
+  [ordered]@{
+    schema = 'comparevi-history/agent-canary-policy@v1'
+    path = $canaryPolicyPathResolved
+    prIdentification = [ordered]@{}
+    targetContract = [ordered]@{}
+    executionContract = [ordered]@{}
+    publicationContract = [ordered]@{}
+    promotionContract = [ordered]@{}
+  }
+} else {
+  [ordered]@{
+    schema = [string]$canaryPolicy.schema
+    path = $canaryPolicyPathResolved
+    prIdentification = $canaryPolicy.prIdentification
+    targetContract = $canaryPolicy.targetContract
+    executionContract = $canaryPolicy.executionContract
+    publicationContract = $canaryPolicy.publicationContract
+    promotionContract = $canaryPolicy.promotionContract
+  }
+}
+
+if ($null -eq $pullRequest) {
+  $pullRequest = [ordered]@{
+    number = $(if ($null -ne $prRun -and $null -ne $prRun.pullRequest -and $null -ne $prRun.pullRequest.number) { [int]$prRun.pullRequest.number } else { 0 })
+    htmlUrl = $(if ($null -ne $prRun) { Get-OptionalString -Value $prRun.pullRequest.htmlUrl } else { $null })
+    baseRepository = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.baseRepository } else { $Repository })
+    baseRef = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.baseRef } else { '' })
+    baseSha = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.baseSha } else { '' })
+    headRepository = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.headRepository } else { $Repository })
+    headRef = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.headRef } else { '' })
+    headSha = $(if ($null -ne $prRun) { [string]$prRun.pullRequest.headSha } else { '' })
+    isFork = $(if ($null -ne $prRun) { [bool]$prRun.pullRequest.isFork } else { $false })
+    draft = $(if ($null -ne $pullRequestDetails) { [bool]$pullRequestDetails.draft } else { $false })
+    labels = @()
+  }
+}
+
+if ($null -eq $trustContext) {
+  $trustContext = [ordered]@{
+    sameRepository = ($pullRequest.baseRepository -eq $pullRequest.headRepository -and -not $pullRequest.isFork)
+    forkBehavior = $(if ($null -ne $prRun) { Get-OptionalString -Value $prRun.executionContext.forkBehavior } else { $null })
+    fullSurface = $(if ($null -ne $prRun) { Get-OptionalString -Value $prRun.executionContext.fullSurface } else { $null })
+  }
+}
+
+if ($null -eq $checks) {
+  $checks = [ordered]@{
+    identification = Get-CheckResult -Reasons @()
+    targetContract = Get-CheckResult -Reasons @()
+    executionContract = Get-CheckResult -Reasons @()
+    publicationContract = Get-CheckResult -Reasons @()
+    artifactContract = Get-CheckResult -Reasons @()
+  }
+}
+
+$evaluation = [ordered]@{
+  schema = 'comparevi-history/agent-canary-evaluation@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  repository = $Repository
+  workflowRunId = $WorkflowRunId
+  artifactName = $effectiveArtifactName
+  canaryPolicy = $policyReceipt
+  pullRequest = $pullRequest
+  trustContext = $trustContext
+  discovery = [ordered]@{
+    schema = $(if ($null -ne $discovery) { [string]$discovery.schema } else { 'comparevi-history/changed-vi-discovery@v2' })
+    path = $(if ([string]::IsNullOrWhiteSpace($discoveryPath)) { $null } else { $discoveryPath })
+    status = $(if ($null -ne $discovery) { [string]$discovery.summary.executionStatus } else { 'blocked' })
+    reason = $(if ($null -ne $discovery) { [string]$discovery.summary.executionReason } else { 'missing-changed-vi-discovery' })
+    changedViCount = $(if ($null -ne $discovery) { [int]$discovery.summary.changedViCount } else { 0 })
+    selectedTargetCount = $(if ($null -ne $discovery) { [int]$discovery.summary.selectedTargetCount } else { 0 })
+    selectedTargetPaths = @(
+      if ($null -ne $discovery) {
+        ConvertTo-ObjectArray -Value $discovery.selectedTargets |
+          ForEach-Object { Get-OptionalString -Value $_.targetPath } |
+          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+      }
+    )
+  }
+  execution = [ordered]@{
+    schema = $(if ($null -ne $prRun) { [string]$prRun.schema } else { 'comparevi-history/pr-run@v2' })
+    path = $(if ([string]::IsNullOrWhiteSpace($prRunPath)) { $null } else { $prRunPath })
+    finalStatus = $(if ($null -ne $prRun) { [string]$prRun.summary.finalStatus } else { 'failed' })
+    finalReason = $(if ($null -ne $prRun) { [string]$prRun.summary.finalReason } else { 'missing-pr-run' })
+    publicModes = @(
+      if ($null -ne $prRun) {
+        ConvertTo-StringArray -Value (Get-NestedValue -Object $prRun -Path @('prPolicy', 'execution', 'publicModes'))
+      }
+    )
+    noisePolicy = $(if ($null -ne $prRun) { Get-OptionalString -Value (Get-NestedValue -Object $prRun -Path @('prPolicy', 'execution', 'noisePolicy')) } else { $null })
+    fullSurface = $(if ($null -ne $prRun) { Get-OptionalString -Value (Get-NestedValue -Object $prRun -Path @('executionContext', 'fullSurface')) } else { $null })
+  }
+  publication = [ordered]@{
+    schema = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.schema } else { 'comparevi-history/pr-comment-publication@v1' })
+    path = $(if ([string]::IsNullOrWhiteSpace($publicationReceiptPath)) { $null } else { $publicationReceiptPath })
+    status = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.summary.status } else { 'failed' })
+    reason = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.summary.reason } else { 'missing-pr-comment-publication' })
+    commentAction = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.summary.commentAction } else { 'none' })
+    commentId = $(if ($null -ne $publicationReceipt -and $null -ne $publicationReceipt.summary.commentId) { [int64]$publicationReceipt.summary.commentId } else { $null })
+    commentUrl = $(if ($null -ne $publicationReceipt) { Get-OptionalString -Value $publicationReceipt.summary.commentUrl } else { $null })
+  }
+  outputs = [ordered]@{
+    resultsDir = $resultsDirResolved
+    evaluationPath = $receiptPath
+    publicationArtifactRoot = $publicationArtifactRoot
+    publicationReceiptPath = $(if ([string]::IsNullOrWhiteSpace($publicationReceiptPath)) { $null } else { $publicationReceiptPath })
+    prRunPath = $(if ([string]::IsNullOrWhiteSpace($prRunPath)) { $null } else { $prRunPath })
+    discoveryPath = $(if ([string]::IsNullOrWhiteSpace($discoveryPath)) { $null } else { $discoveryPath })
+    indexMarkdownPath = $(if ([string]::IsNullOrWhiteSpace($indexMarkdownPath)) { $null } else { $indexMarkdownPath })
+    indexHtmlPath = $(if ([string]::IsNullOrWhiteSpace($indexHtmlPath)) { $null } else { $indexHtmlPath })
+  }
+  checks = $checks
+  summary = [ordered]@{
+    matchedPolicy = $matchedPolicy
+    status = $status
+    reason = $reason
+    failureReasons = @($failureReasons)
+    changedViCount = $(if ($null -ne $discovery) { [int]$discovery.summary.changedViCount } else { 0 })
+    selectedTargetCount = $(if ($null -ne $discovery) { [int]$discovery.summary.selectedTargetCount } else { 0 })
+    executionFinalStatus = $(if ($null -ne $prRun) { [string]$prRun.summary.finalStatus } else { 'failed' })
+    executionFinalReason = $(if ($null -ne $prRun) { [string]$prRun.summary.finalReason } else { 'missing-pr-run' })
+    publicationStatus = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.summary.status } else { 'failed' })
+    publicationReason = $(if ($null -ne $publicationReceipt) { [string]$publicationReceipt.summary.reason } else { 'missing-pr-comment-publication' })
+  }
+}
+$evaluation | ConvertTo-Json -Depth 64 | Set-Content -LiteralPath $receiptPath -Encoding utf8
+
+Write-ActionOutput -Key 'evaluation-path' -Value $receiptPath
+Write-ActionOutput -Key 'evaluation-status' -Value $status
+Write-ActionOutput -Key 'evaluation-reason' -Value $reason
+Write-ActionOutput -Key 'matched-policy' -Value $matchedPolicy.ToString().ToLowerInvariant()
+Write-ActionOutput -Key 'artifact-name' -Value $effectiveArtifactName
+Write-ActionOutput -Key 'publication-receipt-path' -Value $(if ([string]::IsNullOrWhiteSpace($publicationReceiptPath)) { '' } else { $publicationReceiptPath })
+Write-ActionOutput -Key 'pr-run-path' -Value $(if ([string]::IsNullOrWhiteSpace($prRunPath)) { '' } else { $prRunPath })
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  @(
+    '## comparevi-history agent canary evaluation'
+    ''
+    ('- Workflow run id: `{0}`' -f $WorkflowRunId)
+    ('- Artifact name: `{0}`' -f $effectiveArtifactName)
+    ('- Matched canary policy: `{0}`' -f $matchedPolicy.ToString().ToLowerInvariant())
+    ('- Evaluation status: `{0}`' -f $status)
+    ('- Evaluation reason: `{0}`' -f $reason)
+    ('- Pull request number: `{0}`' -f $(if ($evaluation.pullRequest.number -gt 0) { [string]$evaluation.pullRequest.number } else { 'n/a' }))
+    ('- Pull request ref: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace($evaluation.pullRequest.headRef)) { 'n/a' } else { $evaluation.pullRequest.headRef }))
+    ('- Changed VIs: `{0}`' -f $evaluation.summary.changedViCount)
+    ('- Selected targets: `{0}`' -f $evaluation.summary.selectedTargetCount)
+    ('- Execution final status: `{0}`' -f $evaluation.summary.executionFinalStatus)
+    ('- Publication status: `{0}`' -f $evaluation.summary.publicationStatus)
+    ('- Receipt: `{0}`' -f $receiptPath)
+  ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+if ($status -eq 'failed') {
+  throw $reason
+}
+
+$evaluation | ConvertTo-Json -Depth 64


### PR DESCRIPTION
## Summary
- add the agent-canary policy and evaluation contracts
- add a reusable canary evaluation workflow and example wrapper/policy files
- document and test the canary surface in README, safe-template docs, CI, and template contracts

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

## Issue
- Closes #105
