### PR TITLE
Fix PR preview gallery selection so mode-distinct pairs surface in comments and indexes

### DIFF
--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -48,9 +48,17 @@
         "targetCount": { "type": "integer", "minimum": 0 },
         "previewPairCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairCap": { "type": "integer", "minimum": 0 },
+        "commentSelectionPolicy": {
+          "type": "string",
+          "const": "mode-balanced@v1"
+        },
         "commentPreviewPairCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairOmittedCount": { "type": "integer", "minimum": 0 },
         "indexPreviewPairCap": { "type": "integer", "minimum": 0 },
+        "indexSelectionPolicy": {
+          "type": "string",
+          "const": "mode-balanced@v1"
+        },
         "indexPreviewPairCount": { "type": "integer", "minimum": 0 },
         "indexPreviewPairOmittedCount": { "type": "integer", "minimum": 0 }
       }

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -5,6 +5,103 @@ $scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryAutomaticPullReques
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-auto-pr-run-' + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
+function New-PreviewReportFixture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModeRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactPrefix,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex,
+    [Parameter(Mandatory = $true)]
+    [string]$BaseRef,
+    [Parameter(Mandatory = $true)]
+    [string]$HeadRef
+  )
+
+  $artifactDir = Join-Path $ModeRoot ('{0}-{1:D3}-artifacts' -f $ArtifactPrefix, $ComparisonIndex)
+  $reportFilesDir = Join-Path $artifactDir 'compare-report_files'
+  New-Item -ItemType Directory -Path $reportFilesDir -Force | Out-Null
+  foreach ($imageName in @('fp_1.png', 'fp_2.png')) {
+    [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir $imageName), @(0xCA, 0xFE, 0xBA, 0xBE))
+  }
+
+  $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
+  @'
+<!DOCTYPE html>
+<html>
+<body>
+<div class="compared-VIs">
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
+<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr></table></details>
+</div>
+</body>
+</html>
+'@ | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
+
+  return [ordered]@{
+    index = $ComparisonIndex
+    base = [ordered]@{ ref = $BaseRef }
+    head = [ordered]@{ ref = $HeadRef }
+    result = [ordered]@{
+      reportHtml = $reportHtmlPath
+    }
+  }
+}
+
+function New-PreviewModeFixture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$HistoryRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$ModeName,
+    [Parameter(Mandatory = $true)]
+    [string]$ArtifactPrefix
+  )
+
+  $modeRoot = Join-Path $HistoryRoot $ModeName
+  New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
+  $modeManifestPath = Join-Path $modeRoot 'manifest.json'
+  $comparisons = @(
+    (New-PreviewReportFixture -ModeRoot $modeRoot -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $ModeName) -HeadRef ('{0}-head-1' -f $ModeName)),
+    (New-PreviewReportFixture -ModeRoot $modeRoot -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $ModeName) -HeadRef ('{0}-head-2' -f $ModeName))
+  )
+
+  ([ordered]@{
+      schema = 'vi-compare/history@v1'
+      generatedAt = '2026-03-17T00:00:30Z'
+      mode = $ModeName
+      comparisons = $comparisons
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+
+  return [ordered]@{
+    name = $ModeName
+    manifestPath = $modeManifestPath
+  }
+}
+
+function Get-OrdinalPositions {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Content,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Needles
+  )
+
+  $positions = New-Object System.Collections.Generic.List[int]
+  foreach ($needle in $Needles) {
+    $position = $Content.IndexOf($needle, [System.StringComparison]::Ordinal)
+    if ($position -lt 0) {
+      throw "Missing expected content: $needle"
+    }
+
+    $positions.Add($position) | Out-Null
+  }
+
+  return @($positions | ForEach-Object { $_ })
+}
+
 try {
   $resultsDir = Join-Path $tempRoot 'results'
   New-Item -ItemType Directory -Path $resultsDir -Force | Out-Null
@@ -146,64 +243,17 @@ try {
   }
 
   $targetOneHistoryRoot = Split-Path -Parent $targetOneRoot
-  $targetOneModeRoot = Join-Path $targetOneHistoryRoot 'front-panel'
-  $targetOneArtifactDir = Join-Path $targetOneModeRoot 'VIP_Post-Install_Custom_Action.vi-001-artifacts'
-  $targetOneReportFilesDir = Join-Path $targetOneArtifactDir 'compare-report_files'
-  New-Item -ItemType Directory -Path $targetOneReportFilesDir -Force | Out-Null
-  foreach ($imageName in @('fp_1.png', 'fp_2.png', '0_0_11_11_1.png', '0_0_11_11_2.png')) {
-    [System.IO.File]::WriteAllBytes((Join-Path $targetOneReportFilesDir $imageName), @(0xCA, 0xFE, 0xBA, 0xBE))
-  }
-
-  $targetOneReportHtmlPath = Join-Path $targetOneArtifactDir 'compare-report.html'
-  @'
-<!DOCTYPE html>
-<html>
-<body>
-<div class="compared-VIs">
-<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div></summary>
-<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
-<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr></table></details>
-</div>
-<details class="cosmetic" closed>
-<summary class="difference-cosmetic-heading">1. Front Panel - Variant</summary>
-<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">/compare/m0/Base.vi</td><td class="difference-divider"></td><td class="compared-vi-image-caption">/compare/m0/Head.vi</td></tr><tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/0_0_11_11_1.png" alt="compare-report_files/0_0_11_11_1.png"></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/0_0_11_11_2.png" alt="compare-report_files/0_0_11_11_2.png"></td></tr></table>
-</details>
-</body>
-</html>
-'@ | Set-Content -LiteralPath $targetOneReportHtmlPath -Encoding utf8
-
-  $targetOneModeManifestPath = Join-Path $targetOneModeRoot 'manifest.json'
-  @"
-{
-  "schema": "vi-compare/history@v1",
-  "generatedAt": "2026-03-17T00:00:30Z",
-  "mode": "front-panel",
-  "comparisons": [
-    {
-      "index": 1,
-      "base": { "ref": "base-sha" },
-      "head": { "ref": "head-sha" },
-      "result": {
-        "reportHtml": "$($targetOneReportHtmlPath.Replace('\', '\\'))"
-      }
-    }
-  ]
-}
-"@ | Set-Content -LiteralPath $targetOneModeManifestPath -Encoding utf8
-
   $targetOneSuiteManifestPath = Join-Path $targetOneHistoryRoot 'manifest.json'
-  @"
-{
-  "schema": "vi-compare/history-suite@v1",
-  "generatedAt": "2026-03-17T00:00:30Z",
-  "modes": [
-    {
-      "name": "front-panel",
-      "manifestPath": "$($targetOneModeManifestPath.Replace('\', '\\'))"
-    }
-  ]
-}
-"@ | Set-Content -LiteralPath $targetOneSuiteManifestPath -Encoding utf8
+  $targetOneModes = @(
+    (New-PreviewModeFixture -HistoryRoot $targetOneHistoryRoot -ModeName 'front-panel' -ArtifactPrefix 'VIP_Post-Install_Custom_Action.vi'),
+    (New-PreviewModeFixture -HistoryRoot $targetOneHistoryRoot -ModeName 'block-diagram' -ArtifactPrefix 'VIP_Post-Install_Custom_Action.vi'),
+    (New-PreviewModeFixture -HistoryRoot $targetOneHistoryRoot -ModeName 'attributes' -ArtifactPrefix 'VIP_Post-Install_Custom_Action.vi')
+  )
+  ([ordered]@{
+      schema = 'vi-compare/history-suite@v1'
+      generatedAt = '2026-03-17T00:00:30Z'
+      modes = $targetOneModes
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $targetOneSuiteManifestPath -Encoding utf8
 
   foreach ($path in @(
       (Join-Path $targetOneRoot 'request.json'),
@@ -319,7 +369,11 @@ try {
   if ($receipt.summary.totalProcessed -ne 5 -or $receipt.summary.totalDiffs -ne 2) {
     throw 'Aggregate totals mismatch.'
   }
-  if ($receipt.summary.previewPairCount -ne 2 -or $receipt.summary.commentPreviewPairCount -ne 2 -or $receipt.summary.indexPreviewPairCount -ne 2) {
+  if ($receipt.summary.previewPairCount -ne 6 -or
+    $receipt.summary.commentPreviewPairCount -ne 4 -or
+    $receipt.summary.commentPreviewPairOmittedCount -ne 2 -or
+    $receipt.summary.indexPreviewPairCount -ne 6 -or
+    $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
     throw 'Aggregate preview pair summary mismatch.'
   }
   if ($receipt.outputs.workflowRunUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/actions/runs/123456789') {
@@ -353,8 +407,8 @@ try {
   if ($commentBody -notmatch [regex]::Escape('comparevi-history-pr-diagnostics-123456789')) {
     throw 'PR comment body should point reviewers at the artifact bundle.'
   }
-  if ($commentBody -notmatch [regex]::Escape('PR comment preview gallery: `2` shown, `0` omitted, cap `4`')) {
-    throw 'PR comment body should surface preview pair counts.'
+  if ($commentBody -notmatch [regex]::Escape('PR comment preview gallery: `4` shown, `2` omitted, cap `4`')) {
+    throw 'PR comment body should surface the corrected preview pair counts.'
   }
 
   $indexMarkdown = Get-Content -LiteralPath $receipt.outputs.indexMarkdownPath -Raw
@@ -372,26 +426,50 @@ try {
       throw "Index markdown is missing '$requiredText'."
     }
   }
-  if ($indexMarkdown -notmatch [regex]::Escape('![Tooling/deployment/VIP_Post-Install Custom Action.vi | front-panel | Front Panel Overview base](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png)')) {
-    throw 'Index markdown should embed the preview base image.'
+  if ([regex]::Matches($indexMarkdown, [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi |')).Count -ne 6) {
+    throw 'Index markdown should render six preview entries for the PR31-shaped fixture.'
   }
-  if ($indexMarkdown -notmatch [regex]::Escape('![Tooling/deployment/VIP_Post-Install Custom Action.vi | front-panel | Front Panel Overview head](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_2.png)')) {
-    throw 'Index markdown should embed the preview head image.'
+
+  $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+  )
+  if (-not ($markdownPositions[0] -lt $markdownPositions[1] -and $markdownPositions[1] -lt $markdownPositions[2] -and $markdownPositions[2] -lt $markdownPositions[3])) {
+    throw 'Index markdown should preserve the mode-balanced preview ordering.'
   }
 
   $indexHtml = Get-Content -LiteralPath $receipt.outputs.indexHtmlPath -Raw
-  if ($indexHtml -notmatch [regex]::Escape('<section class="preview-gallery">') -or
-    $indexHtml -notmatch [regex]::Escape('targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png')) {
+  if ($indexHtml -notmatch [regex]::Escape('<section class="preview-gallery">')) {
     throw 'Index HTML should embed the preview gallery.'
+  }
+  if ([regex]::Matches($indexHtml, [regex]::Escape('<article class="preview-card">')).Count -ne 6) {
+    throw 'Index HTML should render six preview cards for the PR31-shaped fixture.'
+  }
+
+  $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+  )
+  if (-not ($htmlPositions[0] -lt $htmlPositions[1] -and $htmlPositions[1] -lt $htmlPositions[2] -and $htmlPositions[2] -lt $htmlPositions[3])) {
+    throw 'Index HTML should preserve the mode-balanced preview ordering.'
   }
 
   $previewManifest = Get-Content -LiteralPath $receipt.outputs.previewManifestPath -Raw | ConvertFrom-Json -Depth 64
-  if ($previewManifest.summary.previewPairCount -ne 2) {
+  if ($previewManifest.summary.previewPairCount -ne 6 -or
+    $previewManifest.summary.commentPreviewPairCount -ne 4 -or
+    $previewManifest.summary.indexPreviewPairCount -ne 6) {
     throw 'Preview manifest summary mismatch.'
   }
 
   $stepSummary = Get-Content -LiteralPath $receipt.outputs.publicStepSummaryPath -Raw
-  if ($stepSummary -notmatch 'automatic pull request run' -or $stepSummary -notmatch 'Final status: `failed`' -or $stepSummary -notmatch 'Preview pairs: `2`') {
+  if ($stepSummary -notmatch 'automatic pull request run' -or
+    $stepSummary -notmatch 'Final status: `failed`' -or
+    $stepSummary -notmatch 'Preview pairs: `6`' -or
+    $stepSummary -notmatch 'PR comment preview gallery: `4` shown, `2` omitted, cap `4`') {
     throw 'Public step summary content mismatch.'
   }
 

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -5,6 +5,35 @@ $scriptPath = Join-Path $PSScriptRoot 'Publish-CompareVIHistoryPullRequestCommen
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-pr-publish-' + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
+function New-PreviewPair {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Mode,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex
+  )
+
+  return [ordered]@{
+    targetId = 'dynamic-demo-target'
+    targetPath = 'Tooling/demo/Demo.vi'
+    mode = $Mode
+    comparison = [ordered]@{
+      index = $ComparisonIndex
+      baseRef = ('{0}-base-{1}' -f $Mode, $ComparisonIndex)
+      headRef = ('{0}-head-{1}' -f $Mode, $ComparisonIndex)
+    }
+    sectionKind = 'overview'
+    sectionOrdinal = 0
+    label = 'Front Panel Overview'
+    reportHtmlRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report.html' -f $Mode, $ComparisonIndex)
+    baseImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/fp_1.png' -f $Mode, $ComparisonIndex)
+    headImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/fp_2.png' -f $Mode, $ComparisonIndex)
+    baseByteLength = 4
+    headByteLength = 4
+    sortKey = ('Tooling/demo/Demo.vi|{0}|{1:D4}|00|0000|front-panel-overview' -f $Mode, $ComparisonIndex)
+  }
+}
+
 function New-PublicationArtifactZip {
   param(
     [Parameter(Mandatory = $true)]
@@ -22,143 +51,134 @@ function New-PublicationArtifactZip {
   $zipPath = Join-Path $RootPath 'artifact.zip'
   New-Item -ItemType Directory -Path $artifactRoot -Force | Out-Null
 
-  @"
-{
-  "schema": "comparevi-history/pr-run@v2",
-  "generatedAtUtc": "2026-03-17T00:00:00Z",
-  "pullRequest": {
-    "number": $PullRequestNumber,
-    "htmlUrl": "https://github.com/example/repo/pull/$PullRequestNumber",
-    "baseRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
-    "baseRef": "develop",
-    "baseSha": "base-sha",
-    "headRepository": "LabVIEW-Community-CI-CD/labview-icon-editor-demo",
-    "headRef": "feature/history",
-    "headSha": "head-sha",
-    "isFork": false
-  },
-  "prPolicy": {
-    "schema": "comparevi-history/pr-policy@v2",
-    "path": "C:/repo/.github/comparevi-history-pr-policy.json",
-    "applied": true,
-    "discovery": {},
-    "execution": {},
-    "reviewerSurface": {},
-    "trust": {}
-  },
-  "executionContext": {
-    "selectionMode": "dynamic-paths",
-    "forkBehavior": "hosted-auto",
-    "fullSurface": "artifact-index"
-  },
-  "discovery": {
-    "schema": "comparevi-history/changed-vi-discovery@v2",
-    "path": "C:/results/changed-vi-discovery.json",
-    "status": "ready",
-    "reason": "selected-targets",
-    "changedViCount": 1,
-    "eligibleChangedViCount": 1,
-    "excludedViCount": 0,
-    "selectedTargetCount": 1,
-    "overflowed": false,
-    "overflowChangedViCount": 0
-  },
-  "outputs": {
-    "resultsDir": "C:/results",
-    "prRunPath": "C:/results/pr-run.json",
-    "publicCommentPath": "C:/results/pr-comment.md",
-    "publicStepSummaryPath": "C:/results/pr-step-summary.md",
-    "targetRunsManifestPath": "C:/results/pr-target-runs-manifest.json",
-    "previewManifestPath": $(if ($IncludePreviewManifest.IsPresent) { '"C:/results/pr-preview-manifest.json"' } else { 'null' }),
-    "indexMarkdownPath": "C:/results/index.md",
-    "indexHtmlPath": "C:/results/index.html",
-    "workflowRunUrl": "https://github.com/example/repo/actions/runs/321",
-    "artifactName": "comparevi-history-pr-diagnostics-321"
-  },
-  "summary": {
-    "finalStatus": "$FinalStatus",
-    "finalReason": "completed",
-    "changedViCount": 1,
-    "eligibleChangedViCount": 1,
-    "excludedViCount": 0,
-    "selectedTargetCount": 1,
-    "overflowed": false,
-    "overflowChangedViCount": 0,
-    "executedTargetCount": 1,
-    "failedTargetCount": 0,
-    "totalProcessed": 5,
-    "totalDiffs": 2,
-    "previewPairCount": $(if ($IncludePreviewManifest.IsPresent) { '1' } else { '0' }),
-    "commentPreviewPairCap": 4,
-    "commentPreviewPairCount": $(if ($IncludePreviewManifest.IsPresent) { '1' } else { '0' }),
-    "commentPreviewPairOmittedCount": 0,
-    "indexPreviewPairCap": 12,
-    "indexPreviewPairCount": $(if ($IncludePreviewManifest.IsPresent) { '1' } else { '0' }),
-    "indexPreviewPairOmittedCount": 0
-  },
-  "excludedViFiles": [],
-  "targets": []
-}
-"@ | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-run.json') -Encoding utf8
+  $previewPairs = @(
+    (New-PreviewPair -Mode 'front-panel' -ComparisonIndex 1),
+    (New-PreviewPair -Mode 'block-diagram' -ComparisonIndex 1),
+    (New-PreviewPair -Mode 'attributes' -ComparisonIndex 1),
+    (New-PreviewPair -Mode 'front-panel' -ComparisonIndex 2),
+    (New-PreviewPair -Mode 'block-diagram' -ComparisonIndex 2),
+    (New-PreviewPair -Mode 'attributes' -ComparisonIndex 2)
+  )
+  $commentPreviewPairs = @($previewPairs | Select-Object -First 4)
+
+  ([ordered]@{
+      schema = 'comparevi-history/pr-run@v2'
+      generatedAtUtc = '2026-03-17T00:00:00Z'
+      pullRequest = [ordered]@{
+        number = $PullRequestNumber
+        htmlUrl = "https://github.com/example/repo/pull/$PullRequestNumber"
+        baseRepository = 'LabVIEW-Community-CI-CD/labview-icon-editor-demo'
+        baseRef = 'develop'
+        baseSha = 'base-sha'
+        headRepository = 'LabVIEW-Community-CI-CD/labview-icon-editor-demo'
+        headRef = 'feature/history'
+        headSha = 'head-sha'
+        isFork = $false
+      }
+      prPolicy = [ordered]@{
+        schema = 'comparevi-history/pr-policy@v2'
+        path = 'C:/repo/.github/comparevi-history-pr-policy.json'
+        applied = $true
+        discovery = @{}
+        execution = @{}
+        reviewerSurface = @{}
+        trust = @{}
+      }
+      executionContext = [ordered]@{
+        selectionMode = 'dynamic-paths'
+        forkBehavior = 'hosted-auto'
+        fullSurface = 'artifact-index'
+      }
+      discovery = [ordered]@{
+        schema = 'comparevi-history/changed-vi-discovery@v2'
+        path = 'C:/results/changed-vi-discovery.json'
+        status = 'ready'
+        reason = 'selected-targets'
+        changedViCount = 1
+        eligibleChangedViCount = 1
+        excludedViCount = 0
+        selectedTargetCount = 1
+        overflowed = $false
+        overflowChangedViCount = 0
+      }
+      outputs = [ordered]@{
+        resultsDir = 'C:/results'
+        prRunPath = 'C:/results/pr-run.json'
+        publicCommentPath = 'C:/results/pr-comment.md'
+        publicStepSummaryPath = 'C:/results/pr-step-summary.md'
+        targetRunsManifestPath = 'C:/results/pr-target-runs-manifest.json'
+        previewManifestPath = $(if ($IncludePreviewManifest.IsPresent) { 'C:/results/pr-preview-manifest.json' } else { $null })
+        indexMarkdownPath = 'C:/results/index.md'
+        indexHtmlPath = 'C:/results/index.html'
+        workflowRunUrl = 'https://github.com/example/repo/actions/runs/321'
+        artifactName = 'comparevi-history-pr-diagnostics-321'
+      }
+      summary = [ordered]@{
+        finalStatus = $FinalStatus
+        finalReason = 'completed'
+        changedViCount = 1
+        eligibleChangedViCount = 1
+        excludedViCount = 0
+        selectedTargetCount = 1
+        overflowed = $false
+        overflowChangedViCount = 0
+        executedTargetCount = 1
+        failedTargetCount = 0
+        totalProcessed = 5
+        totalDiffs = 2
+        previewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        commentPreviewPairCap = 4
+        commentPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
+        commentPreviewPairOmittedCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        indexPreviewPairCap = 12
+        indexPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        indexPreviewPairOmittedCount = 0
+      }
+      excludedViFiles = @()
+      targets = @()
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-run.json') -Encoding utf8
   $CommentBody | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-comment.md') -Encoding utf8
 
   if ($IncludePreviewManifest.IsPresent) {
-    $previewImageRoot = Join-Path $artifactRoot 'targets/001/history/front-panel/Demo.vi-001-artifacts/compare-report_files'
-    New-Item -ItemType Directory -Path $previewImageRoot -Force | Out-Null
-    [System.IO.File]::WriteAllBytes((Join-Path $previewImageRoot 'fp_1.png'), @(0xCA, 0xFE, 0xBA, 0xBE))
-    [System.IO.File]::WriteAllBytes((Join-Path $previewImageRoot 'fp_2.png'), @(0xBA, 0xAD, 0xF0, 0x0D))
+    foreach ($previewPair in $previewPairs) {
+      foreach ($relativePath in @([string]$previewPair.baseImageRelativePath, [string]$previewPair.headImageRelativePath)) {
+        $fullPath = Join-Path $artifactRoot ($relativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        New-Item -ItemType Directory -Path (Split-Path -Parent $fullPath) -Force | Out-Null
+        [System.IO.File]::WriteAllBytes($fullPath, @(0xCA, 0xFE, 0xBA, 0xBE))
+      }
+    }
 
-    @"
-{
-  "schema": "comparevi-history/pr-preview-manifest@v1",
-  "generatedAtUtc": "2026-03-17T00:00:00Z",
-  "targetRunsManifestPath": "C:/results/pr-target-runs-manifest.json",
-  "resultsDir": "C:/results",
-  "summary": {
-    "targetCount": 1,
-    "previewPairCount": 1,
-    "commentPreviewPairCap": 4,
-    "commentPreviewPairCount": 1,
-    "commentPreviewPairOmittedCount": 0,
-    "indexPreviewPairCap": 12,
-    "indexPreviewPairCount": 1,
-    "indexPreviewPairOmittedCount": 0
-  },
-  "targets": [
-    {
-      "targetId": "dynamic-demo-target",
-      "targetPath": "Tooling/demo/Demo.vi",
-      "finalStatus": "succeeded",
-      "finalReason": "completed",
-      "previewPairCount": 1,
-      "previewPairs": []
-    }
-  ],
-  "previewPairs": [],
-  "commentPreviewPairs": [
-    {
-      "targetId": "dynamic-demo-target",
-      "targetPath": "Tooling/demo/Demo.vi",
-      "mode": "front-panel",
-      "comparison": {
-        "index": 1,
-        "baseRef": "base-sha",
-        "headRef": "head-sha"
-      },
-      "sectionKind": "overview",
-      "sectionOrdinal": 0,
-      "label": "Front Panel Overview",
-      "reportHtmlRelativePath": "targets/001/history/front-panel/Demo.vi-001-artifacts/compare-report.html",
-      "baseImageRelativePath": "targets/001/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png",
-      "headImageRelativePath": "targets/001/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_2.png",
-      "baseByteLength": 4,
-      "headByteLength": 4,
-      "sortKey": "Tooling/demo/Demo.vi|00|0001|00|0000|front-panel-overview"
-    }
-  ],
-  "indexPreviewPairs": []
-}
-"@ | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-preview-manifest.json') -Encoding utf8
+    ([ordered]@{
+        schema = 'comparevi-history/pr-preview-manifest@v1'
+        generatedAtUtc = '2026-03-17T00:00:00Z'
+        targetRunsManifestPath = 'C:/results/pr-target-runs-manifest.json'
+        resultsDir = 'C:/results'
+        summary = [ordered]@{
+          targetCount = 1
+          previewPairCount = 6
+          commentPreviewPairCap = 4
+          commentSelectionPolicy = 'mode-balanced@v1'
+          commentPreviewPairCount = 4
+          commentPreviewPairOmittedCount = 2
+          indexPreviewPairCap = 12
+          indexSelectionPolicy = 'mode-balanced@v1'
+          indexPreviewPairCount = 6
+          indexPreviewPairOmittedCount = 0
+        }
+        targets = @(
+          [ordered]@{
+            targetId = 'dynamic-demo-target'
+            targetPath = 'Tooling/demo/Demo.vi'
+            finalStatus = 'succeeded'
+            finalReason = 'completed'
+            previewPairCount = 6
+            previewPairs = $previewPairs
+          }
+        )
+        previewPairs = $previewPairs
+        commentPreviewPairs = $commentPreviewPairs
+        indexPreviewPairs = $previewPairs
+      } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-preview-manifest.json') -Encoding utf8
   }
 
   if (Test-Path -LiteralPath $zipPath) {
@@ -325,21 +345,55 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([string]$createReceipt.previewPublication.status -ne 'succeeded') {
     throw 'Expected preview publication to succeed for the first path.'
   }
+  if ([int]$createReceipt.previewPublication.previewPairCount -ne 4 -or [int]$createReceipt.previewPublication.publishedImageCount -ne 8) {
+    throw 'Preview publication counts mismatch for the first path.'
+  }
   if ($global:RecordedPosts.Count -ne 1) {
     throw 'Expected one PR comment creation request.'
   }
   if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<!-- comparevi-history:pull-request-diagnostics -->')) {
     throw 'Created PR comment body is missing the sticky marker.'
   }
-  if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('### Preview gallery') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('https://raw.githubusercontent.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/base.png')) {
-    throw 'Created PR comment body did not embed the published preview image URLs.'
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('#### `Tooling/demo/Demo.vi |')).Count -ne 4) {
+    throw 'Created PR comment body should render four preview gallery sections.'
+  }
+  if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
+    [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
+    throw 'Created PR comment body should embed eight preview image URLs.'
   }
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'
   }
-  if ($global:RecordedContentWrites.Count -ne 3) {
-    throw 'Expected preview publication to write two images and one manifest.'
+  if ($global:RecordedContentWrites.Count -ne 9) {
+    throw 'Expected preview publication to write eight images and one manifest.'
+  }
+
+  $publishedPairOrder = @(
+    $createReceipt.previewPublication.commentPreviewPairs |
+      ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
+  ) -join ','
+  if ($publishedPairOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2') {
+    throw "Preview publication order mismatch: $publishedPairOrder"
+  }
+
+  $writeOrder = @(
+    $global:RecordedContentWrites |
+      ForEach-Object { [string]$_.path }
+  )
+  $expectedImagePrefixes = @(
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/003-front-panel-overview/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/003-front-panel-overview/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/004-front-panel-overview/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/004-front-panel-overview/head.png'
+  )
+  foreach ($index in 0..7) {
+    if ([string]$writeOrder[$index] -ne $expectedImagePrefixes[$index]) {
+      throw "Published preview write order mismatch at position $index."
+    }
   }
 
   $createOutputText = Get-Content -LiteralPath $createOutputPath -Raw
@@ -351,8 +405,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
       'comment-url=https://github.com/example/repo/pull/55#issuecomment-991',
       'preview-publication-status=succeeded',
       'preview-publication-reason=preview-images-published',
-      'preview-pair-count=1',
-      'published-image-count=2'
+      'preview-pair-count=4',
+      'published-image-count=8'
     )) {
     if ($createOutputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -5,15 +5,22 @@ $scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryPullRequestPreviewM
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-pr-preview-manifest-' + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
-try {
-  $resultsDir = Join-Path $tempRoot 'results'
-  $targetRoot = Join-Path $resultsDir 'targets/001-demo/history'
-  $modeRoot = Join-Path $targetRoot 'front-panel'
-  $artifactDir = Join-Path $modeRoot 'Demo.vi-001-artifacts'
+function New-PreviewReportFixture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModeRoot,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex,
+    [Parameter(Mandatory = $true)]
+    [string]$BaseRef,
+    [Parameter(Mandatory = $true)]
+    [string]$HeadRef
+  )
+
+  $artifactDir = Join-Path $ModeRoot ('Demo.vi-{0:D3}-artifacts' -f $ComparisonIndex)
   $reportFilesDir = Join-Path $artifactDir 'compare-report_files'
   New-Item -ItemType Directory -Path $reportFilesDir -Force | Out-Null
-
-  foreach ($imageName in @('fp_1.png', 'fp_2.png', '0_0_11_11_1.png', '0_0_11_11_2.png', '1_0_11_11_1.png', '1_0_11_11_2.png')) {
+  foreach ($imageName in @('fp_1.png', 'fp_2.png')) {
     [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir $imageName), @(0xCA, 0xFE, 0xBA, 0xBE))
   }
 
@@ -23,125 +30,145 @@ try {
 <html>
 <body>
 <div class="compared-VIs">
-<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/m0/Base.vi</div><div class="dropdown-right">Second VI: /compare/m0/Head.vi</div></summary>
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
 <table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
 <tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr></table></details>
 </div>
-<div class="included-attributes"></div>
-<details class="cosmetic" closed>
-<summary class="difference-cosmetic-heading">1. Front Panel - Variant</summary>
-<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">/compare/m0/Base.vi</td><td class="difference-divider"></td><td class="compared-vi-image-caption">/compare/m0/Head.vi</td></tr><tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/0_0_11_11_1.png" alt="compare-report_files/0_0_11_11_1.png"></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/0_0_11_11_2.png" alt="compare-report_files/0_0_11_11_2.png"></td></tr></table>
-</details>
-<details class="cosmetic" closed>
-<summary class="difference-cosmetic-heading">2. Front Panel - Pane</summary>
-<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">/compare/m0/Base.vi</td><td class="difference-divider"></td><td class="compared-vi-image-caption">/compare/m0/Head.vi</td></tr><tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/1_0_11_11_1.png" alt="compare-report_files/1_0_11_11_1.png"></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/1_0_11_11_2.png" alt="compare-report_files/1_0_11_11_2.png"></td></tr></table>
-</details>
 </body>
 </html>
 '@ | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
 
-  $modeManifestPath = Join-Path $modeRoot 'manifest.json'
-  @"
-{
-  "schema": "vi-compare/history@v1",
-  "generatedAt": "2026-03-18T00:00:00Z",
-  "mode": "front-panel",
-  "comparisons": [
-    {
-      "index": 1,
-      "base": { "ref": "base-sha" },
-      "head": { "ref": "head-sha" },
-      "result": {
-        "reportHtml": "$($reportHtmlPath.Replace('\', '\\'))"
-      }
+  return [ordered]@{
+    index = $ComparisonIndex
+    base = [ordered]@{ ref = $BaseRef }
+    head = [ordered]@{ ref = $HeadRef }
+    result = [ordered]@{
+      reportHtml = $reportHtmlPath
     }
-  ]
+  }
 }
-"@ | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+
+try {
+  $resultsDir = Join-Path $tempRoot 'results'
+  $targetRoot = Join-Path $resultsDir 'targets/001-demo/history'
+  New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+  $modeManifests = New-Object System.Collections.Generic.List[object]
+  foreach ($modeName in @('front-panel', 'block-diagram', 'attributes')) {
+    $modeRoot = Join-Path $targetRoot $modeName
+    New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
+
+    $comparisons = @(
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $modeName) -HeadRef ('{0}-head-1' -f $modeName)),
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $modeName) -HeadRef ('{0}-head-2' -f $modeName))
+    )
+
+    $modeManifestPath = Join-Path $modeRoot 'manifest.json'
+    ([ordered]@{
+        schema = 'vi-compare/history@v1'
+        generatedAt = '2026-03-18T00:00:00Z'
+        mode = $modeName
+        comparisons = $comparisons
+      } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+
+    $modeManifests.Add([ordered]@{
+        name = $modeName
+        manifestPath = $modeManifestPath
+      }) | Out-Null
+  }
 
   $suiteManifestPath = Join-Path $targetRoot 'manifest.json'
-  @"
-{
-  "schema": "vi-compare/history-suite@v1",
-  "generatedAt": "2026-03-18T00:00:00Z",
-  "modes": [
-    {
-      "name": "front-panel",
-      "manifestPath": "$($modeManifestPath.Replace('\', '\\'))"
-    }
-  ]
-}
-"@ | Set-Content -LiteralPath $suiteManifestPath -Encoding utf8
+  ([ordered]@{
+      schema = 'vi-compare/history-suite@v1'
+      generatedAt = '2026-03-18T00:00:00Z'
+      modes = @($modeManifests | ForEach-Object { $_ })
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $suiteManifestPath -Encoding utf8
 
   $targetRunsManifestPath = Join-Path $resultsDir 'pr-target-runs-manifest.json'
-  @"
-{
-  "schema": "comparevi-history/pr-target-runs-manifest@v2",
-  "generatedAtUtc": "2026-03-18T00:00:00Z",
-  "summary": {
-    "selectedTargetCount": 1,
-    "executedTargetCount": 1,
-    "failedTargetCount": 0,
-    "skippedTargetCount": 0,
-    "executionStatus": "succeeded",
-    "executionReason": "completed"
-  },
-  "targets": [
-    {
-      "targetId": "dynamic-demo-target",
-      "targetSource": "dynamic-path",
-      "targetPath": "Tooling/demo/Demo.vi",
-      "requestedModes": ["front-panel"],
-      "keepArtifactsOnNoDiff": true,
-      "finalStatus": "succeeded",
-      "finalReason": "completed",
-      "manifestPath": "$($suiteManifestPath.Replace('\', '\\'))"
-    }
-  ]
-}
-"@ | Set-Content -LiteralPath $targetRunsManifestPath -Encoding utf8
+  ([ordered]@{
+      schema = 'comparevi-history/pr-target-runs-manifest@v2'
+      generatedAtUtc = '2026-03-18T00:00:00Z'
+      summary = [ordered]@{
+        selectedTargetCount = 1
+        executedTargetCount = 1
+        failedTargetCount = 0
+        skippedTargetCount = 0
+        executionStatus = 'succeeded'
+        executionReason = 'completed'
+      }
+      targets = @(
+        [ordered]@{
+          targetId = 'dynamic-demo-target'
+          targetSource = 'dynamic-path'
+          targetPath = 'Tooling/demo/Demo.vi'
+          requestedModes = @('attributes', 'front-panel', 'block-diagram')
+          keepArtifactsOnNoDiff = $true
+          finalStatus = 'succeeded'
+          finalReason = 'completed'
+          manifestPath = $suiteManifestPath
+        }
+      )
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $targetRunsManifestPath -Encoding utf8
 
   $outputPath = Join-Path $tempRoot 'preview-manifest.out'
   $receiptJson = & $scriptPath `
     -TargetRunsManifestPath $targetRunsManifestPath `
     -ResultsDir $resultsDir `
-    -CommentPreviewPairCap 2 `
-    -IndexPreviewPairCap 3 `
+    -CommentPreviewPairCap 4 `
+    -IndexPreviewPairCap 12 `
     -GitHubOutputPath $outputPath
 
   $receipt = $receiptJson | ConvertFrom-Json -Depth 64
   if ($receipt.schema -ne 'comparevi-history/pr-preview-manifest@v1') {
     throw 'Preview manifest schema mismatch.'
   }
-  if ($receipt.summary.previewPairCount -ne 3) {
-    throw 'Expected three preview pairs from the report HTML.'
+  if ($receipt.summary.previewPairCount -ne 6) {
+    throw 'Expected six preview pairs from the PR31-shaped fixture.'
   }
-  if ($receipt.summary.commentPreviewPairCount -ne 2 -or $receipt.summary.commentPreviewPairOmittedCount -ne 1) {
+  if ($receipt.summary.commentSelectionPolicy -ne 'mode-balanced@v1' -or $receipt.summary.indexSelectionPolicy -ne 'mode-balanced@v1') {
+    throw 'Expected explicit mode-balanced selection policies in the preview manifest summary.'
+  }
+  if ($receipt.summary.commentPreviewPairCount -ne 4 -or $receipt.summary.commentPreviewPairOmittedCount -ne 2) {
     throw 'Comment preview pair selection mismatch.'
   }
-  if ($receipt.summary.indexPreviewPairCount -ne 3 -or $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
+  if ($receipt.summary.indexPreviewPairCount -ne 6 -or $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
     throw 'Index preview pair selection mismatch.'
   }
-  if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 3) {
+  if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 6) {
     throw 'Target preview pair count mismatch.'
   }
-  if ($receipt.commentPreviewPairs[0].label -ne 'Front Panel Overview') {
-    throw 'Expected overview preview to sort first for the PR comment.'
+
+  $commentOrder = @(
+    $receipt.commentPreviewPairs |
+      ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
+  ) -join ','
+  if ($commentOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2') {
+    throw "Comment preview pair order mismatch: $commentOrder"
   }
+
+  $indexOrder = @(
+    $receipt.indexPreviewPairs |
+      ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
+  ) -join ','
+  if ($indexOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2,block-diagram:2,attributes:2') {
+    throw "Index preview pair order mismatch: $indexOrder"
+  }
+
   if ($receipt.commentPreviewPairs[0].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
-    throw 'Expected normalized relative path for the base preview image.'
+    throw 'Expected normalized relative path for the first comment preview base image.'
   }
-  if ($receipt.previewPairs[1].label -ne '1. Front Panel - Variant') {
-    throw 'Expected detail preview label normalization.'
+  if ($receipt.commentPreviewPairs[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
+    throw 'Expected mode-specific preview identity to survive repeated image filenames.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw
   foreach ($requiredKey in @(
       'preview-manifest-path=',
-      'preview-pair-count=3',
-      'comment-preview-pair-count=2',
-      'comment-preview-pair-omitted-count=1',
-      'index-preview-pair-count=3'
+      'preview-pair-count=6',
+      'comment-preview-pair-count=4',
+      'comment-preview-pair-omitted-count=2',
+      'index-preview-pair-count=6',
+      'index-preview-pair-omitted-count=0'
     )) {
     if ($outputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -193,7 +193,7 @@ function New-MarkdownPreviewGallery {
   $lines = New-Object System.Collections.Generic.List[string]
   $lines.Add('## Preview gallery') | Out-Null
   $lines.Add('') | Out-Null
-  foreach ($previewPair in @(ConvertTo-PreviewPairArray -Value $PreviewPairs)) {
+  foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
     $title = '{0} | {1} | {2}' -f [string]$previewPair.targetPath, [string]$previewPair.mode, [string]$previewPair.label
     $lines.Add(('### {0}' -f $title)) | Out-Null
     $lines.Add('') | Out-Null
@@ -220,7 +220,7 @@ function New-HtmlPreviewGallery {
   }
 
   $cards = New-Object System.Collections.Generic.List[string]
-  foreach ($previewPair in @(ConvertTo-PreviewPairArray -Value $PreviewPairs)) {
+  foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
     $title = '{0} | {1} | {2}' -f [string]$previewPair.targetPath, [string]$previewPair.mode, [string]$previewPair.label
     $reportLink = if ([string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
       ''

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -249,6 +249,47 @@ function ConvertTo-PreviewPairArray {
   )
 }
 
+function Get-PreviewPairIdentityKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return '{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}' -f `
+    [string]$PreviewPair.targetId, `
+    [string]$PreviewPair.mode, `
+    [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0), `
+    [string]$PreviewPair.sectionKind, `
+    [int](Get-NestedValue -Object $PreviewPair -Path @('sectionOrdinal') -Default 0), `
+    $(if ([string]::IsNullOrWhiteSpace([string]$PreviewPair.reportHtmlRelativePath)) { '' } else { [string]$PreviewPair.reportHtmlRelativePath }), `
+    [string]$PreviewPair.baseImageRelativePath, `
+    [string]$PreviewPair.headImageRelativePath
+}
+
+function Add-PreviewPairSelection {
+  param(
+    [AllowNull()]
+    [object]$PreviewPair,
+    [AllowEmptyCollection()]
+    [System.Collections.Generic.List[object]]$Selected,
+    [AllowEmptyCollection()]
+    [System.Collections.Generic.HashSet[string]]$Seen,
+    [int]$Limit
+  )
+
+  if ($null -eq $PreviewPair -or $Selected.Count -ge $Limit) {
+    return $false
+  }
+
+  $identityKey = Get-PreviewPairIdentityKey -PreviewPair $PreviewPair
+  if (-not $Seen.Add($identityKey)) {
+    return $false
+  }
+
+  $Selected.Add($PreviewPair) | Out-Null
+  return $true
+}
+
 function Select-PreviewPairs {
   param(
     [Parameter(Mandatory = $true)]
@@ -260,25 +301,34 @@ function Select-PreviewPairs {
     return @()
   }
 
+  $orderedPairs = @(ConvertTo-PreviewPairArray -Value $PreviewPairs)
   $selected = New-Object System.Collections.Generic.List[object]
   $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-  foreach ($pair in @(ConvertTo-PreviewPairArray -Value $PreviewPairs)) {
+
+  foreach ($mode in @('front-panel', 'block-diagram', 'attributes')) {
     if ($selected.Count -ge $Limit) {
       break
     }
 
-    $dedupeKey = '{0}|{1}|{2}|{3}|{4}|{5}' -f `
-      [string]$pair.targetId, `
-      [int](Get-NestedValue -Object $pair -Path @('comparison', 'index') -Default 0), `
-      [string]$pair.sectionKind, `
-      [string]$pair.label, `
-      [System.IO.Path]::GetFileName([string]$pair.baseImageRelativePath), `
-      [System.IO.Path]::GetFileName([string]$pair.headImageRelativePath)
-    if (-not $seen.Add($dedupeKey)) {
-      continue
+    $overviewPair = @(
+      $orderedPairs |
+        Where-Object {
+          [string]$_.mode -eq $mode -and
+          [string]$_.sectionKind -eq 'overview'
+        } |
+        Select-Object -First 1
+    )
+    if ($overviewPair) {
+      Add-PreviewPairSelection -PreviewPair $overviewPair[0] -Selected $selected -Seen $seen -Limit $Limit | Out-Null
+    }
+  }
+
+  foreach ($pair in $orderedPairs) {
+    if ($selected.Count -ge $Limit) {
+      break
     }
 
-    $selected.Add($pair) | Out-Null
+    Add-PreviewPairSelection -PreviewPair $pair -Selected $selected -Seen $seen -Limit $Limit | Out-Null
   }
 
   return @($selected | ForEach-Object { $_ })
@@ -466,9 +516,11 @@ $receipt = [ordered]@{
     targetCount = $targetReceiptArray.Count
     previewPairCount = $orderedPreviewPairs.Count
     commentPreviewPairCap = [int]$CommentPreviewPairCap
+    commentSelectionPolicy = 'mode-balanced@v1'
     commentPreviewPairCount = $commentPreviewPairs.Count
     commentPreviewPairOmittedCount = [Math]::Max($orderedPreviewPairs.Count - $commentPreviewPairs.Count, 0)
     indexPreviewPairCap = [int]$IndexPreviewPairCap
+    indexSelectionPolicy = 'mode-balanced@v1'
     indexPreviewPairCount = $indexPreviewPairs.Count
     indexPreviewPairOmittedCount = [Math]::Max($orderedPreviewPairs.Count - $indexPreviewPairs.Count, 0)
   }


### PR DESCRIPTION
## Summary
- fix PR preview pair identity so repeated filenames no longer collapse distinct mode/comparison surfaces
- replace the capped selector with deterministic `mode-balanced@v1` selection for comment and index preview arrays
- extend the preview manifest, aggregate PR run, and publication regressions to cover the PR31-shaped 6-pair fixture

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

## Issue
- Closes #118
