### PR TITLE
Fix reviewer preview gallery rendering

### DIFF
--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -47,17 +47,19 @@
       "properties": {
         "targetCount": { "type": "integer", "minimum": 0 },
         "previewPairCount": { "type": "integer", "minimum": 0 },
+        "rawPreviewPairCount": { "type": "integer", "minimum": 0 },
+        "reviewerPreviewPairCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairCap": { "type": "integer", "minimum": 0 },
         "commentSelectionPolicy": {
           "type": "string",
-          "const": "mode-balanced@v1"
+          "enum": ["mode-balanced@v1", "reviewer-canonical@v1"]
         },
         "commentPreviewPairCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairOmittedCount": { "type": "integer", "minimum": 0 },
         "indexPreviewPairCap": { "type": "integer", "minimum": 0 },
         "indexSelectionPolicy": {
           "type": "string",
-          "const": "mode-balanced@v1"
+          "enum": ["mode-balanced@v1", "reviewer-canonical@v1"]
         },
         "indexPreviewPairCount": { "type": "integer", "minimum": 0 },
         "indexPreviewPairOmittedCount": { "type": "integer", "minimum": 0 }
@@ -132,6 +134,14 @@
         "headImageRelativePath": { "type": "string", "minLength": 1 },
         "baseByteLength": { "type": "integer", "minimum": 0 },
         "headByteLength": { "type": "integer", "minimum": 0 },
+        "baseImageSha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "headImageSha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
         "sortKey": { "type": "string", "minLength": 1 }
       }
     },

--- a/docs/schemas/comparevi-history-pr-run-v2.schema.json
+++ b/docs/schemas/comparevi-history-pr-run-v2.schema.json
@@ -281,6 +281,8 @@
         "totalProcessed",
         "totalDiffs",
         "previewPairCount",
+        "rawPreviewPairCount",
+        "reviewerPreviewPairCount",
         "commentPreviewPairCap",
         "commentPreviewPairCount",
         "commentPreviewPairOmittedCount",
@@ -342,6 +344,14 @@
           "minimum": 0
         },
         "previewPairCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rawPreviewPairCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reviewerPreviewPairCount": {
           "type": "integer",
           "minimum": 0
         },

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -90,6 +90,15 @@ function Get-NestedValue {
       return $Default
     }
 
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
     $property = $current.PSObject.Properties[$segment]
     if ($null -eq $property) {
       return $Default
@@ -231,6 +240,24 @@ function ConvertTo-HtmlText {
   }
 
   return [System.Net.WebUtility]::HtmlEncode($Value)
+}
+
+function Get-ReviewerPreviewTitle {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  return [string]$PreviewPair.targetPath
+}
+
+function Get-ReviewerPreviewSubtitle {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  $comparisonIndex = [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+  $label = Get-OptionalString -Value $PreviewPair.label
+  if ([string]::IsNullOrWhiteSpace($label)) {
+    return 'Comparison {0}' -f $comparisonIndex
+  }
+
+  return 'Comparison {0} - {1}' -f $comparisonIndex, $label
 }
 
 function ConvertTo-GitHubContentPath {
@@ -376,15 +403,26 @@ function New-CommentPreviewMarkdown {
   $lines.Add('### Preview gallery') | Out-Null
   $lines.Add('') | Out-Null
   foreach ($previewPair in $PreviewPairs) {
-    $title = '{0} | {1} | {2}' -f [string]$previewPair.targetPath, [string]$previewPair.mode, [string]$previewPair.label
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
     $baseUrl = [string]$previewPair.baseImageUrl
     $headUrl = [string]$previewPair.headImageUrl
     $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
-    $lines.Add(('#### `{0}`' -f $title)) | Out-Null
+    $baseAlt = '{0} base' -f $subtitle
+    $headAlt = '{0} head' -f $subtitle
+    $lines.Add(('<h4><code>{0}</code></h4>' -f (ConvertTo-HtmlText $title))) | Out-Null
+    $lines.Add(('<p>{0}</p>' -f (ConvertTo-HtmlText $subtitle))) | Out-Null
     $lines.Add('') | Out-Null
-    $lines.Add('| Base | Head |') | Out-Null
-    $lines.Add('| --- | --- |') | Out-Null
-    $lines.Add(('| [![{0} base]({1})]({3}) | [![{0} head]({2})]({3}) |' -f $title, $baseUrl, $headUrl, $linkUrl)) | Out-Null
+    $lines.Add('<table>') | Out-Null
+    $lines.Add('<thead><tr><th>Base</th><th>Head</th></tr></thead>') | Out-Null
+    $lines.Add('<tbody><tr>') | Out-Null
+    $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $baseAlt), (ConvertTo-HtmlText $baseUrl))) | Out-Null
+    $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $headAlt), (ConvertTo-HtmlText $headUrl))) | Out-Null
+    $lines.Add('</tr></tbody>') | Out-Null
+    $lines.Add('</table>') | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($RunUrl)) {
+      $lines.Add(('<p><a href="{0}">workflow run</a></p>' -f (ConvertTo-HtmlText $RunUrl))) | Out-Null
+    }
     $lines.Add('') | Out-Null
   }
 

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -370,9 +370,11 @@ try {
     throw 'Aggregate totals mismatch.'
   }
   if ($receipt.summary.previewPairCount -ne 6 -or
-    $receipt.summary.commentPreviewPairCount -ne 4 -or
-    $receipt.summary.commentPreviewPairOmittedCount -ne 2 -or
-    $receipt.summary.indexPreviewPairCount -ne 6 -or
+    $receipt.summary.rawPreviewPairCount -ne 6 -or
+    $receipt.summary.reviewerPreviewPairCount -ne 2 -or
+    $receipt.summary.commentPreviewPairCount -ne 2 -or
+    $receipt.summary.commentPreviewPairOmittedCount -ne 0 -or
+    $receipt.summary.indexPreviewPairCount -ne 2 -or
     $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
     throw 'Aggregate preview pair summary mismatch.'
   }
