### PR TITLE
#126 Promote reviewer preview titles from history-pair context

### DIFF
--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -94,7 +94,11 @@
       "properties": {
         "index": { "type": "integer", "minimum": 0 },
         "baseRef": { "type": ["string", "null"] },
-        "headRef": { "type": ["string", "null"] }
+        "headRef": { "type": ["string", "null"] },
+        "baseShortRef": { "type": ["string", "null"] },
+        "headShortRef": { "type": ["string", "null"] },
+        "baseSubject": { "type": ["string", "null"] },
+        "headSubject": { "type": ["string", "null"] }
       }
     },
     "previewPair": {

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -242,6 +242,72 @@ function ConvertTo-HtmlText {
   return [System.Net.WebUtility]::HtmlEncode($Value)
 }
 
+function ConvertTo-ShortRef {
+  param([AllowNull()][string]$Ref)
+
+  $refValue = Get-OptionalString -Value $Ref
+  if ([string]::IsNullOrWhiteSpace($refValue)) {
+    return $null
+  }
+
+  if ($refValue.Length -le 12) {
+    return $refValue
+  }
+
+  return $refValue.Substring(0, 12)
+}
+
+function Get-ReviewerPreviewComparisonIndex {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  return [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+}
+
+function Get-ReviewerPreviewRevisionContext {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  $baseShortRef = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseShortRef'))
+  if ([string]::IsNullOrWhiteSpace($baseShortRef)) {
+    $baseShortRef = ConvertTo-ShortRef -Ref (Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseRef')))
+  }
+
+  $headShortRef = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headShortRef'))
+  if ([string]::IsNullOrWhiteSpace($headShortRef)) {
+    $headShortRef = ConvertTo-ShortRef -Ref (Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headRef')))
+  }
+
+  if ([string]::IsNullOrWhiteSpace($baseShortRef) -and [string]::IsNullOrWhiteSpace($headShortRef)) {
+    return $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($baseShortRef)) {
+    return $headShortRef
+  }
+
+  if ([string]::IsNullOrWhiteSpace($headShortRef)) {
+    return $baseShortRef
+  }
+
+  return '{0} -> {1}' -f $baseShortRef, $headShortRef
+}
+
+function Get-ReviewerPreviewDetailLines {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $baseSubject = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseSubject'))
+  if (-not [string]::IsNullOrWhiteSpace($baseSubject)) {
+    $lines.Add('Base: {0}' -f $baseSubject) | Out-Null
+  }
+
+  $headSubject = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headSubject'))
+  if (-not [string]::IsNullOrWhiteSpace($headSubject)) {
+    $lines.Add('Head: {0}' -f $headSubject) | Out-Null
+  }
+
+  return @($lines | ForEach-Object { $_ })
+}
+
 function Get-ReviewerPreviewTitle {
   param([Parameter(Mandatory = $true)][object]$PreviewPair)
 
@@ -251,13 +317,7 @@ function Get-ReviewerPreviewTitle {
 function Get-ReviewerPreviewSubtitle {
   param([Parameter(Mandatory = $true)][object]$PreviewPair)
 
-  $comparisonIndex = [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
-  $label = Get-OptionalString -Value $PreviewPair.label
-  if ([string]::IsNullOrWhiteSpace($label)) {
-    return 'Comparison {0}' -f $comparisonIndex
-  }
-
-  return 'Comparison {0} - {1}' -f $comparisonIndex, $label
+  return 'History pair {0}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $PreviewPair)
 }
 
 function ConvertTo-GitHubContentPath {
@@ -405,6 +465,13 @@ function New-CommentPreviewMarkdown {
   foreach ($previewPair in $PreviewPairs) {
     $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
     $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
+    $detailHtml = if ($detailLines.Count -eq 0) {
+      ''
+    } else {
+      '<div class="comparevi-preview-history">' + (($detailLines | ForEach-Object { '<p>' + (ConvertTo-HtmlText $_) + '</p>' }) -join '') + '</div>'
+    }
     $baseUrl = [string]$previewPair.baseImageUrl
     $headUrl = [string]$previewPair.headImageUrl
     $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
@@ -412,6 +479,12 @@ function New-CommentPreviewMarkdown {
     $headAlt = '{0} head' -f $subtitle
     $lines.Add(('<h4><code>{0}</code></h4>' -f (ConvertTo-HtmlText $title))) | Out-Null
     $lines.Add(('<p>{0}</p>' -f (ConvertTo-HtmlText $subtitle))) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+      $lines.Add(('<p><code>{0}</code></p>' -f (ConvertTo-HtmlText $revisionContext))) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($detailHtml)) {
+      $lines.Add($detailHtml) | Out-Null
+    }
     $lines.Add('') | Out-Null
     $lines.Add('<table>') | Out-Null
     $lines.Add('<thead><tr><th>Base</th><th>Head</th></tr></thead>') | Out-Null

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -42,8 +42,14 @@ function New-PreviewReportFixture {
 
   return [ordered]@{
     index = $ComparisonIndex
-    base = [ordered]@{ ref = $BaseRef }
-    head = [ordered]@{ ref = $HeadRef }
+    base = [ordered]@{
+      ref = $BaseRef
+      short = ('base-{0:D2}' -f $ComparisonIndex)
+    }
+    head = [ordered]@{
+      ref = $HeadRef
+      short = ('head-{0:D2}' -f $ComparisonIndex)
+    }
     result = [ordered]@{
       reportHtml = $reportHtmlPath
     }
@@ -414,8 +420,9 @@ try {
   }
   if ($commentBody -match [regex]::Escape('| front-panel |') -or
     $commentBody -match [regex]::Escape('| block-diagram |') -or
-    $commentBody -match [regex]::Escape('| attributes |')) {
-    throw 'PR comment body should not surface execution modes in the reviewer-facing preview gallery.'
+    $commentBody -match [regex]::Escape('| attributes |') -or
+    $commentBody -match [regex]::Escape('Front Panel Overview')) {
+    throw 'PR comment body should not surface execution modes or report captions in the reviewer-facing preview gallery.'
   }
 
   $indexMarkdown = Get-Content -LiteralPath $receipt.outputs.indexMarkdownPath -Raw
@@ -438,8 +445,15 @@ try {
   }
   if ($indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | front-panel |') -or
     $indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | block-diagram |') -or
-    $indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | attributes |')) {
-    throw 'Index markdown should not surface execution modes in reviewer-facing preview titles.'
+    $indexMarkdown -match [regex]::Escape('### Tooling/deployment/VIP_Post-Install Custom Action.vi | attributes |') -or
+    $indexMarkdown -match [regex]::Escape('Front Panel Overview')) {
+    throw 'Index markdown should not surface execution modes or report captions in reviewer-facing preview titles.'
+  }
+  if ($indexMarkdown -notmatch [regex]::Escape('History pair 1') -or
+    $indexMarkdown -notmatch [regex]::Escape('History pair 2') -or
+    $indexMarkdown -notmatch [regex]::Escape('`base-01 -> head-01`') -or
+    $indexMarkdown -notmatch [regex]::Escape('`base-02 -> head-02`')) {
+    throw 'Index markdown should surface stable history-pair subtitles and revision refs.'
   }
 
   $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
@@ -457,8 +471,15 @@ try {
   if ([regex]::Matches($indexHtml, [regex]::Escape('<article class="preview-card">')).Count -ne 2) {
     throw 'Index HTML should render two reviewer-canonical preview cards for the PR31-shaped fixture.'
   }
-  if ($indexHtml -match [regex]::Escape('<strong>Mode</strong>')) {
-    throw 'Index HTML should not surface execution modes in reviewer-facing preview cards.'
+  if ($indexHtml -match [regex]::Escape('<strong>Mode</strong>') -or
+    $indexHtml -match [regex]::Escape('Front Panel Overview')) {
+    throw 'Index HTML should not surface execution modes or report captions in reviewer-facing preview cards.'
+  }
+  if ($indexHtml -notmatch [regex]::Escape('History pair 1') -or
+    $indexHtml -notmatch [regex]::Escape('History pair 2') -or
+    $indexHtml -notmatch [regex]::Escape('base-01 -&gt; head-01') -or
+    $indexHtml -notmatch [regex]::Escape('base-02 -&gt; head-02')) {
+    throw 'Index HTML should surface stable history-pair subtitles and revision refs.'
   }
 
   $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -21,6 +21,10 @@ function New-PreviewPair {
       index = $ComparisonIndex
       baseRef = ('{0}-base-{1}' -f $Mode, $ComparisonIndex)
       headRef = ('{0}-head-{1}' -f $Mode, $ComparisonIndex)
+      baseShortRef = ('base-{0:D2}' -f $ComparisonIndex)
+      headShortRef = ('head-{0:D2}' -f $ComparisonIndex)
+      baseSubject = ('Base subject {0}' -f $ComparisonIndex)
+      headSubject = ('Head subject {0}' -f $ComparisonIndex)
     }
     sectionKind = 'overview'
     sectionOrdinal = 0
@@ -361,14 +365,24 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<h4><code>Tooling/demo/Demo.vi</code></h4>')).Count -ne 2) {
     throw 'Created PR comment body should render two reviewer-canonical preview gallery sections.'
   }
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p>History pair 1</p>')).Count -ne 1 -or
+    [regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p>History pair 2</p>')).Count -ne 1) {
+    throw 'Created PR comment body should render stable history-pair subtitles.'
+  }
+  if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<p><code>base-01 -&gt; head-01</code></p>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('Base subject 1') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('Head subject 1')) {
+    throw 'Created PR comment body should surface revision refs and commit-subject context.'
+  }
   if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 2 -or
     [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 2) {
     throw 'Created PR comment body should embed four preview image URLs.'
   }
   if ($global:RecordedPosts[0].body -match [regex]::Escape('| front-panel |') -or
     $global:RecordedPosts[0].body -match [regex]::Escape('| block-diagram |') -or
-    $global:RecordedPosts[0].body -match [regex]::Escape('| attributes |')) {
-    throw 'Created PR comment body should not surface execution modes in reviewer-facing preview headings.'
+    $global:RecordedPosts[0].body -match [regex]::Escape('| attributes |') -or
+    $global:RecordedPosts[0].body -match [regex]::Escape('Front Panel Overview')) {
+    throw 'Created PR comment body should not surface execution modes or report captions in reviewer-facing preview headings.'
   }
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -40,8 +40,14 @@ function New-PreviewReportFixture {
 
   return [ordered]@{
     index = $ComparisonIndex
-    base = [ordered]@{ ref = $BaseRef }
-    head = [ordered]@{ ref = $HeadRef }
+    base = [ordered]@{
+      ref = $BaseRef
+      short = ('base-{0:D2}' -f $ComparisonIndex)
+    }
+    head = [ordered]@{
+      ref = $HeadRef
+      short = ('head-{0:D2}' -f $ComparisonIndex)
+    }
     result = [ordered]@{
       reportHtml = $reportHtmlPath
     }
@@ -162,6 +168,14 @@ try {
   }
   if ($receipt.commentPreviewPairs[1].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-002-artifacts/compare-report_files/fp_1.png') {
     throw 'Expected reviewer selection to collapse mode-duplicated preview pairs while preserving comparison order.'
+  }
+  if ([string]$receipt.commentPreviewPairs[0].comparison.baseShortRef -ne 'base-01' -or
+    [string]$receipt.commentPreviewPairs[0].comparison.headShortRef -ne 'head-01') {
+    throw 'Expected preview manifest pairs to preserve comparison short refs for reviewer rendering.'
+  }
+  if ($null -ne $receipt.commentPreviewPairs[0].comparison.baseSubject -or
+    $null -ne $receipt.commentPreviewPairs[0].comparison.headSubject) {
+    throw 'Preview manifest fixture without a repository root should not invent commit subjects.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -170,6 +170,81 @@ function Escape-Html {
   return [System.Net.WebUtility]::HtmlEncode($Value)
 }
 
+function ConvertTo-ShortRef {
+  param([AllowNull()][string]$Ref)
+
+  $refValue = Get-OptionalString -Value $Ref
+  if ([string]::IsNullOrWhiteSpace($refValue)) {
+    return $null
+  }
+
+  if ($refValue.Length -le 12) {
+    return $refValue
+  }
+
+  return $refValue.Substring(0, 12)
+}
+
+function Get-ReviewerPreviewComparisonIndex {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+}
+
+function Get-ReviewerPreviewRevisionContext {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  $baseShortRef = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseShortRef'))
+  if ([string]::IsNullOrWhiteSpace($baseShortRef)) {
+    $baseShortRef = ConvertTo-ShortRef -Ref (Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseRef')))
+  }
+
+  $headShortRef = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headShortRef'))
+  if ([string]::IsNullOrWhiteSpace($headShortRef)) {
+    $headShortRef = ConvertTo-ShortRef -Ref (Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headRef')))
+  }
+
+  if ([string]::IsNullOrWhiteSpace($baseShortRef) -and [string]::IsNullOrWhiteSpace($headShortRef)) {
+    return $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($baseShortRef)) {
+    return $headShortRef
+  }
+
+  if ([string]::IsNullOrWhiteSpace($headShortRef)) {
+    return $baseShortRef
+  }
+
+  return '{0} -> {1}' -f $baseShortRef, $headShortRef
+}
+
+function Get-ReviewerPreviewDetailLines {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $baseSubject = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'baseSubject'))
+  if (-not [string]::IsNullOrWhiteSpace($baseSubject)) {
+    $lines.Add('Base: {0}' -f $baseSubject) | Out-Null
+  }
+
+  $headSubject = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('comparison', 'headSubject'))
+  if (-not [string]::IsNullOrWhiteSpace($headSubject)) {
+    $lines.Add('Head: {0}' -f $headSubject) | Out-Null
+  }
+
+  return @($lines | ForEach-Object { $_ })
+}
+
 function Get-ReviewerPreviewTitle {
   param(
     [Parameter(Mandatory = $true)]
@@ -185,13 +260,7 @@ function Get-ReviewerPreviewSubtitle {
     [object]$PreviewPair
   )
 
-  $comparisonIndex = [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
-  $label = Get-OptionalString -Value $PreviewPair.label
-  if ([string]::IsNullOrWhiteSpace($label)) {
-    return 'Comparison {0}' -f $comparisonIndex
-  }
-
-  return 'Comparison {0} - {1}' -f $comparisonIndex, $label
+  return 'History pair {0}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $PreviewPair)
 }
 
 function ConvertTo-PreviewPairArray {
@@ -229,10 +298,22 @@ function New-MarkdownPreviewGallery {
   foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
     $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
     $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
     $lines.Add(('### `{0}`' -f $title)) | Out-Null
     $lines.Add('') | Out-Null
     $lines.Add($subtitle) | Out-Null
     $lines.Add('') | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+      $lines.Add(('`{0}`' -f $revisionContext)) | Out-Null
+      $lines.Add('') | Out-Null
+    }
+    foreach ($detailLine in $detailLines) {
+      $lines.Add($detailLine) | Out-Null
+    }
+    if ($detailLines.Count -gt 0) {
+      $lines.Add('') | Out-Null
+    }
     $lines.Add('**Base**') | Out-Null
     $lines.Add((
         '![{0}]({1})' -f
@@ -269,6 +350,14 @@ function New-HtmlPreviewGallery {
   foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
     $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
     $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
+    $comparisonIndex = Get-ReviewerPreviewComparisonIndex -PreviewPair $previewPair
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
+    $detailHtml = if ($detailLines.Count -eq 0) {
+      ''
+    } else {
+      '<div class="preview-card-history">' + (($detailLines | ForEach-Object { '<p>' + (Escape-Html $_) + '</p>' }) -join '') + '</div>'
+    }
     $reportLink = if ([string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
       ''
     } else {
@@ -279,10 +368,10 @@ function New-HtmlPreviewGallery {
   <h3>$(Escape-Html $title)</h3>
   <p class="preview-card-subtitle">$(Escape-Html $subtitle)</p>
   <div class="preview-card-meta">
-    <strong>Target</strong><span><code>$(Escape-Html ([string]$previewPair.targetPath))</code></span>
-    <strong>Comparison</strong><span><code>$([int](Get-NestedValue -Object $previewPair -Path @('comparison', 'index') -Default 0))</code></span>
-    <strong>Section</strong><span><code>$(Escape-Html ([string]$previewPair.label))</code></span>
+    <strong>History pair</strong><span><code>$(Escape-Html ([string]$comparisonIndex))</code></span>
+    <strong>Revisions</strong><span><code>$(Escape-Html $revisionContext)</code></span>
   </div>
+  $detailHtml
   <div class="preview-image-grid">
     <figure>
       <img alt="$(Escape-Html ($subtitle + ' base'))" src="$(Escape-Html ([string]$previewPair.baseImageRelativePath))">

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -214,6 +214,21 @@ function ConvertTo-Slug {
   return $slug
 }
 
+function ConvertTo-ShortRef {
+  param([AllowNull()][string]$Ref)
+
+  $refValue = Get-OptionalString -Value $Ref
+  if ([string]::IsNullOrWhiteSpace($refValue)) {
+    return $null
+  }
+
+  if ($refValue.Length -le 12) {
+    return $refValue
+  }
+
+  return $refValue.Substring(0, 12)
+}
+
 function Get-ModeSortOrder {
   param([AllowNull()][string]$Mode)
 
@@ -226,6 +241,110 @@ function Get-ModeSortOrder {
   }
 
   return 99
+}
+
+$gitCommitSubjectCache = @{}
+
+function Resolve-TargetRepositoryRoot {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Target,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  $publicRunPath = Resolve-ExistingPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $Target -Path @('publicRunPath'))) -BasePath $BasePath -PathType Leaf
+  if ($null -eq $publicRunPath) {
+    return $null
+  }
+
+  try {
+    $publicRun = Read-JsonFile -Path $publicRunPath
+  } catch {
+    return $null
+  }
+
+  $repositoryRoot = Get-OptionalString -Value (Get-NestedValue -Object $publicRun -Path @('request', 'consumer', 'repositoryRoot'))
+  if ([string]::IsNullOrWhiteSpace($repositoryRoot)) {
+    return $null
+  }
+
+  $resolvedRepositoryRoot = Resolve-ExistingPath -Path $repositoryRoot -BasePath $BasePath -PathType Container
+  if ($null -eq $resolvedRepositoryRoot) {
+    return $null
+  }
+
+  if (-not (Test-Path -LiteralPath (Join-Path $resolvedRepositoryRoot '.git'))) {
+    return $null
+  }
+
+  return $resolvedRepositoryRoot
+}
+
+function Get-GitCommitSubject {
+  param(
+    [AllowNull()]
+    [string]$RepositoryRoot,
+    [AllowNull()]
+    [string]$Ref
+  )
+
+  $resolvedRepositoryRoot = Get-OptionalString -Value $RepositoryRoot
+  $resolvedRef = Get-OptionalString -Value $Ref
+  if ([string]::IsNullOrWhiteSpace($resolvedRepositoryRoot) -or [string]::IsNullOrWhiteSpace($resolvedRef)) {
+    return $null
+  }
+
+  $cacheKey = '{0}|{1}' -f $resolvedRepositoryRoot, $resolvedRef
+  if ($gitCommitSubjectCache.ContainsKey($cacheKey)) {
+    return $gitCommitSubjectCache[$cacheKey]
+  }
+
+  $subject = $null
+  try {
+    $subject = (& git -C $resolvedRepositoryRoot show -s --format=%s $resolvedRef 2>$null)
+    if ($LASTEXITCODE -ne 0) {
+      $subject = $null
+    }
+  } catch {
+    $subject = $null
+  }
+
+  $subject = Get-OptionalString -Value $subject
+  $gitCommitSubjectCache[$cacheKey] = $subject
+  return $subject
+}
+
+function New-PreviewPairComparison {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Comparison,
+    [AllowNull()]
+    [string]$RepositoryRoot
+  )
+
+  $index = [int](Get-NestedValue -Object $Comparison -Path @('index') -Default 0)
+  $baseRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('base', 'ref'))
+  $headRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('head', 'ref'))
+  $baseShortRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('base', 'short'))
+  if ([string]::IsNullOrWhiteSpace($baseShortRef)) {
+    $baseShortRef = ConvertTo-ShortRef -Ref $baseRef
+  }
+
+  $headShortRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('head', 'short'))
+  if ([string]::IsNullOrWhiteSpace($headShortRef)) {
+    $headShortRef = ConvertTo-ShortRef -Ref $headRef
+  }
+
+  return [ordered]@{
+    index = $index
+    baseRef = $baseRef
+    headRef = $headRef
+    baseShortRef = $baseShortRef
+    headShortRef = $headShortRef
+    baseSubject = Get-GitCommitSubject -RepositoryRoot $RepositoryRoot -Ref $baseRef
+    headSubject = Get-GitCommitSubject -RepositoryRoot $RepositoryRoot -Ref $headRef
+  }
 }
 
 function Get-SectionKindSortOrder {
@@ -333,7 +452,9 @@ function Get-ReportPreviewPairs {
     [Parameter(Mandatory = $true)]
     [string]$Mode,
     [Parameter(Mandatory = $true)]
-    [object]$Comparison
+    [object]$Comparison,
+    [AllowNull()]
+    [string]$RepositoryRoot
   )
 
   if (-not (Test-Path -LiteralPath $ReportHtmlPath -PathType Leaf)) {
@@ -386,7 +507,8 @@ function Get-ReportPreviewPairs {
       'Preview'
     }
 
-    $comparisonIndex = [int](Get-NestedValue -Object $Comparison -Path @('index') -Default 0)
+    $comparisonReceipt = New-PreviewPairComparison -Comparison $Comparison -RepositoryRoot $RepositoryRoot
+    $comparisonIndex = [int]$comparisonReceipt.index
     $sortKey = '{0}|{1:D2}|{2:D4}|{3:D2}|{4:D4}|{5}' -f `
       $TargetPath, `
       (Get-ModeSortOrder -Mode $Mode), `
@@ -395,15 +517,11 @@ function Get-ReportPreviewPairs {
       $sectionOrdinal, `
       (ConvertTo-Slug -Value $label)
 
-    $pairs.Add([ordered]@{
+      $pairs.Add([ordered]@{
         targetId = $TargetId
         targetPath = $TargetPath
         mode = $Mode
-        comparison = [ordered]@{
-          index = $comparisonIndex
-          baseRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('base', 'ref'))
-          headRef = Get-OptionalString -Value (Get-NestedValue -Object $Comparison -Path @('head', 'ref'))
-        }
+        comparison = $comparisonReceipt
         sectionKind = $sectionKind
         sectionOrdinal = $sectionOrdinal
         label = $label
@@ -449,6 +567,7 @@ $targetReceipts = New-Object System.Collections.Generic.List[object]
 
 foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets)) {
   $targetPreviewPairs = New-Object System.Collections.Generic.List[object]
+  $targetRepositoryRoot = Resolve-TargetRepositoryRoot -Target $target -BasePath $basePath
   $suiteManifestPath = Resolve-ExistingPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $target -Path @('manifestPath'))) -BasePath $basePath -PathType Leaf
   if ($null -ne $suiteManifestPath) {
     $suiteManifest = Read-JsonFile -Path $suiteManifestPath
@@ -469,7 +588,7 @@ foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets))
           continue
         }
 
-        foreach ($previewPair in @(Get-ReportPreviewPairs -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Mode $modeName -Comparison $comparison)) {
+        foreach ($previewPair in @(Get-ReportPreviewPairs -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Mode $modeName -Comparison $comparison -RepositoryRoot $targetRepositoryRoot)) {
           $targetPreviewPairs.Add($previewPair) | Out-Null
           $allPreviewPairs.Add($previewPair) | Out-Null
         }


### PR DESCRIPTION
## Summary
- promote reviewer preview titles from generic report captions to history-pair labels
- carry base/head short refs and commit subjects additively in `pr-preview-manifest@v1`
- render the artifact index and sticky comment gallery from those richer comparison fields

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
