### PR TITLE
#111 Resolve canary evaluation artifacts from publisher runs

### DIFF
--- a/.github/workflows/pull-request-diagnostics-canary-evaluate.yml
+++ b/.github/workflows/pull-request-diagnostics-canary-evaluate.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       artifact_name:
-        description: Optional publication artifact name override.
+        description: Optional publication artifact name override. When unset, the evaluator resolves the publication artifact from the completed publisher run.
         required: false
         default: ''
         type: string

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ The canary lane is intentionally narrow:
 The evaluator consumes publication receipts and artifact contents only:
 
 - it downloads the publication artifact from `CompareVI History Pull Request Diagnostics Publish`
+- it resolves that publication artifact from the completed publisher run instead of requiring the consumer to predict a
+  publisher-artifact name from the `workflow_run` payload
 - it reads `pr-comment-publication.json`, `pr-run.json`, `changed-vi-discovery.json`, `index.md`, and `index.html`
 - it verifies the changed-VI count, selected-target count, canonical canary path, explicit public modes, raw
   `noisePolicy = include`, sticky comment publication, and `artifact-index` reviewer surface

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -153,6 +153,9 @@ Consumer repositories should not contain:
   `<!-- comparevi-history:pull-request-diagnostics -->`.
 - The agent-canary evaluation template expects the publication artifact to contain `pr-comment-publication.json` plus
   the expanded execution artifact with `pr-run.json`, `changed-vi-discovery.json`, `index.md`, and `index.html`.
+- The agent-canary evaluation template should not try to predict a publication artifact name from the publisher
+  `workflow_run` id. The reusable evaluator resolves the publication artifact from the completed publisher run and treats
+  `artifact_name` as an override only.
 - The agent-canary lane is same-repo only, uses branch prefix `agent-canary/`, requires the `agent-canary` label, and
   expects one long-lived draft PR instead of a stream of throwaway proof branches.
 - The action owns reviewer-facing rendering. Consumers should publish PR comments from `public-comment-path` and append

--- a/docs/examples/comparevi-history-agent-canary-evaluate.yml
+++ b/docs/examples/comparevi-history-agent-canary-evaluate.yml
@@ -19,6 +19,5 @@ jobs:
     with:
       consumer_repository: ${{ github.repository }}
       workflow_run_id: ${{ github.event.workflow_run.id }}
-      artifact_name: comparevi-history-pr-diagnostics-publish-${{ github.event.workflow_run.id }}
       canary_policy_path: .github/comparevi-history-agent-canary.json
       platform_ref: v1