@@ -407,8 +409,13 @@ try {
   if ($commentBody -notmatch [regex]::Escape('comparevi-history-pr-diagnostics-123456789')) {
     throw 'PR comment body should point reviewers at the artifact bundle.'
   }
-  if ($commentBody -notmatch [regex]::Escape('PR comment preview gallery: `4` shown, `2` omitted, cap `4`')) {
+  if ($commentBody -notmatch [regex]::Escape('Reviewer preview gallery: `2` shown, `0` omitted, cap `4`')) {
     throw 'PR comment body should surface the corrected preview pair counts.'
+  }
+  if ($commentBody -match [regex]::Escape('| front-panel |') -or
+    $commentBody -match [regex]::Escape('| block-diagram |') -or
+    $commentBody -match [regex]::Escape('| attributes |')) {
+    throw 'PR comment body should not surface execution modes in the reviewer-facing preview gallery.'
   }
 
   $indexMarkdown = Get-Content -LiteralPath $receipt.outputs.indexMarkdownPath -Raw
@@ -426,50 +433,56 @@ try {
       throw "Index markdown is missing '$requiredText'."
     }
   }
-  if ([regex]::Matches($indexMarkdown, [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi |')).Count -ne 6) {
-    throw 'Index markdown should render six preview entries for the PR31-shaped fixture.'
+  if ([regex]::Matches($indexMarkdown, [regex]::Escape('### `Tooling/deployment/VIP_Post-Install Custom Action.vi`')).Count -ne 2) {
+    throw 'Index markdown should render two reviewer-canonical preview entries for the PR31-shaped fixture.'
+  }
+  if ($indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | front-panel |') -or
+    $indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | block-diagram |') -or
+    $indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | attributes |')) {
+    throw 'Index markdown should not surface execution modes in reviewer-facing preview titles.'
   }
 
   $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
   )
-  if (-not ($markdownPositions[0] -lt $markdownPositions[1] -and $markdownPositions[1] -lt $markdownPositions[2] -and $markdownPositions[2] -lt $markdownPositions[3])) {
-    throw 'Index markdown should preserve the mode-balanced preview ordering.'
+  if (-not ($markdownPositions[0] -lt $markdownPositions[1])) {
+    throw 'Index markdown should preserve the reviewer-canonical comparison ordering.'
   }
 
   $indexHtml = Get-Content -LiteralPath $receipt.outputs.indexHtmlPath -Raw
   if ($indexHtml -notmatch [regex]::Escape('<section class="preview-gallery">')) {
     throw 'Index HTML should embed the preview gallery.'
   }
-  if ([regex]::Matches($indexHtml, [regex]::Escape('<article class="preview-card">')).Count -ne 6) {
-    throw 'Index HTML should render six preview cards for the PR31-shaped fixture.'
+  if ([regex]::Matches($indexHtml, [regex]::Escape('<article class="preview-card">')).Count -ne 2) {
+    throw 'Index HTML should render two reviewer-canonical preview cards for the PR31-shaped fixture.'
+  }
+  if ($indexHtml -match [regex]::Escape('<strong>Mode</strong>')) {
+    throw 'Index HTML should not surface execution modes in reviewer-facing preview cards.'
   }
 
   $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
   )
-  if (-not ($htmlPositions[0] -lt $htmlPositions[1] -and $htmlPositions[1] -lt $htmlPositions[2] -and $htmlPositions[2] -lt $htmlPositions[3])) {
-    throw 'Index HTML should preserve the mode-balanced preview ordering.'
+  if (-not ($htmlPositions[0] -lt $htmlPositions[1])) {
+    throw 'Index HTML should preserve the reviewer-canonical comparison ordering.'
   }
 
   $previewManifest = Get-Content -LiteralPath $receipt.outputs.previewManifestPath -Raw | ConvertFrom-Json -Depth 64
   if ($previewManifest.summary.previewPairCount -ne 6 -or
-    $previewManifest.summary.commentPreviewPairCount -ne 4 -or
-    $previewManifest.summary.indexPreviewPairCount -ne 6) {
+    $previewManifest.summary.rawPreviewPairCount -ne 6 -or
+    $previewManifest.summary.reviewerPreviewPairCount -ne 2 -or
+    $previewManifest.summary.commentPreviewPairCount -ne 2 -or
+    $previewManifest.summary.indexPreviewPairCount -ne 2) {
     throw 'Preview manifest summary mismatch.'
   }
 
   $stepSummary = Get-Content -LiteralPath $receipt.outputs.publicStepSummaryPath -Raw
   if ($stepSummary -notmatch 'automatic pull request run' -or
     $stepSummary -notmatch 'Final status: `failed`' -or
-    $stepSummary -notmatch 'Preview pairs: `6`' -or
-    $stepSummary -notmatch 'PR comment preview gallery: `4` shown, `2` omitted, cap `4`') {
+    $stepSummary -notmatch 'Reviewer preview gallery: `2` shown, `0` omitted, cap `4`' -or
+    $stepSummary -notmatch 'Raw preview surfaces collapsed for review: `6` raw -> `2` reviewer-canonical') {
     throw 'Public step summary content mismatch.'
   }
 

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -127,11 +127,13 @@ function New-PublicationArtifactZip {
         totalProcessed = 5
         totalDiffs = 2
         previewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        rawPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        reviewerPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         commentPreviewPairCap = 4
-        commentPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
-        commentPreviewPairOmittedCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        commentPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        commentPreviewPairOmittedCount = 0
         indexPreviewPairCap = 12
-        indexPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        indexPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         indexPreviewPairOmittedCount = 0
       }
       excludedViFiles = @()
@@ -156,13 +158,15 @@ function New-PublicationArtifactZip {
         summary = [ordered]@{
           targetCount = 1
           previewPairCount = 6
+          rawPreviewPairCount = 6
+          reviewerPreviewPairCount = 2
           commentPreviewPairCap = 4
-          commentSelectionPolicy = 'mode-balanced@v1'
-          commentPreviewPairCount = 4
-          commentPreviewPairOmittedCount = 2
+          commentSelectionPolicy = 'reviewer-canonical@v1'
+          commentPreviewPairCount = 2
+          commentPreviewPairOmittedCount = 0
           indexPreviewPairCap = 12
-          indexSelectionPolicy = 'mode-balanced@v1'
-          indexPreviewPairCount = 6
+          indexSelectionPolicy = 'reviewer-canonical@v1'
+          indexPreviewPairCount = 2
           indexPreviewPairOmittedCount = 0
         }
         targets = @(
@@ -176,8 +180,8 @@ function New-PublicationArtifactZip {
           }
         )
         previewPairs = $previewPairs
-        commentPreviewPairs = $commentPreviewPairs
-        indexPreviewPairs = $previewPairs
+        commentPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
+        indexPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
       } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-preview-manifest.json') -Encoding utf8
   }
 
@@ -345,7 +349,7 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([string]$createReceipt.previewPublication.status -ne 'succeeded') {
     throw 'Expected preview publication to succeed for the first path.'
   }
-  if ([int]$createReceipt.previewPublication.previewPairCount -ne 4 -or [int]$createReceipt.previewPublication.publishedImageCount -ne 8) {
+  if ([int]$createReceipt.previewPublication.previewPairCount -ne 2 -or [int]$createReceipt.previewPublication.publishedImageCount -ne 4) {
     throw 'Preview publication counts mismatch for the first path.'
   }
   if ($global:RecordedPosts.Count -ne 1) {
@@ -354,25 +358,30 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<!-- comparevi-history:pull-request-diagnostics -->')) {
     throw 'Created PR comment body is missing the sticky marker.'
   }
-  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('#### `Tooling/demo/Demo.vi |')).Count -ne 4) {
-    throw 'Created PR comment body should render four preview gallery sections.'
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<h4><code>Tooling/demo/Demo.vi</code></h4>')).Count -ne 2) {
+    throw 'Created PR comment body should render two reviewer-canonical preview gallery sections.'
   }
-  if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
-    [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
-    throw 'Created PR comment body should embed eight preview image URLs.'
+  if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 2 -or
+    [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 2) {
+    throw 'Created PR comment body should embed four preview image URLs.'
+  }
+  if ($global:RecordedPosts[0].body -match [regex]::Escape('| front-panel |') -or
+    $global:RecordedPosts[0].body -match [regex]::Escape('| block-diagram |') -or
+    $global:RecordedPosts[0].body -match [regex]::Escape('| attributes |')) {
+    throw 'Created PR comment body should not surface execution modes in reviewer-facing preview headings.'
   }
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'
   }
-  if ($global:RecordedContentWrites.Count -ne 9) {
-    throw 'Expected preview publication to write eight images and one manifest.'
+  if ($global:RecordedContentWrites.Count -ne 5) {
+    throw 'Expected preview publication to write four images and one manifest.'
   }
 
   $publishedPairOrder = @(
     $createReceipt.previewPublication.commentPreviewPairs |
       ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
   ) -join ','
-  if ($publishedPairOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2') {
+  if ($publishedPairOrder -ne 'front-panel:1,front-panel:2') {
     throw "Preview publication order mismatch: $publishedPairOrder"
   }
 
@@ -384,13 +393,9 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/base.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/head.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/head.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/003-front-panel-overview/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/003-front-panel-overview/head.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/004-front-panel-overview/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/004-front-panel-overview/head.png'
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/head.png'
   )
-  foreach ($index in 0..7) {
+  foreach ($index in 0..3) {
     if ([string]$writeOrder[$index] -ne $expectedImagePrefixes[$index]) {
       throw "Published preview write order mismatch at position $index."
     }
@@ -405,8 +410,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
       'comment-url=https://github.com/example/repo/pull/55#issuecomment-991',
       'preview-publication-status=succeeded',
       'preview-publication-reason=preview-images-published',
-      'preview-pair-count=4',
-      'published-image-count=8'
+      'preview-pair-count=2',
+      'published-image-count=4'
     )) {
     if ($createOutputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -125,13 +125,16 @@ try {
   if ($receipt.summary.previewPairCount -ne 6) {
     throw 'Expected six preview pairs from the PR31-shaped fixture.'
   }
-  if ($receipt.summary.commentSelectionPolicy -ne 'mode-balanced@v1' -or $receipt.summary.indexSelectionPolicy -ne 'mode-balanced@v1') {
-    throw 'Expected explicit mode-balanced selection policies in the preview manifest summary.'
+  if ($receipt.summary.rawPreviewPairCount -ne 6 -or $receipt.summary.reviewerPreviewPairCount -ne 2) {
+    throw 'Expected explicit raw and reviewer preview pair counts in the preview manifest summary.'
   }
-  if ($receipt.summary.commentPreviewPairCount -ne 4 -or $receipt.summary.commentPreviewPairOmittedCount -ne 2) {
+  if ($receipt.summary.commentSelectionPolicy -ne 'reviewer-canonical@v1' -or $receipt.summary.indexSelectionPolicy -ne 'reviewer-canonical@v1') {
+    throw 'Expected explicit reviewer-canonical selection policies in the preview manifest summary.'
+  }
+  if ($receipt.summary.commentPreviewPairCount -ne 2 -or $receipt.summary.commentPreviewPairOmittedCount -ne 0) {
     throw 'Comment preview pair selection mismatch.'
   }
-  if ($receipt.summary.indexPreviewPairCount -ne 6 -or $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
+  if ($receipt.summary.indexPreviewPairCount -ne 2 -or $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
     throw 'Index preview pair selection mismatch.'
   }
   if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 6) {
@@ -142,7 +145,7 @@ try {
     $receipt.commentPreviewPairs |
       ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
   ) -join ','
-  if ($commentOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2') {
+  if ($commentOrder -ne 'front-panel:1,front-panel:2') {
     throw "Comment preview pair order mismatch: $commentOrder"
   }
 
@@ -150,24 +153,26 @@ try {
     $receipt.indexPreviewPairs |
       ForEach-Object { '{0}:{1}' -f [string]$_.mode, [int]$_.comparison.index }
   ) -join ','
-  if ($indexOrder -ne 'front-panel:1,block-diagram:1,attributes:1,front-panel:2,block-diagram:2,attributes:2') {
+  if ($indexOrder -ne 'front-panel:1,front-panel:2') {
     throw "Index preview pair order mismatch: $indexOrder"
   }
 
   if ($receipt.commentPreviewPairs[0].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
     throw 'Expected normalized relative path for the first comment preview base image.'
   }
-  if ($receipt.commentPreviewPairs[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
-    throw 'Expected mode-specific preview identity to survive repeated image filenames.'
+  if ($receipt.commentPreviewPairs[1].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-002-artifacts/compare-report_files/fp_1.png') {
+    throw 'Expected reviewer selection to collapse mode-duplicated preview pairs while preserving comparison order.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw
   foreach ($requiredKey in @(
       'preview-manifest-path=',
-      'preview-pair-count=6',
-      'comment-preview-pair-count=4',
-      'comment-preview-pair-omitted-count=2',
-      'index-preview-pair-count=6',
+      'preview-pair-count=2',
+      'raw-preview-pair-count=6',
+      'reviewer-preview-pair-count=2',
+      'comment-preview-pair-count=2',
+      'comment-preview-pair-omitted-count=0',
+      'index-preview-pair-count=2',
       'index-preview-pair-omitted-count=0'
     )) {
     if ($outputText -notmatch [regex]::Escape($requiredKey)) {

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -94,6 +94,15 @@ function Get-NestedValue {
       return $Default
     }
 
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
     $property = $current.PSObject.Properties[$segment]
     if ($null -eq $property) {
       return $Default
@@ -161,6 +170,30 @@ function Escape-Html {
   return [System.Net.WebUtility]::HtmlEncode($Value)
 }
 
+function Get-ReviewerPreviewTitle {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return [string]$PreviewPair.targetPath
+}
+
+function Get-ReviewerPreviewSubtitle {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  $comparisonIndex = [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+  $label = Get-OptionalString -Value $PreviewPair.label
+  if ([string]::IsNullOrWhiteSpace($label)) {
+    return 'Comparison {0}' -f $comparisonIndex
+  }
+
+  return 'Comparison {0} - {1}' -f $comparisonIndex, $label
+}
+
 function ConvertTo-PreviewPairArray {
   param(
     [AllowNull()]
@@ -194,12 +227,25 @@ function New-MarkdownPreviewGallery {
   $lines.Add('## Preview gallery') | Out-Null
   $lines.Add('') | Out-Null
   foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
-    $title = '{0} | {1} | {2}' -f [string]$previewPair.targetPath, [string]$previewPair.mode, [string]$previewPair.label
-    $lines.Add(('### {0}' -f $title)) | Out-Null
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
+    $lines.Add(('### `{0}`' -f $title)) | Out-Null
     $lines.Add('') | Out-Null
-    $lines.Add('| Base | Head |') | Out-Null
-    $lines.Add('| --- | --- |') | Out-Null
-    $lines.Add(('| ![{0} base]({1}) | ![{0} head]({2}) |' -f $title, [string]$previewPair.baseImageRelativePath, [string]$previewPair.headImageRelativePath)) | Out-Null
+    $lines.Add($subtitle) | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('**Base**') | Out-Null
+    $lines.Add((
+        '![{0}]({1})' -f
+          ('{0} base' -f $subtitle),
+          [string]$previewPair.baseImageRelativePath
+      )) | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('**Head**') | Out-Null
+    $lines.Add((
+        '![{0}]({1})' -f
+          ('{0} head' -f $subtitle),
+          [string]$previewPair.headImageRelativePath
+      )) | Out-Null
     if (-not [string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
       $lines.Add(('- Report: [{0}]({0})' -f [string]$previewPair.reportHtmlRelativePath)) | Out-Null
     }
@@ -221,7 +267,8 @@ function New-HtmlPreviewGallery {
 
   $cards = New-Object System.Collections.Generic.List[string]
   foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
-    $title = '{0} | {1} | {2}' -f [string]$previewPair.targetPath, [string]$previewPair.mode, [string]$previewPair.label
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
     $reportLink = if ([string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
       ''
     } else {
@@ -230,18 +277,19 @@ function New-HtmlPreviewGallery {
     $cards.Add(@"
 <article class="preview-card">
   <h3>$(Escape-Html $title)</h3>
+  <p class="preview-card-subtitle">$(Escape-Html $subtitle)</p>
   <div class="preview-card-meta">
     <strong>Target</strong><span><code>$(Escape-Html ([string]$previewPair.targetPath))</code></span>
-    <strong>Mode</strong><span><code>$(Escape-Html ([string]$previewPair.mode))</code></span>
+    <strong>Comparison</strong><span><code>$([int](Get-NestedValue -Object $previewPair -Path @('comparison', 'index') -Default 0))</code></span>
     <strong>Section</strong><span><code>$(Escape-Html ([string]$previewPair.label))</code></span>
   </div>
   <div class="preview-image-grid">
     <figure>
-      <img alt="$(Escape-Html ($title + ' base'))" src="$(Escape-Html ([string]$previewPair.baseImageRelativePath))">
+      <img alt="$(Escape-Html ($subtitle + ' base'))" src="$(Escape-Html ([string]$previewPair.baseImageRelativePath))">
       <figcaption>Base</figcaption>
     </figure>
     <figure>
-      <img alt="$(Escape-Html ($title + ' head'))" src="$(Escape-Html ([string]$previewPair.headImageRelativePath))">
+      <img alt="$(Escape-Html ($subtitle + ' head'))" src="$(Escape-Html ([string]$previewPair.headImageRelativePath))">
       <figcaption>Head</figcaption>
     </figure>
   </div>
@@ -314,7 +362,8 @@ $totalProcessed = 0
 $totalDiffs = 0
 $previewManifest = $null
 $previewManifestPathResolved = $null
-$previewPairCount = 0
+$rawPreviewPairCount = 0
+$reviewerPreviewPairCount = 0
 $commentPreviewPairCount = 0
 $commentPreviewPairOmittedCount = 0
 $indexPreviewPairCount = 0
@@ -345,7 +394,8 @@ if ($null -ne $targetManifest) {
   if ([string]$previewManifest.schema -ne 'comparevi-history/pr-preview-manifest@v1') {
     throw "Unsupported preview manifest schema in '$previewManifestPathResolved': $($previewManifest.schema)"
   }
-  $previewPairCount = [int]$previewManifest.summary.previewPairCount
+  $rawPreviewPairCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'rawPreviewPairCount') -Default $previewManifest.summary.previewPairCount)
+  $reviewerPreviewPairCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'reviewerPreviewPairCount') -Default $previewManifest.summary.previewPairCount)
   $commentPreviewPairCap = [int]$previewManifest.summary.commentPreviewPairCap
   $commentPreviewPairCount = [int]$previewManifest.summary.commentPreviewPairCount
   $commentPreviewPairOmittedCount = [int]$previewManifest.summary.commentPreviewPairOmittedCount
@@ -397,9 +447,11 @@ $commentLines.Add(('- Executed targets: `{0}`' -f $executedTargetCount)) | Out-N
 $commentLines.Add(('- Failed targets: `{0}`' -f $failedTargetCount)) | Out-Null
 $commentLines.Add(('- Total processed pairs: `{0}`' -f $totalProcessed)) | Out-Null
 $commentLines.Add(('- Total diffs: `{0}`' -f $totalDiffs)) | Out-Null
-if ($previewPairCount -gt 0) {
-  $commentLines.Add(('- Preview pairs: `{0}`' -f $previewPairCount)) | Out-Null
-  $commentLines.Add(('- PR comment preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
+if ($reviewerPreviewPairCount -gt 0) {
+  $commentLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
+  if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
+    $commentLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
+  }
 }
 if (-not [string]::IsNullOrWhiteSpace($RunUrl)) {
   $commentLines.Add(('- Workflow run: [view run]({0})' -f $RunUrl)) | Out-Null
@@ -453,9 +505,11 @@ $indexLines.Add(('- Aggregate receipt: [pr-run.json](pr-run.json)')) | Out-Null
 if ($null -ne $previewManifestPathResolved -and (Test-Path -LiteralPath $previewManifestPathResolved -PathType Leaf)) {
   $indexLines.Add(('- Preview manifest: [pr-preview-manifest.json](pr-preview-manifest.json)')) | Out-Null
 }
-$indexLines.Add(('- Preview pairs: `{0}`' -f $previewPairCount)) | Out-Null
-if ($previewPairCount -gt 0) {
-  $indexLines.Add(('- Index preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
+if ($reviewerPreviewPairCount -gt 0) {
+  $indexLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
+  if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
+    $indexLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
+  }
 }
 $indexLines.Add('') | Out-Null
 $previewGalleryMarkdown = New-MarkdownPreviewGallery -PreviewPairs $indexPreviewPairs
@@ -539,6 +593,7 @@ $indexHtml = @"
     ul { padding-left: 1.2rem; }
     .preview-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr)); gap: 1rem; margin: 1.5rem 0; }
     .preview-card { background: #ffffff; border: 1px solid #cbd5e1; padding: 1rem; }
+    .preview-card-subtitle { color: #334155; margin-top: -0.35rem; margin-bottom: 1rem; }
     .preview-card-meta { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 0.75rem; margin-bottom: 1rem; }
     .preview-image-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }
     .preview-image-grid figure { margin: 0; }
@@ -556,8 +611,8 @@ $indexHtml = @"
     <li>Discovery receipt: <a href="changed-vi-discovery.json">changed-vi-discovery.json</a></li>
     <li>Aggregate receipt: <a href="pr-run.json">pr-run.json</a></li>
     $(if ($null -ne $previewManifestPathResolved -and (Test-Path -LiteralPath $previewManifestPathResolved -PathType Leaf)) { '<li>Preview manifest: <a href="pr-preview-manifest.json">pr-preview-manifest.json</a></li>' } else { '' })
-    <li>Preview pairs: <code>$previewPairCount</code></li>
-    $(if ($previewPairCount -gt 0) { '<li>Index preview gallery: <code>' + $indexPreviewPairCount + '</code> shown, <code>' + $indexPreviewPairOmittedCount + '</code> omitted, cap <code>' + $indexPreviewPairCap + '</code></li>' } else { '' })
+    $(if ($reviewerPreviewPairCount -gt 0) { '<li>Reviewer preview gallery: <code>' + $indexPreviewPairCount + '</code> shown, <code>' + $indexPreviewPairOmittedCount + '</code> omitted, cap <code>' + $indexPreviewPairCap + '</code></li>' } else { '' })
+    $(if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) { '<li>Raw preview surfaces collapsed for review: <code>' + $rawPreviewPairCount + '</code> raw -> <code>' + $reviewerPreviewPairCount + '</code> reviewer-canonical</li>' } else { '' })
   </ul>
   $(New-HtmlPreviewGallery -PreviewPairs $indexPreviewPairs)
   <table>
@@ -590,9 +645,11 @@ $stepSummaryLines.Add(('- Aggregate receipt: `{0}`' -f $prRunPath)) | Out-Null
 $stepSummaryLines.Add(('- Index markdown: `{0}`' -f $indexMdPath)) | Out-Null
 $stepSummaryLines.Add(('- Index HTML: `{0}`' -f $indexHtmlPath)) | Out-Null
 $stepSummaryLines.Add(('- Preview manifest: `{0}`' -f $(if ($null -eq $previewManifestPathResolved) { 'n/a' } else { $previewManifestPathResolved }))) | Out-Null
-$stepSummaryLines.Add(('- Preview pairs: `{0}`' -f $previewPairCount)) | Out-Null
-$stepSummaryLines.Add(('- PR comment preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
+$stepSummaryLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
 $stepSummaryLines.Add(('- Index preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
+if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
+  $stepSummaryLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
+}
 $stepSummaryLines.Add(('- Public comment body enabled: `{0}`' -f $emitCommentBody.ToString().ToLowerInvariant())) | Out-Null
 $stepSummaryLines.Add(('- Public step summary enabled: `{0}`' -f $emitStepSummary.ToString().ToLowerInvariant())) | Out-Null
 $stepSummaryLines.Add('') | Out-Null
@@ -693,7 +750,9 @@ $receipt = [ordered]@{
     failedTargetCount = $failedTargetCount
     totalProcessed = $totalProcessed
     totalDiffs = $totalDiffs
-    previewPairCount = $previewPairCount
+    previewPairCount = $rawPreviewPairCount
+    rawPreviewPairCount = $rawPreviewPairCount
+    reviewerPreviewPairCount = $reviewerPreviewPairCount
     commentPreviewPairCap = $commentPreviewPairCap
     commentPreviewPairCount = $commentPreviewPairCount
     commentPreviewPairOmittedCount = $commentPreviewPairOmittedCount

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -116,6 +116,15 @@ function Get-NestedValue {
       return $Default
     }
 
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
     $property = $current.PSObject.Properties[$segment]
     if ($null -eq $property) {
       return $Default
@@ -249,45 +258,49 @@ function ConvertTo-PreviewPairArray {
   )
 }
 
-function Get-PreviewPairIdentityKey {
+function Get-FileSha256Hex {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  return [string](Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-PreviewPairReviewerIdentityKey {
   param(
     [Parameter(Mandatory = $true)]
     [object]$PreviewPair
   )
 
-  return '{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}' -f `
+  return '{0}|{1}|{2}|{3}|{4}|{5}|{6}' -f `
     [string]$PreviewPair.targetId, `
-    [string]$PreviewPair.mode, `
     [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0), `
     [string]$PreviewPair.sectionKind, `
     [int](Get-NestedValue -Object $PreviewPair -Path @('sectionOrdinal') -Default 0), `
-    $(if ([string]::IsNullOrWhiteSpace([string]$PreviewPair.reportHtmlRelativePath)) { '' } else { [string]$PreviewPair.reportHtmlRelativePath }), `
-    [string]$PreviewPair.baseImageRelativePath, `
-    [string]$PreviewPair.headImageRelativePath
+    [string]$PreviewPair.label, `
+    $(if ([string]::IsNullOrWhiteSpace([string]$PreviewPair.baseImageSha256)) { [string]$PreviewPair.baseImageRelativePath } else { [string]$PreviewPair.baseImageSha256 }), `
+    $(if ([string]::IsNullOrWhiteSpace([string]$PreviewPair.headImageSha256)) { [string]$PreviewPair.headImageRelativePath } else { [string]$PreviewPair.headImageSha256 })
 }
 
-function Add-PreviewPairSelection {
+function Get-ReviewerPreviewPairArray {
   param(
     [AllowNull()]
-    [object]$PreviewPair,
-    [AllowEmptyCollection()]
-    [System.Collections.Generic.List[object]]$Selected,
-    [AllowEmptyCollection()]
-    [System.Collections.Generic.HashSet[string]]$Seen,
-    [int]$Limit
+    $Value
   )
 
-  if ($null -eq $PreviewPair -or $Selected.Count -ge $Limit) {
-    return $false
+  $selected = New-Object System.Collections.Generic.List[object]
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($previewPair in @(ConvertTo-PreviewPairArray -Value $Value)) {
+    $identityKey = Get-PreviewPairReviewerIdentityKey -PreviewPair $previewPair
+    if (-not $seen.Add($identityKey)) {
+      continue
+    }
+
+    $selected.Add($previewPair) | Out-Null
   }
 
-  $identityKey = Get-PreviewPairIdentityKey -PreviewPair $PreviewPair
-  if (-not $Seen.Add($identityKey)) {
-    return $false
-  }
-
-  $Selected.Add($PreviewPair) | Out-Null
-  return $true
+  return @($selected | ForEach-Object { $_ })
 }
 
 function Select-PreviewPairs {
@@ -301,37 +314,10 @@ function Select-PreviewPairs {
     return @()
   }
 
-  $orderedPairs = @(ConvertTo-PreviewPairArray -Value $PreviewPairs)
-  $selected = New-Object System.Collections.Generic.List[object]
-  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-
-  foreach ($mode in @('front-panel', 'block-diagram', 'attributes')) {
-    if ($selected.Count -ge $Limit) {
-      break
-    }
-
-    $overviewPair = @(
-      $orderedPairs |
-        Where-Object {
-          [string]$_.mode -eq $mode -and
-          [string]$_.sectionKind -eq 'overview'
-        } |
-        Select-Object -First 1
-    )
-    if ($overviewPair) {
-      Add-PreviewPairSelection -PreviewPair $overviewPair[0] -Selected $selected -Seen $seen -Limit $Limit | Out-Null
-    }
-  }
-
-  foreach ($pair in $orderedPairs) {
-    if ($selected.Count -ge $Limit) {
-      break
-    }
-
-    Add-PreviewPairSelection -PreviewPair $pair -Selected $selected -Seen $seen -Limit $Limit | Out-Null
-  }
-
-  return @($selected | ForEach-Object { $_ })
+  return @(
+    Get-ReviewerPreviewPairArray -Value $PreviewPairs |
+      Select-Object -First $Limit
+  )
 }
 
 function Get-ReportPreviewPairs {
@@ -426,6 +412,8 @@ function Get-ReportPreviewPairs {
         headImageRelativePath = Resolve-RelativePath -Path $headImagePath -ResultsRoot $ResultsRoot
         baseByteLength = [int64](Get-Item -LiteralPath $baseImagePath).Length
         headByteLength = [int64](Get-Item -LiteralPath $headImagePath).Length
+        baseImageSha256 = Get-FileSha256Hex -Path $baseImagePath
+        headImageSha256 = Get-FileSha256Hex -Path $headImagePath
         sortKey = $sortKey
       }) | Out-Null
 
@@ -500,6 +488,7 @@ foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets))
 }
 
 $orderedPreviewPairs = @(ConvertTo-PreviewPairArray -Value $allPreviewPairs)
+$reviewerPreviewPairs = @(Get-ReviewerPreviewPairArray -Value $orderedPreviewPairs)
 $commentPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $CommentPreviewPairCap)
 $indexPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $IndexPreviewPairCap)
 $targetReceiptArray = @($targetReceipts | ForEach-Object { $_ })
@@ -515,14 +504,16 @@ $receipt = [ordered]@{
   summary = [ordered]@{
     targetCount = $targetReceiptArray.Count
     previewPairCount = $orderedPreviewPairs.Count
+    rawPreviewPairCount = $orderedPreviewPairs.Count
+    reviewerPreviewPairCount = $reviewerPreviewPairs.Count
     commentPreviewPairCap = [int]$CommentPreviewPairCap
-    commentSelectionPolicy = 'mode-balanced@v1'
+    commentSelectionPolicy = 'reviewer-canonical@v1'
     commentPreviewPairCount = $commentPreviewPairs.Count
-    commentPreviewPairOmittedCount = [Math]::Max($orderedPreviewPairs.Count - $commentPreviewPairs.Count, 0)
+    commentPreviewPairOmittedCount = [Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0)
     indexPreviewPairCap = [int]$IndexPreviewPairCap
-    indexSelectionPolicy = 'mode-balanced@v1'
+    indexSelectionPolicy = 'reviewer-canonical@v1'
     indexPreviewPairCount = $indexPreviewPairs.Count
-    indexPreviewPairOmittedCount = [Math]::Max($orderedPreviewPairs.Count - $indexPreviewPairs.Count, 0)
+    indexPreviewPairOmittedCount = [Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0)
   }
   targets = $targetReceiptArray
   previewPairs = $orderedPreviewPairArray
@@ -533,20 +524,23 @@ $receipt = [ordered]@{
 $receipt | ConvertTo-Json -Depth 64 | Set-Content -LiteralPath $outputPathResolved -Encoding utf8
 
 Write-ActionOutput -Key 'preview-manifest-path' -Value $outputPathResolved
-Write-ActionOutput -Key 'preview-pair-count' -Value ([string]$orderedPreviewPairs.Count)
+Write-ActionOutput -Key 'preview-pair-count' -Value ([string]$reviewerPreviewPairs.Count)
+Write-ActionOutput -Key 'raw-preview-pair-count' -Value ([string]$orderedPreviewPairs.Count)
+Write-ActionOutput -Key 'reviewer-preview-pair-count' -Value ([string]$reviewerPreviewPairs.Count)
 Write-ActionOutput -Key 'comment-preview-pair-count' -Value ([string]$commentPreviewPairs.Count)
-Write-ActionOutput -Key 'comment-preview-pair-omitted-count' -Value ([string][Math]::Max($orderedPreviewPairs.Count - $commentPreviewPairs.Count, 0))
+Write-ActionOutput -Key 'comment-preview-pair-omitted-count' -Value ([string][Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0))
 Write-ActionOutput -Key 'index-preview-pair-count' -Value ([string]$indexPreviewPairs.Count)
-Write-ActionOutput -Key 'index-preview-pair-omitted-count' -Value ([string][Math]::Max($orderedPreviewPairs.Count - $indexPreviewPairs.Count, 0))
+Write-ActionOutput -Key 'index-preview-pair-omitted-count' -Value ([string][Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0))
 
 if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
   @(
     '## comparevi-history PR preview manifest'
     ''
     ('- Preview manifest: `{0}`' -f $outputPathResolved)
-    ('- Total preview pairs: `{0}`' -f $orderedPreviewPairs.Count)
-    ('- Comment preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairs.Count, [Math]::Max($orderedPreviewPairs.Count - $commentPreviewPairs.Count, 0), [int]$CommentPreviewPairCap)
-    ('- Index preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairs.Count, [Math]::Max($orderedPreviewPairs.Count - $indexPreviewPairs.Count, 0), [int]$IndexPreviewPairCap)
+    ('- Raw preview pairs: `{0}`' -f $orderedPreviewPairs.Count)
+    ('- Reviewer preview pairs: `{0}`' -f $reviewerPreviewPairs.Count)
+    ('- Comment preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairs.Count, [Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0), [int]$CommentPreviewPairCap)
+    ('- Index preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairs.Count, [Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0), [int]$IndexPreviewPairCap)
   ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
 }
 


### PR DESCRIPTION
## Summary
- switch PR preview selection to reviewer-canonical pairs so mode-duplicated execution surfaces collapse before rendering
- replace pipe-heavy markdown preview tables with HTML image rendering so base/head previews display reliably in GitHub comments
- keep raw preview surfaces in machine receipts while updating reviewer-facing counts and regressions to the canonical gallery contract

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

Closes #122