--- a/scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
+++ b/scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
@@ -343,11 +343,20 @@ try {
 
     $methodKey = if ([string]::IsNullOrWhiteSpace($Method)) { 'Get' } else { $Method }
     if ($methodKey -eq 'Get' -and $Uri -like 'https://api.github.com/repos/*/actions/runs/*/artifacts?per_page=100') {
+      $artifactNames = @()
+      if ($global:MockScenario -is [System.Collections.IDictionary] -and $global:MockScenario.Contains('ArtifactNames')) {
+        $artifactNames = @($global:MockScenario.ArtifactNames)
+      } elseif ($global:MockScenario -is [System.Collections.IDictionary] -and $global:MockScenario.Contains('ArtifactName') -and -not [string]::IsNullOrWhiteSpace($global:MockScenario.ArtifactName)) {
+        $artifactNames = @($global:MockScenario.ArtifactName)
+      }
+
       return @{
         artifacts = @(
-          @{
-            name = $global:MockScenario.ArtifactName
-            archive_download_url = 'https://example.test/publication-artifact.zip'
+          $artifactNames | ForEach-Object {
+            @{
+              name = $_
+              archive_download_url = 'https://example.test/publication-artifact.zip'
+            }
           }
         )
       }
@@ -418,6 +427,9 @@ try {
   if ($successReceipt.publication.status -ne 'succeeded' -or $successReceipt.execution.finalStatus -ne 'succeeded') {
     throw 'Success case status propagation mismatch.'
   }
+  if ($successReceipt.artifactName -ne 'comparevi-history-pr-diagnostics-publish-444') {
+    throw 'Success case should preserve the resolved artifact name.'
+  }
   if (-not (Test-Path -LiteralPath $successReceipt.outputs.indexMarkdownPath -PathType Leaf) -or
     -not (Test-Path -LiteralPath $successReceipt.outputs.indexHtmlPath -PathType Leaf)) {
     throw 'Success case should preserve index surfaces.'
@@ -463,6 +475,32 @@ try {
     $skipReceipt.summary.failureReasons -notcontains 'missing-required-label:agent-canary' -or
     $skipReceipt.summary.failureReasons -notcontains 'pr-not-draft') {
     throw 'Non-canary skip reasons mismatch.'
+  }
+
+  $fallbackRoot = Join-Path $tempRoot 'fallback'
+  New-Item -ItemType Directory -Path $fallbackRoot -Force | Out-Null
+  $fallbackFixture = New-PublicationArtifactZip -RootPath $fallbackRoot -HeadRef 'feature/not-a-canary' -Draft $false -Labels @('triage')
+  $global:MockScenario = @{
+    ArtifactNames = @('comparevi-history-pr-diagnostics-publish-333')
+    ZipPath = $fallbackFixture.ZipPath
+    PullRequestDraft = $fallbackFixture.Draft
+    PullRequestLabels = $fallbackFixture.Labels
+  }
+
+  $fallbackJson = & $scriptPath `
+    -Repository 'LabVIEW-Community-CI-CD/labview-icon-editor-demo' `
+    -WorkflowRunId '4451' `
+    -ArtifactName 'comparevi-history-pr-diagnostics-publish-4451' `
+    -CanaryPolicyPath $policyPath `
+    -GitHubToken 'token' `
+    -ResultsDir (Join-Path $fallbackRoot 'results')
+
+  $fallbackReceipt = $fallbackJson | ConvertFrom-Json -Depth 64
+  if ($fallbackReceipt.artifactName -ne 'comparevi-history-pr-diagnostics-publish-333') {
+    throw 'Fallback resolution should use the actual publisher artifact name.'
+  }
+  if ($fallbackReceipt.summary.status -ne 'skipped' -or $fallbackReceipt.summary.reason -ne 'non-canary-pr') {
+    throw 'Fallback resolution should still skip non-canary PRs cleanly.'
   }
 
   $wrongPathRoot = Join-Path $tempRoot 'wrong-path'

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -153,7 +153,7 @@ Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*actions:\s+read\s*$
 Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*contents:\s+read\s*$' -Message 'Agent canary template must request contents: read.'
 Assert-Match -Content $agentCanaryTemplate -Pattern '(?m)^\s*pull-requests:\s+read\s*$' -Message 'Agent canary template must request pull-requests: read so labels and draft state can be evaluated deterministically.'
 Assert-Match -Content $agentCanaryTemplate -Pattern 'workflow_run_id:\s+\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Agent canary template must route workflow_run.id into the reusable evaluator.'
-Assert-Match -Content $agentCanaryTemplate -Pattern 'artifact_name:\s+comparevi-history-pr-diagnostics-publish-\$\{\{ github\.event\.workflow_run\.id \}\}' -Message 'Agent canary template must resolve the deterministic publication artifact name.'
+Assert-NotMatch -Content $agentCanaryTemplate -Pattern '(?m)^\s*artifact_name:\s*$' -Message 'Agent canary template should let the reusable evaluator resolve the publisher artifact from the completed workflow run.'
 Assert-Match -Content $agentCanaryTemplate -Pattern 'canary_policy_path:\s+\.github/comparevi-history-agent-canary\.json' -Message 'Agent canary template must consume the checked-in agent-canary policy.'
 Assert-Match -Content $agentCanaryTemplate -Pattern 'platform_ref:\s+v1' -Message 'Agent canary template must keep platform_ref aligned with the workflow pin.'
 

--- a/scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1
+++ b/scripts/Write-CompareVIHistoryAgentCanaryEvaluation.ps1
@@ -179,11 +179,27 @@ function Find-Artifact {
   $response = Invoke-GitHubJson -Method Get -Uri $uri
   $artifacts = @($response.artifacts | Where-Object { $null -ne $_ })
   $exact = @($artifacts | Where-Object { [string]$_.name -eq $RequestedArtifactName } | Select-Object -First 1)
-  if ($exact) {
-    return $exact
+  if ($exact.Count -gt 0) {
+    return $exact[0]
   }
 
-  return @($artifacts | Where-Object { [string]$_.name -like "$RequestedArtifactName*" } | Select-Object -First 1)
+  $prefix = @($artifacts | Where-Object { [string]$_.name -like "$RequestedArtifactName*" } | Select-Object -First 1)
+  if ($prefix.Count -gt 0) {
+    return $prefix[0]
+  }
+
+  # workflow_run follow-ons can know the publisher run id but not always the execution-derived artifact name.
+  # When the publisher exposes a single artifact, treat it as the canonical publication payload.
+  if ($artifacts.Count -eq 1) {
+    return $artifacts[0]
+  }
+
+  $publicationArtifacts = @($artifacts | Where-Object { [string]$_.name -like 'comparevi-history-pr-diagnostics-publish-*' })
+  if ($publicationArtifacts.Count -eq 1) {
+    return $publicationArtifacts[0]
+  }
+
+  return $null
 }
 
 function Find-ExpandedArtifactFile {
@@ -231,11 +247,12 @@ if (-not (Test-Path -LiteralPath $canaryPolicyPathResolved -PathType Leaf)) {
 
 New-Item -ItemType Directory -Path $resultsDirResolved -Force | Out-Null
 
-$effectiveArtifactName = if ([string]::IsNullOrWhiteSpace($ArtifactName)) {
+$requestedArtifactName = if ([string]::IsNullOrWhiteSpace($ArtifactName)) {
   "comparevi-history-pr-diagnostics-publish-$WorkflowRunId"
 } else {
   $ArtifactName.Trim()
 }
+$effectiveArtifactName = $requestedArtifactName
 
 $receiptPath = Join-Path $resultsDirResolved 'agent-canary-evaluation.json'
 $downloadZipPath = Join-Path $resultsDirResolved 'publication-artifact.zip'
@@ -269,10 +286,11 @@ try {
     throw "Unsupported canary policy schema in '$canaryPolicyPathResolved': $($canaryPolicy.schema)"
   }
 
-  $artifact = Find-Artifact -RepositorySlug $Repository -RunId $WorkflowRunId -RequestedArtifactName $effectiveArtifactName
+  $artifact = Find-Artifact -RepositorySlug $Repository -RunId $WorkflowRunId -RequestedArtifactName $requestedArtifactName
   if (-not $artifact) {
-    throw "missing-publication-artifact:$effectiveArtifactName"
+    throw "missing-publication-artifact:$requestedArtifactName"
   }
+  $effectiveArtifactName = [string]$artifact.name
 
   Invoke-WebRequest -Uri ([string]$artifact.archive_download_url) -Headers (Get-GitHubHeaders) -OutFile $downloadZipPath
   Expand-Archive -Path $downloadZipPath -DestinationPath $publicationArtifactRoot -Force


### PR DESCRIPTION
## Summary
- resolve agent-canary publication artifacts from the completed publisher run instead of requiring a consumer-predicted artifact name
- keep `artifact_name` as an override, not the default contract
- update the published canary template so consumers stay thin and stop guessing publisher artifact names

## Why
- live proof `LabVIEW-Community-CI-CD/labview-icon-editor-demo#31` succeeded on execution and publication
- follow-on canary evaluation run `23226121447` failed because the publisher artifact name is keyed to the execution run id, not the publisher `workflow_run` id
- a same-repo non-canary PR should skip cleanly after evaluating the publication artifact, not fail on artifact lookup

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`
