### PR TITLE
#130 Show both front panel and block diagram in reviewer previews

### DIFF
--- a/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
@@ -119,9 +119,56 @@
           "type": "integer",
           "minimum": 0
         },
+        "publishedSurfaceCount": {
+          "type": "integer",
+          "minimum": 0
+        },
         "publishedImageCount": {
           "type": "integer",
           "minimum": 0
+        },
+        "commentPreviewCards": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "targetId",
+              "targetPath",
+              "comparison",
+              "surfaces"
+            ],
+            "properties": {
+              "targetId": { "type": "string", "minLength": 1 },
+              "targetPath": { "type": "string", "minLength": 1 },
+              "comparison": { "type": "object" },
+              "surfaces": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "surfaceKind",
+                    "surfaceLabel",
+                    "reportHtmlRelativePath",
+                    "baseImagePath",
+                    "baseImageUrl",
+                    "headImagePath",
+                    "headImageUrl"
+                  ],
+                  "properties": {
+                    "surfaceKind": { "type": "string", "minLength": 1 },
+                    "surfaceLabel": { "type": "string", "minLength": 1 },
+                    "reportHtmlRelativePath": { "type": ["string", "null"] },
+                    "baseImagePath": { "type": "string", "minLength": 1 },
+                    "baseImageUrl": { "type": "string", "minLength": 1 },
+                    "headImagePath": { "type": "string", "minLength": 1 },
+                    "headImageUrl": { "type": "string", "minLength": 1 }
+                  }
+                }
+              }
+            }
+          }
         },
         "commentPreviewPairs": {
           "type": "array",

--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -49,6 +49,8 @@
         "previewPairCount": { "type": "integer", "minimum": 0 },
         "rawPreviewPairCount": { "type": "integer", "minimum": 0 },
         "reviewerPreviewPairCount": { "type": "integer", "minimum": 0 },
+        "reviewerPreviewCardCount": { "type": "integer", "minimum": 0 },
+        "reviewerPreviewSurfaceCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairCap": { "type": "integer", "minimum": 0 },
         "commentSelectionPolicy": {
           "type": "string",
@@ -56,13 +58,19 @@
         },
         "commentPreviewPairCount": { "type": "integer", "minimum": 0 },
         "commentPreviewPairOmittedCount": { "type": "integer", "minimum": 0 },
+        "commentPreviewCardCount": { "type": "integer", "minimum": 0 },
+        "commentPreviewSurfaceCount": { "type": "integer", "minimum": 0 },
+        "commentCardSelectionPolicy": { "type": "string", "minLength": 1 },
         "indexPreviewPairCap": { "type": "integer", "minimum": 0 },
         "indexSelectionPolicy": {
           "type": "string",
           "enum": ["mode-balanced@v1", "reviewer-canonical@v1"]
         },
         "indexPreviewPairCount": { "type": "integer", "minimum": 0 },
-        "indexPreviewPairOmittedCount": { "type": "integer", "minimum": 0 }
+        "indexPreviewPairOmittedCount": { "type": "integer", "minimum": 0 },
+        "indexPreviewCardCount": { "type": "integer", "minimum": 0 },
+        "indexPreviewSurfaceCount": { "type": "integer", "minimum": 0 },
+        "indexCardSelectionPolicy": { "type": "string", "minLength": 1 }
       }
     },
     "targets": {
@@ -80,6 +88,18 @@
     "indexPreviewPairs": {
       "type": "array",
       "items": { "$ref": "#/$defs/previewPair" }
+    },
+    "reviewerPreviewCards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/previewCard" }
+    },
+    "commentPreviewCards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/previewCard" }
+    },
+    "indexPreviewCards": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/previewCard" }
     }
   },
   "$defs": {
@@ -147,6 +167,57 @@
           "pattern": "^[a-f0-9]{64}$"
         },
         "sortKey": { "type": "string", "minLength": 1 }
+      }
+    },
+    "previewSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "surfaceKind",
+        "surfaceLabel",
+        "reportHtmlRelativePath",
+        "baseImageRelativePath",
+        "headImageRelativePath"
+      ],
+      "properties": {
+        "surfaceKind": { "type": "string", "minLength": 1 },
+        "surfaceLabel": { "type": "string", "minLength": 1 },
+        "mode": { "type": ["string", "null"] },
+        "label": { "type": ["string", "null"] },
+        "reportHtmlRelativePath": { "type": ["string", "null"] },
+        "baseImageRelativePath": { "type": "string", "minLength": 1 },
+        "headImageRelativePath": { "type": "string", "minLength": 1 },
+        "baseByteLength": { "type": "integer", "minimum": 0 },
+        "headByteLength": { "type": "integer", "minimum": 0 },
+        "baseImageSha256": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "headImageSha256": {
+          "type": ["string", "null"],
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "sortKey": { "type": ["string", "null"] }
+      }
+    },
+    "previewCard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetId",
+        "targetPath",
+        "comparison",
+        "surfaces"
+      ],
+      "properties": {
+        "targetId": { "type": "string", "minLength": 1 },
+        "targetPath": { "type": "string", "minLength": 1 },
+        "comparison": { "$ref": "#/$defs/comparison" },
+        "sortKey": { "type": ["string", "null"] },
+        "surfaces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/previewSurface" }
+        }
       }
     },
     "target": {

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -320,6 +320,156 @@ function Get-ReviewerPreviewSubtitle {
   return 'History pair {0}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $PreviewPair)
 }
 
+function Get-ReviewerPreviewSurfaceKind {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  switch ([string]$PreviewPair.mode) {
+    'front-panel' { return 'front-panel' }
+    'block-diagram' { return 'block-diagram' }
+    default { return $null }
+  }
+}
+
+function Get-ReviewerPreviewSurfaceLabel {
+  param(
+    [AllowNull()][string]$SurfaceKind,
+    [AllowNull()][string]$FallbackLabel
+  )
+
+  switch ($SurfaceKind) {
+    'front-panel' { return 'Front panel' }
+    'block-diagram' { return 'Block diagram' }
+    default {
+      if (-not [string]::IsNullOrWhiteSpace($FallbackLabel)) {
+        return $FallbackLabel
+      }
+
+      return 'Preview'
+    }
+  }
+}
+
+function Get-ReviewerPreviewCardKey {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  return '{0}|{1}' -f `
+    [string]$PreviewPair.targetId, `
+    [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+}
+
+function New-ReviewerPreviewManifestSurface {
+  param([Parameter(Mandatory = $true)][object]$PreviewPair)
+
+  $surfaceKind = Get-ReviewerPreviewSurfaceKind -PreviewPair $PreviewPair
+  if ([string]::IsNullOrWhiteSpace($surfaceKind)) {
+    $surfaceKind = 'preview'
+  }
+
+  return [ordered]@{
+    surfaceKind = $surfaceKind
+    surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel ([string]$PreviewPair.label)
+    mode = Get-OptionalString -Value $PreviewPair.mode
+    label = [string]$PreviewPair.label
+    reportHtmlRelativePath = Get-OptionalString -Value $PreviewPair.reportHtmlRelativePath
+    baseImageRelativePath = [string]$PreviewPair.baseImageRelativePath
+    headImageRelativePath = [string]$PreviewPair.headImageRelativePath
+  }
+}
+
+function New-ReviewerPreviewCards {
+  param(
+    [AllowEmptyCollection()][object[]]$SelectedPreviewPairs = @(),
+    [AllowEmptyCollection()][object[]]$AllPreviewPairs = @(),
+    [AllowEmptyCollection()][object[]]$ExistingCards = @()
+  )
+
+  if ($ExistingCards.Count -gt 0) {
+    return @(
+      ConvertTo-ObjectArray -Value $ExistingCards |
+        Sort-Object {
+          $comparisonIndex = [int](Get-NestedValue -Object $_ -Path @('comparison', 'index') -Default 0)
+          '{0}|{1:D4}' -f [string]$_.targetPath, $comparisonIndex
+        }
+    )
+  }
+
+  $orderedAllPreviewPairs = @(
+    ConvertTo-ObjectArray -Value $AllPreviewPairs |
+      Sort-Object {
+        $sortKey = Get-OptionalString -Value $_.sortKey
+        if ([string]::IsNullOrWhiteSpace($sortKey)) {
+          [string]$_.label
+        } else {
+          $sortKey
+        }
+      }
+  )
+  if ($orderedAllPreviewPairs.Count -eq 0) {
+    $orderedAllPreviewPairs = @(
+      ConvertTo-ObjectArray -Value $SelectedPreviewPairs |
+        Sort-Object {
+          $sortKey = Get-OptionalString -Value $_.sortKey
+          if ([string]::IsNullOrWhiteSpace($sortKey)) {
+            [string]$_.label
+          } else {
+            $sortKey
+          }
+        }
+    )
+  }
+
+  $cards = New-Object System.Collections.Generic.List[object]
+  $seenCards = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($selectedPreviewPair in @(
+      ConvertTo-ObjectArray -Value $SelectedPreviewPairs |
+        Sort-Object {
+          $sortKey = Get-OptionalString -Value $_.sortKey
+          if ([string]::IsNullOrWhiteSpace($sortKey)) {
+            [string]$_.label
+          } else {
+            $sortKey
+          }
+        }
+    )) {
+    $cardKey = Get-ReviewerPreviewCardKey -PreviewPair $selectedPreviewPair
+    if (-not $seenCards.Add($cardKey)) {
+      continue
+    }
+
+    $matchingPairs = @(
+      $orderedAllPreviewPairs |
+        Where-Object { (Get-ReviewerPreviewCardKey -PreviewPair $_) -eq $cardKey }
+    )
+    if ($matchingPairs.Count -eq 0) {
+      $matchingPairs = @($selectedPreviewPair)
+    }
+
+    $surfaces = New-Object System.Collections.Generic.List[object]
+    $seenSurfaces = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($matchingPair in $matchingPairs) {
+      $surface = New-ReviewerPreviewManifestSurface -PreviewPair $matchingPair
+      if (-not $seenSurfaces.Add([string]$surface.surfaceKind)) {
+        continue
+      }
+
+      $surfaces.Add($surface) | Out-Null
+    }
+
+    if ($surfaces.Count -eq 0) {
+      $surfaces.Add((New-ReviewerPreviewManifestSurface -PreviewPair $selectedPreviewPair)) | Out-Null
+    }
+
+    $cards.Add([ordered]@{
+        targetId = [string]$selectedPreviewPair.targetId
+        targetPath = [string]$selectedPreviewPair.targetPath
+        comparison = $selectedPreviewPair.comparison
+        surfaces = @($surfaces | ForEach-Object { $_ })
+      }) | Out-Null
+  }
+
+  return @($cards | ForEach-Object { $_ })
+}
+
 function ConvertTo-GitHubContentPath {
   param([Parameter(Mandatory = $true)][string]$Path)
 
@@ -450,33 +600,28 @@ function ConvertTo-BlobGitHubUrl {
 function New-CommentPreviewMarkdown {
   param(
     [Parameter(Mandatory = $true)]
-    [object[]]$PreviewPairs,
+    [object[]]$PreviewCards,
     [AllowNull()]
     [string]$RunUrl
   )
 
-  if ($PreviewPairs.Count -eq 0) {
+  if ($PreviewCards.Count -eq 0) {
     return ''
   }
 
   $lines = New-Object System.Collections.Generic.List[string]
   $lines.Add('### Preview gallery') | Out-Null
   $lines.Add('') | Out-Null
-  foreach ($previewPair in $PreviewPairs) {
-    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
-    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
-    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
-    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
+  foreach ($previewCard in $PreviewCards) {
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewCard
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewCard
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewCard
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewCard)
     $detailHtml = if ($detailLines.Count -eq 0) {
       ''
     } else {
       '<div class="comparevi-preview-history">' + (($detailLines | ForEach-Object { '<p>' + (ConvertTo-HtmlText $_) + '</p>' }) -join '') + '</div>'
     }
-    $baseUrl = [string]$previewPair.baseImageUrl
-    $headUrl = [string]$previewPair.headImageUrl
-    $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
-    $baseAlt = '{0} base' -f $subtitle
-    $headAlt = '{0} head' -f $subtitle
     $lines.Add(('<h4><code>{0}</code></h4>' -f (ConvertTo-HtmlText $title))) | Out-Null
     $lines.Add(('<p>{0}</p>' -f (ConvertTo-HtmlText $subtitle))) | Out-Null
     if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
@@ -485,14 +630,23 @@ function New-CommentPreviewMarkdown {
     if (-not [string]::IsNullOrWhiteSpace($detailHtml)) {
       $lines.Add($detailHtml) | Out-Null
     }
-    $lines.Add('') | Out-Null
-    $lines.Add('<table>') | Out-Null
-    $lines.Add('<thead><tr><th>Base</th><th>Head</th></tr></thead>') | Out-Null
-    $lines.Add('<tbody><tr>') | Out-Null
-    $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $baseAlt), (ConvertTo-HtmlText $baseUrl))) | Out-Null
-    $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $headAlt), (ConvertTo-HtmlText $headUrl))) | Out-Null
-    $lines.Add('</tr></tbody>') | Out-Null
-    $lines.Add('</table>') | Out-Null
+    foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
+      $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+      $baseUrl = [string]$surface.baseImageUrl
+      $headUrl = [string]$surface.headImageUrl
+      $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
+      $baseAlt = '{0} base' -f $surfaceLabel
+      $headAlt = '{0} head' -f $surfaceLabel
+      $lines.Add('') | Out-Null
+      $lines.Add(('<p><strong>{0}</strong></p>' -f (ConvertTo-HtmlText $surfaceLabel))) | Out-Null
+      $lines.Add('<table>') | Out-Null
+      $lines.Add('<thead><tr><th>Base</th><th>Head</th></tr></thead>') | Out-Null
+      $lines.Add('<tbody><tr>') | Out-Null
+      $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $baseAlt), (ConvertTo-HtmlText $baseUrl))) | Out-Null
+      $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $headAlt), (ConvertTo-HtmlText $headUrl))) | Out-Null
+      $lines.Add('</tr></tbody>') | Out-Null
+      $lines.Add('</table>') | Out-Null
+    }
     if (-not [string]::IsNullOrWhiteSpace($RunUrl)) {
       $lines.Add(('<p><a href="{0}">workflow run</a></p>' -f (ConvertTo-HtmlText $RunUrl))) | Out-Null
     }
@@ -541,8 +695,11 @@ function Publish-CommentPreviewSurface {
   Ensure-PreviewBranch -RepositorySlug $RepositorySlug -BranchName $BranchName | Out-Null
 
   $prNumber = [int](Get-OptionalString -Value (Get-NestedValue -Object $PreviewManifest -Path @('pullRequest', 'number') -Default 0))
-  $previewPairs = @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $PreviewManifest -Path @('commentPreviewPairs') -Default @()))
-  if ($previewPairs.Count -eq 0) {
+  $previewCards = @(New-ReviewerPreviewCards `
+      -SelectedPreviewPairs @($PreviewManifest.commentPreviewPairs | ForEach-Object { $_ }) `
+      -AllPreviewPairs @($PreviewManifest.previewPairs | ForEach-Object { $_ }) `
+      -ExistingCards @($PreviewManifest.commentPreviewCards | ForEach-Object { $_ }))
+  if ($previewCards.Count -eq 0) {
     return [ordered]@{
       status = 'not-required'
       reason = 'no-comment-preview-pairs'
@@ -552,52 +709,87 @@ function Publish-CommentPreviewSurface {
       manifestUrl = $null
       previewPairCount = 0
       publishedImageCount = 0
+      publishedSurfaceCount = 0
+      commentPreviewCards = @()
       commentPreviewPairs = @()
     }
   }
 
   $runRoot = '{0}/pull-request-{1}/workflow-run-{2}' -f $RootPath.TrimEnd('/'), ('{0:D5}' -f $prNumber), $ExecutionRunId
+  $publishedPreviewCards = New-Object System.Collections.Generic.List[object]
   $publishedPreviewPairs = New-Object System.Collections.Generic.List[object]
   $publishedImageCount = 0
-  $pairOrdinal = 1
-  foreach ($previewPair in $previewPairs) {
-    $pairRoot = '{0}/{1}-{2}' -f $runRoot, ('{0:D3}' -f $pairOrdinal), (ConvertTo-Slug -Value ([string]$previewPair.label) -Fallback 'preview')
-    $baseRelativePath = [string]$previewPair.baseImageRelativePath
-    $headRelativePath = [string]$previewPair.headImageRelativePath
-    $baseImagePath = Join-Path $ArtifactRoot ($baseRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    $headImagePath = Join-Path $ArtifactRoot ($headRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-    if (-not (Test-Path -LiteralPath $baseImagePath -PathType Leaf)) {
-      throw "Preview base image was missing from the downloaded artifact: $baseRelativePath"
-    }
-    if (-not (Test-Path -LiteralPath $headImagePath -PathType Leaf)) {
-      throw "Preview head image was missing from the downloaded artifact: $headRelativePath"
-    }
+  $publishedSurfaceCount = 0
+  $cardOrdinal = 1
+  foreach ($previewCard in $previewCards) {
+    $cardRoot = '{0}/{1}-{2}' -f $runRoot, ('{0:D3}' -f $cardOrdinal), ('history-pair-' + ('{0:D2}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $previewCard)))
+    $publishedSurfaces = New-Object System.Collections.Generic.List[object]
+    $surfaceOrdinal = 1
+    foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
+      $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+      $surfaceSlug = ConvertTo-Slug -Value (Get-OptionalString -Value $surface.surfaceKind) -Fallback ('surface-' + ('{0:D2}' -f $surfaceOrdinal))
+      $surfaceRoot = '{0}/{1}-{2}' -f $cardRoot, ('{0:D2}' -f $surfaceOrdinal), $surfaceSlug
+      $baseRelativePath = [string]$surface.baseImageRelativePath
+      $headRelativePath = [string]$surface.headImageRelativePath
+      $baseImagePath = Join-Path $ArtifactRoot ($baseRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+      $headImagePath = Join-Path $ArtifactRoot ($headRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+      if (-not (Test-Path -LiteralPath $baseImagePath -PathType Leaf)) {
+        throw "Preview base image was missing from the downloaded artifact: $baseRelativePath"
+      }
+      if (-not (Test-Path -LiteralPath $headImagePath -PathType Leaf)) {
+        throw "Preview head image was missing from the downloaded artifact: $headRelativePath"
+      }
 
-    $baseExtension = [System.IO.Path]::GetExtension($baseImagePath)
-    $headExtension = [System.IO.Path]::GetExtension($headImagePath)
-    $basePublishPath = '{0}/base{1}' -f $pairRoot, $baseExtension
-    $headPublishPath = '{0}/head{1}' -f $pairRoot, $headExtension
+      $baseExtension = [System.IO.Path]::GetExtension($baseImagePath)
+      $headExtension = [System.IO.Path]::GetExtension($headImagePath)
+      $basePublishPath = '{0}/base{1}' -f $surfaceRoot, $baseExtension
+      $headPublishPath = '{0}/head{1}' -f $surfaceRoot, $headExtension
 
-    $messageBase = 'comparevi-history: publish PR preview images for run {0}' -f $ExecutionRunId
-    Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath -Bytes ([System.IO.File]::ReadAllBytes($baseImagePath)) -Message $messageBase | Out-Null
-    Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $headPublishPath -Bytes ([System.IO.File]::ReadAllBytes($headImagePath)) -Message $messageBase | Out-Null
-    $publishedImageCount += 2
+      $messageBase = 'comparevi-history: publish PR preview images for run {0}' -f $ExecutionRunId
+      Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath -Bytes ([System.IO.File]::ReadAllBytes($baseImagePath)) -Message $messageBase | Out-Null
+      Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $headPublishPath -Bytes ([System.IO.File]::ReadAllBytes($headImagePath)) -Message $messageBase | Out-Null
+      $publishedImageCount += 2
+      $publishedSurfaceCount += 1
 
-    $publishedPreviewPairs.Add([ordered]@{
-        targetId = [string]$previewPair.targetId
-        targetPath = [string]$previewPair.targetPath
-        mode = [string]$previewPair.mode
-        label = [string]$previewPair.label
-        sectionKind = [string]$previewPair.sectionKind
-        comparison = $previewPair.comparison
-        reportHtmlRelativePath = Get-OptionalString -Value $previewPair.reportHtmlRelativePath
+      $publishedSurface = [ordered]@{
+        surfaceKind = Get-OptionalString -Value $surface.surfaceKind
+        surfaceLabel = $surfaceLabel
+        reportHtmlRelativePath = Get-OptionalString -Value $surface.reportHtmlRelativePath
         baseImagePath = $basePublishPath
         baseImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath
         headImagePath = $headPublishPath
         headImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $headPublishPath
-      }) | Out-Null
+      }
+      $publishedSurfaces.Add($publishedSurface) | Out-Null
+      $surfaceOrdinal += 1
+    }
 
-    $pairOrdinal += 1
+    $publishedCard = [ordered]@{
+      targetId = [string]$previewCard.targetId
+      targetPath = [string]$previewCard.targetPath
+      comparison = $previewCard.comparison
+      surfaces = @($publishedSurfaces | ForEach-Object { $_ })
+    }
+    $publishedPreviewCards.Add($publishedCard) | Out-Null
+
+    $representativeSurface = @($publishedSurfaces | Select-Object -First 1)
+    if ($null -ne $representativeSurface) {
+      $publishedPreviewPairs.Add([ordered]@{
+          targetId = [string]$previewCard.targetId
+          targetPath = [string]$previewCard.targetPath
+          mode = Get-OptionalString -Value $representativeSurface.surfaceKind
+          label = Get-OptionalString -Value $representativeSurface.surfaceLabel
+          sectionKind = 'overview'
+          comparison = $previewCard.comparison
+          reportHtmlRelativePath = Get-OptionalString -Value $representativeSurface.reportHtmlRelativePath
+          baseImagePath = [string]$representativeSurface.baseImagePath
+          baseImageUrl = [string]$representativeSurface.baseImageUrl
+          headImagePath = [string]$representativeSurface.headImagePath
+          headImageUrl = [string]$representativeSurface.headImageUrl
+        }) | Out-Null
+    }
+
+    $cardOrdinal += 1
   }
 
   $publishedManifestPath = "$runRoot/preview-manifest.json"
@@ -607,6 +799,7 @@ function Publish-CommentPreviewSurface {
     repository = $RepositorySlug
     branch = $BranchName
     root = $runRoot
+    previewCards = @($publishedPreviewCards | ForEach-Object { $_ })
     previewPairs = @($publishedPreviewPairs | ForEach-Object { $_ })
   }
   $publishedManifestBytes = [System.Text.Encoding]::UTF8.GetBytes(($publishedManifest | ConvertTo-Json -Depth 32))
@@ -619,8 +812,10 @@ function Publish-CommentPreviewSurface {
     root = $runRoot
     manifestPath = $publishedManifestPath
     manifestUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $publishedManifestPath
-    previewPairCount = $publishedPreviewPairs.Count
+    previewPairCount = $publishedPreviewCards.Count
     publishedImageCount = $publishedImageCount
+    publishedSurfaceCount = $publishedSurfaceCount
+    commentPreviewCards = @($publishedPreviewCards | ForEach-Object { $_ })
     commentPreviewPairs = @($publishedPreviewPairs | ForEach-Object { $_ })
   }
 }
@@ -689,6 +884,8 @@ $previewPublication = [ordered]@{
   manifestUrl = $null
   previewPairCount = 0
   publishedImageCount = 0
+  publishedSurfaceCount = 0
+  commentPreviewCards = @()
   commentPreviewPairs = @()
 }
 
@@ -740,7 +937,7 @@ try {
       $previewManifest | Add-Member -NotePropertyName pullRequest -NotePropertyValue $prRun.pullRequest -Force
       if ([int](Get-NestedValue -Object $previewManifest -Path @('summary', 'commentPreviewPairCount') -Default 0) -gt 0) {
         $previewPublication = Publish-CommentPreviewSurface -RepositorySlug $Repository -BranchName $PreviewBranch -RootPath $PreviewRoot -ExecutionRunId $WorkflowRunId -ArtifactRoot $artifactRoot -PreviewManifest $previewManifest
-        $previewMarkdown = New-CommentPreviewMarkdown -PreviewPairs @($previewPublication.commentPreviewPairs | ForEach-Object { $_ }) -RunUrl $workflowRunUrl
+        $previewMarkdown = New-CommentPreviewMarkdown -PreviewCards @($previewPublication.commentPreviewCards | ForEach-Object { $_ }) -RunUrl $workflowRunUrl
         $commentBody = Insert-PreviewGallery -CommentBody $commentBody -PreviewMarkdown $previewMarkdown
         $commentBody | Set-Content -LiteralPath $commentBodyPath -Encoding utf8
       } else {
@@ -753,6 +950,8 @@ try {
         manifestUrl = $null
         previewPairCount = 0
         publishedImageCount = 0
+        publishedSurfaceCount = 0
+        commentPreviewCards = @()
         commentPreviewPairs = @()
       }
     }
@@ -829,6 +1028,7 @@ Write-ActionOutput -Key 'preview-publication-reason' -Value ([string]$previewPub
 Write-ActionOutput -Key 'preview-manifest-url' -Value $(if ([string]::IsNullOrWhiteSpace([string]$previewPublication.manifestUrl)) { '' } else { [string]$previewPublication.manifestUrl })
 Write-ActionOutput -Key 'preview-pair-count' -Value ([string]$previewPublication.previewPairCount)
 Write-ActionOutput -Key 'published-image-count' -Value ([string]$previewPublication.publishedImageCount)
+Write-ActionOutput -Key 'published-surface-count' -Value ([string](Get-NestedValue -Object $previewPublication -Path @('publishedSurfaceCount') -Default 0))
 
 if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
   @(
@@ -845,6 +1045,7 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ('- Preview publication reason: `{0}`' -f [string]$previewPublication.reason)
     ('- Preview publication manifest: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$previewPublication.manifestUrl)) { 'n/a' } else { [string]$previewPublication.manifestUrl }))
     ('- Published preview pairs: `{0}`' -f [string]$previewPublication.previewPairCount)
+    ('- Published preview surfaces: `{0}`' -f [string](Get-NestedValue -Object $previewPublication -Path @('publishedSurfaceCount') -Default 0))
     ('- Published preview images: `{0}`' -f [string]$previewPublication.publishedImageCount)
     ('- Receipt: `{0}`' -f $receiptPath)
   ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -455,13 +455,21 @@ try {
     $indexMarkdown -notmatch [regex]::Escape('`base-02 -> head-02`')) {
     throw 'Index markdown should surface stable history-pair subtitles and revision refs.'
   }
+  if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Front panel')).Count -ne 2 -or
+    [regex]::Matches($indexMarkdown, [regex]::Escape('#### Block diagram')).Count -ne 2) {
+    throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
+  }
 
   $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
   )
-  if (-not ($markdownPositions[0] -lt $markdownPositions[1])) {
-    throw 'Index markdown should preserve the reviewer-canonical comparison ordering.'
+  if (-not ($markdownPositions[0] -lt $markdownPositions[1] -and
+      $markdownPositions[1] -lt $markdownPositions[2] -and
+      $markdownPositions[2] -lt $markdownPositions[3])) {
+    throw 'Index markdown should preserve history-pair ordering while surfacing both front-panel and block-diagram previews.'
   }
 
   $indexHtml = Get-Content -LiteralPath $receipt.outputs.indexHtmlPath -Raw
@@ -481,13 +489,21 @@ try {
     $indexHtml -notmatch [regex]::Escape('base-02 -&gt; head-02')) {
     throw 'Index HTML should surface stable history-pair subtitles and revision refs.'
   }
+  if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Front panel</h4>')).Count -ne 2 -or
+    [regex]::Matches($indexHtml, [regex]::Escape('<h4>Block diagram</h4>')).Count -ne 2) {
+    throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
+  }
 
   $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
   )
-  if (-not ($htmlPositions[0] -lt $htmlPositions[1])) {
-    throw 'Index HTML should preserve the reviewer-canonical comparison ordering.'
+  if (-not ($htmlPositions[0] -lt $htmlPositions[1] -and
+      $htmlPositions[1] -lt $htmlPositions[2] -and
+      $htmlPositions[2] -lt $htmlPositions[3])) {
+    throw 'Index HTML should preserve history-pair ordering while surfacing both front-panel and block-diagram previews.'
   }
 
   $previewManifest = Get-Content -LiteralPath $receipt.outputs.previewManifestPath -Raw | ConvertFrom-Json -Depth 64
@@ -495,8 +511,16 @@ try {
     $previewManifest.summary.rawPreviewPairCount -ne 6 -or
     $previewManifest.summary.reviewerPreviewPairCount -ne 2 -or
     $previewManifest.summary.commentPreviewPairCount -ne 2 -or
-    $previewManifest.summary.indexPreviewPairCount -ne 2) {
+    $previewManifest.summary.indexPreviewPairCount -ne 2 -or
+    $previewManifest.summary.commentPreviewCardCount -ne 2 -or
+    $previewManifest.summary.commentPreviewSurfaceCount -ne 4 -or
+    $previewManifest.summary.indexPreviewCardCount -ne 2 -or
+    $previewManifest.summary.indexPreviewSurfaceCount -ne 4) {
     throw 'Preview manifest summary mismatch.'
+  }
+  if ($previewManifest.indexPreviewCards.Count -ne 2 -or
+    (@($previewManifest.indexPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
+    throw 'Preview manifest should expose reviewer cards with both front-panel and block-diagram surfaces.'
   }
 
   $stepSummary = Get-Content -LiteralPath $receipt.outputs.publicStepSummaryPath -Raw

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -38,6 +38,45 @@ function New-PreviewPair {
   }
 }
 
+function New-PreviewCard {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$PreviewPairs,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex
+  )
+
+  $matchingPairs = @(
+    $PreviewPairs |
+      Where-Object { [int]$_.comparison.index -eq $ComparisonIndex -and [string]$_.mode -in @('front-panel', 'block-diagram') } |
+      Sort-Object {
+        switch ([string]$_.mode) {
+          'front-panel' { 0 }
+          'block-diagram' { 1 }
+          default { 99 }
+        }
+      }
+  )
+
+  return [ordered]@{
+    targetId = 'dynamic-demo-target'
+    targetPath = 'Tooling/demo/Demo.vi'
+    comparison = $matchingPairs[0].comparison
+    surfaces = @(
+      $matchingPairs |
+        ForEach-Object {
+          [ordered]@{
+            surfaceKind = [string]$_.mode
+            surfaceLabel = if ([string]$_.mode -eq 'front-panel') { 'Front panel' } else { 'Block diagram' }
+            reportHtmlRelativePath = [string]$_.reportHtmlRelativePath
+            baseImageRelativePath = [string]$_.baseImageRelativePath
+            headImageRelativePath = [string]$_.headImageRelativePath
+          }
+        }
+    )
+  }
+}
+
 function New-PublicationArtifactZip {
   param(
     [Parameter(Mandatory = $true)]
@@ -64,6 +103,10 @@ function New-PublicationArtifactZip {
     (New-PreviewPair -Mode 'attributes' -ComparisonIndex 2)
   )
   $commentPreviewPairs = @($previewPairs | Select-Object -First 4)
+  $commentPreviewCards = @(
+    (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 1),
+    (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 2)
+  )
 
   ([ordered]@{
       schema = 'comparevi-history/pr-run@v2'
@@ -133,12 +176,20 @@ function New-PublicationArtifactZip {
         previewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
         rawPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
         reviewerPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        reviewerPreviewCardCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        reviewerPreviewSurfaceCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
         commentPreviewPairCap = 4
         commentPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         commentPreviewPairOmittedCount = 0
+        commentPreviewCardCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        commentPreviewSurfaceCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
+        commentCardSelectionPolicy = 'reviewer-multisurface@v1'
         indexPreviewPairCap = 12
         indexPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         indexPreviewPairOmittedCount = 0
+        indexPreviewCardCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
+        indexPreviewSurfaceCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
+        indexCardSelectionPolicy = 'reviewer-multisurface@v1'
       }
       excludedViFiles = @()
       targets = @()
@@ -164,14 +215,22 @@ function New-PublicationArtifactZip {
           previewPairCount = 6
           rawPreviewPairCount = 6
           reviewerPreviewPairCount = 2
+          reviewerPreviewCardCount = 2
+          reviewerPreviewSurfaceCount = 4
           commentPreviewPairCap = 4
           commentSelectionPolicy = 'reviewer-canonical@v1'
           commentPreviewPairCount = 2
           commentPreviewPairOmittedCount = 0
+          commentPreviewCardCount = 2
+          commentPreviewSurfaceCount = 4
+          commentCardSelectionPolicy = 'reviewer-multisurface@v1'
           indexPreviewPairCap = 12
           indexSelectionPolicy = 'reviewer-canonical@v1'
           indexPreviewPairCount = 2
           indexPreviewPairOmittedCount = 0
+          indexPreviewCardCount = 2
+          indexPreviewSurfaceCount = 4
+          indexCardSelectionPolicy = 'reviewer-multisurface@v1'
         }
         targets = @(
           [ordered]@{
@@ -186,6 +245,9 @@ function New-PublicationArtifactZip {
         previewPairs = $previewPairs
         commentPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
         indexPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
+        reviewerPreviewCards = $commentPreviewCards
+        commentPreviewCards = $commentPreviewCards
+        indexPreviewCards = $commentPreviewCards
       } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-preview-manifest.json') -Encoding utf8
   }
 
@@ -353,7 +415,9 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([string]$createReceipt.previewPublication.status -ne 'succeeded') {
     throw 'Expected preview publication to succeed for the first path.'
   }
-  if ([int]$createReceipt.previewPublication.previewPairCount -ne 2 -or [int]$createReceipt.previewPublication.publishedImageCount -ne 4) {
+  if ([int]$createReceipt.previewPublication.previewPairCount -ne 2 -or
+    [int]$createReceipt.previewPublication.publishedSurfaceCount -ne 4 -or
+    [int]$createReceipt.previewPublication.publishedImageCount -ne 8) {
     throw 'Preview publication counts mismatch for the first path.'
   }
   if ($global:RecordedPosts.Count -ne 1) {
@@ -374,9 +438,13 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('Head subject 1')) {
     throw 'Created PR comment body should surface revision refs and commit-subject context.'
   }
-  if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 2 -or
-    [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 2) {
-    throw 'Created PR comment body should embed four preview image URLs.'
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Front panel</strong></p>')).Count -ne 2 -or
+    [regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Block diagram</strong></p>')).Count -ne 2) {
+    throw 'Created PR comment body should render both front-panel and block-diagram surfaces for each history pair.'
+  }
+  if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
+    [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
+    throw 'Created PR comment body should embed eight preview image URLs.'
   }
   if ($global:RecordedPosts[0].body -match [regex]::Escape('| front-panel |') -or
     $global:RecordedPosts[0].body -match [regex]::Escape('| block-diagram |') -or
@@ -387,8 +455,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'
   }
-  if ($global:RecordedContentWrites.Count -ne 5) {
-    throw 'Expected preview publication to write four images and one manifest.'
+  if ($global:RecordedContentWrites.Count -ne 9) {
+    throw 'Expected preview publication to write eight images and one manifest.'
   }
 
   $publishedPairOrder = @(
@@ -398,18 +466,26 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($publishedPairOrder -ne 'front-panel:1,front-panel:2') {
     throw "Preview publication order mismatch: $publishedPairOrder"
   }
+  if ($createReceipt.previewPublication.commentPreviewCards.Count -ne 2 -or
+    (@($createReceipt.previewPublication.commentPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
+    throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
+  }
 
   $writeOrder = @(
     $global:RecordedContentWrites |
       ForEach-Object { [string]$_.path }
   )
   $expectedImagePrefixes = @(
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-front-panel-overview/head.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-front-panel-overview/head.png'
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/base.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/head.png'
   )
-  foreach ($index in 0..3) {
+  foreach ($index in 0..7) {
     if ([string]$writeOrder[$index] -ne $expectedImagePrefixes[$index]) {
       throw "Published preview write order mismatch at position $index."
     }
@@ -425,7 +501,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
       'preview-publication-status=succeeded',
       'preview-publication-reason=preview-images-published',
       'preview-pair-count=2',
-      'published-image-count=4'
+      'published-image-count=8',
+      'published-surface-count=4'
     )) {
     if ($createOutputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -134,14 +134,28 @@ try {
   if ($receipt.summary.rawPreviewPairCount -ne 6 -or $receipt.summary.reviewerPreviewPairCount -ne 2) {
     throw 'Expected explicit raw and reviewer preview pair counts in the preview manifest summary.'
   }
+  if ($receipt.summary.reviewerPreviewCardCount -ne 2 -or
+    $receipt.summary.reviewerPreviewSurfaceCount -ne 4) {
+    throw 'Expected reviewer preview card and surface counts in the preview manifest summary.'
+  }
   if ($receipt.summary.commentSelectionPolicy -ne 'reviewer-canonical@v1' -or $receipt.summary.indexSelectionPolicy -ne 'reviewer-canonical@v1') {
     throw 'Expected explicit reviewer-canonical selection policies in the preview manifest summary.'
   }
   if ($receipt.summary.commentPreviewPairCount -ne 2 -or $receipt.summary.commentPreviewPairOmittedCount -ne 0) {
     throw 'Comment preview pair selection mismatch.'
   }
+  if ($receipt.summary.commentPreviewCardCount -ne 2 -or
+    $receipt.summary.commentPreviewSurfaceCount -ne 4 -or
+    $receipt.summary.commentCardSelectionPolicy -ne 'reviewer-multisurface@v1') {
+    throw 'Comment preview card summary mismatch.'
+  }
   if ($receipt.summary.indexPreviewPairCount -ne 2 -or $receipt.summary.indexPreviewPairOmittedCount -ne 0) {
     throw 'Index preview pair selection mismatch.'
+  }
+  if ($receipt.summary.indexPreviewCardCount -ne 2 -or
+    $receipt.summary.indexPreviewSurfaceCount -ne 4 -or
+    $receipt.summary.indexCardSelectionPolicy -ne 'reviewer-multisurface@v1') {
+    throw 'Index preview card summary mismatch.'
   }
   if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 6) {
     throw 'Target preview pair count mismatch.'
@@ -177,6 +191,24 @@ try {
     $null -ne $receipt.commentPreviewPairs[0].comparison.headSubject) {
     throw 'Preview manifest fixture without a repository root should not invent commit subjects.'
   }
+  if ($receipt.commentPreviewCards.Count -ne 2 -or $receipt.indexPreviewCards.Count -ne 2) {
+    throw 'Expected reviewer preview cards for both comment and index surfaces.'
+  }
+  $commentCardSurfaceSummary = @(
+    $receipt.commentPreviewCards[0].surfaces |
+      ForEach-Object { [string]$_.surfaceKind }
+  ) -join ','
+  if ($commentCardSurfaceSummary -ne 'front-panel,block-diagram') {
+    throw "Expected the first reviewer card to surface both front-panel and block-diagram images. Actual: $commentCardSurfaceSummary"
+  }
+  if ($receipt.commentPreviewCards[0].surfaces[0].surfaceLabel -ne 'Front panel' -or
+    $receipt.commentPreviewCards[0].surfaces[1].surfaceLabel -ne 'Block diagram') {
+    throw 'Reviewer cards should use reviewer-facing surface labels.'
+  }
+  if ($receipt.commentPreviewCards[0].surfaces[0].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png' -or
+    $receipt.commentPreviewCards[0].surfaces[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
+    throw 'Reviewer cards should preserve both front-panel and block-diagram image paths for the same history pair.'
+  }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw
   foreach ($requiredKey in @(
@@ -187,7 +219,13 @@ try {
       'comment-preview-pair-count=2',
       'comment-preview-pair-omitted-count=0',
       'index-preview-pair-count=2',
-      'index-preview-pair-omitted-count=0'
+      'index-preview-pair-omitted-count=0',
+      'reviewer-preview-card-count=2',
+      'reviewer-preview-surface-count=4',
+      'comment-preview-card-count=2',
+      'comment-preview-surface-count=4',
+      'index-preview-card-count=2',
+      'index-preview-surface-count=4'
     )) {
     if ($outputText -notmatch [regex]::Escape($requiredKey)) {
       throw "Expected GitHub output '$requiredKey'."

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -282,24 +282,151 @@ function ConvertTo-PreviewPairArray {
   )
 }
 
+function Get-ReviewerPreviewSurfaceLabel {
+  param(
+    [AllowNull()]
+    [string]$SurfaceKind,
+    [AllowNull()]
+    [string]$FallbackLabel
+  )
+
+  switch ($SurfaceKind) {
+    'front-panel' { return 'Front panel' }
+    'block-diagram' { return 'Block diagram' }
+    default {
+      if (-not [string]::IsNullOrWhiteSpace($FallbackLabel)) {
+        return $FallbackLabel
+      }
+
+      return 'Preview'
+    }
+  }
+}
+
+function New-ReviewerPreviewSurface {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  $surfaceKind = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('surfaceKind'))
+  if ([string]::IsNullOrWhiteSpace($surfaceKind)) {
+    switch ([string]$PreviewPair.mode) {
+      'front-panel' { $surfaceKind = 'front-panel' }
+      'block-diagram' { $surfaceKind = 'block-diagram' }
+      default { $surfaceKind = 'preview' }
+    }
+  }
+
+  return [ordered]@{
+    surfaceKind = $surfaceKind
+    surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel (Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('surfaceLabel') -Default $PreviewPair.label))
+    reportHtmlRelativePath = Get-OptionalString -Value $PreviewPair.reportHtmlRelativePath
+    baseImageRelativePath = Get-OptionalString -Value $PreviewPair.baseImageRelativePath
+    headImageRelativePath = Get-OptionalString -Value $PreviewPair.headImageRelativePath
+  }
+}
+
+function Get-ReviewerPreviewCardKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return '{0}|{1}' -f `
+    [string]$PreviewPair.targetId, `
+    [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+}
+
+function New-ReviewerPreviewCards {
+  param(
+    [AllowEmptyCollection()]
+    [object[]]$SelectedPreviewPairs = @(),
+    [AllowEmptyCollection()]
+    [object[]]$AllPreviewPairs = @(),
+    [AllowEmptyCollection()]
+    [object[]]$ExistingCards = @()
+  )
+
+  if ($ExistingCards.Count -gt 0) {
+    return @(
+      ConvertTo-ObjectArray -Value $ExistingCards |
+        Sort-Object {
+          $comparisonIndex = [int](Get-NestedValue -Object $_ -Path @('comparison', 'index') -Default 0)
+          '{0}|{1:D4}' -f [string]$_.targetPath, $comparisonIndex
+        }
+    )
+  }
+
+  $orderedAllPreviewPairs = @(ConvertTo-PreviewPairArray -Value $AllPreviewPairs)
+  if ($orderedAllPreviewPairs.Count -eq 0) {
+    $orderedAllPreviewPairs = @(ConvertTo-PreviewPairArray -Value $SelectedPreviewPairs)
+  }
+
+  $cards = New-Object System.Collections.Generic.List[object]
+  $seenCards = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($selectedPreviewPair in @(ConvertTo-PreviewPairArray -Value $SelectedPreviewPairs)) {
+    $cardKey = Get-ReviewerPreviewCardKey -PreviewPair $selectedPreviewPair
+    if (-not $seenCards.Add($cardKey)) {
+      continue
+    }
+
+    $matchingPairs = @(
+      $orderedAllPreviewPairs |
+        Where-Object { (Get-ReviewerPreviewCardKey -PreviewPair $_) -eq $cardKey }
+    )
+    if ($matchingPairs.Count -eq 0) {
+      $matchingPairs = @($selectedPreviewPair)
+    }
+
+    $surfaces = New-Object System.Collections.Generic.List[object]
+    $seenSurfaces = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($matchingPair in $matchingPairs) {
+      $surface = New-ReviewerPreviewSurface -PreviewPair $matchingPair
+      if ([string]::IsNullOrWhiteSpace([string]$surface.surfaceKind)) {
+        continue
+      }
+
+      if (-not $seenSurfaces.Add([string]$surface.surfaceKind)) {
+        continue
+      }
+
+      $surfaces.Add($surface) | Out-Null
+    }
+
+    if ($surfaces.Count -eq 0) {
+      $surfaces.Add((New-ReviewerPreviewSurface -PreviewPair $selectedPreviewPair)) | Out-Null
+    }
+
+    $cards.Add([ordered]@{
+        targetId = [string]$selectedPreviewPair.targetId
+        targetPath = [string]$selectedPreviewPair.targetPath
+        comparison = $selectedPreviewPair.comparison
+        surfaces = @($surfaces | ForEach-Object { $_ })
+      }) | Out-Null
+  }
+
+  return @($cards | ForEach-Object { $_ })
+}
+
 function New-MarkdownPreviewGallery {
   param(
     [AllowEmptyCollection()]
-    [object[]]$PreviewPairs
+    [object[]]$PreviewCards
   )
 
-  if ($PreviewPairs.Count -eq 0) {
+  if ($PreviewCards.Count -eq 0) {
     return ''
   }
 
   $lines = New-Object System.Collections.Generic.List[string]
   $lines.Add('## Preview gallery') | Out-Null
   $lines.Add('') | Out-Null
-  foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
-    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
-    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
-    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
-    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
+  foreach ($previewCard in @(ConvertTo-ObjectArray -Value $PreviewCards)) {
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewCard
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewCard
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewCard
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewCard)
     $lines.Add(('### `{0}`' -f $title)) | Out-Null
     $lines.Add('') | Out-Null
     $lines.Add($subtitle) | Out-Null
@@ -314,23 +441,28 @@ function New-MarkdownPreviewGallery {
     if ($detailLines.Count -gt 0) {
       $lines.Add('') | Out-Null
     }
-    $lines.Add('**Base**') | Out-Null
-    $lines.Add((
-        '![{0}]({1})' -f
-          ('{0} base' -f $subtitle),
-          [string]$previewPair.baseImageRelativePath
-      )) | Out-Null
-    $lines.Add('') | Out-Null
-    $lines.Add('**Head**') | Out-Null
-    $lines.Add((
-        '![{0}]({1})' -f
-          ('{0} head' -f $subtitle),
-          [string]$previewPair.headImageRelativePath
-      )) | Out-Null
-    if (-not [string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
-      $lines.Add(('- Report: [{0}]({0})' -f [string]$previewPair.reportHtmlRelativePath)) | Out-Null
+    foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
+      $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+      $lines.Add(('#### {0}' -f $surfaceLabel)) | Out-Null
+      $lines.Add('') | Out-Null
+      $lines.Add('**Base**') | Out-Null
+      $lines.Add((
+          '![{0}]({1})' -f
+            ('{0} base' -f $surfaceLabel),
+            [string]$surface.baseImageRelativePath
+        )) | Out-Null
+      $lines.Add('') | Out-Null
+      $lines.Add('**Head**') | Out-Null
+      $lines.Add((
+          '![{0}]({1})' -f
+            ('{0} head' -f $surfaceLabel),
+            [string]$surface.headImageRelativePath
+        )) | Out-Null
+      if (-not [string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
+        $lines.Add(('- Report: [{0}]({0})' -f [string]$surface.reportHtmlRelativePath)) | Out-Null
+      }
+      $lines.Add('') | Out-Null
     }
-    $lines.Add('') | Out-Null
   }
 
   return $lines -join "`n"
@@ -339,29 +471,49 @@ function New-MarkdownPreviewGallery {
 function New-HtmlPreviewGallery {
   param(
     [AllowEmptyCollection()]
-    [object[]]$PreviewPairs
+    [object[]]$PreviewCards
   )
 
-  if ($PreviewPairs.Count -eq 0) {
+  if ($PreviewCards.Count -eq 0) {
     return ''
   }
 
   $cards = New-Object System.Collections.Generic.List[string]
-  foreach ($previewPair in @(ConvertTo-ObjectArray -Value $PreviewPairs)) {
-    $title = Get-ReviewerPreviewTitle -PreviewPair $previewPair
-    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewPair
-    $comparisonIndex = Get-ReviewerPreviewComparisonIndex -PreviewPair $previewPair
-    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewPair
-    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewPair)
+  foreach ($previewCard in @(ConvertTo-ObjectArray -Value $PreviewCards)) {
+    $title = Get-ReviewerPreviewTitle -PreviewPair $previewCard
+    $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $previewCard
+    $comparisonIndex = Get-ReviewerPreviewComparisonIndex -PreviewPair $previewCard
+    $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $previewCard
+    $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $previewCard)
     $detailHtml = if ($detailLines.Count -eq 0) {
       ''
     } else {
       '<div class="preview-card-history">' + (($detailLines | ForEach-Object { '<p>' + (Escape-Html $_) + '</p>' }) -join '') + '</div>'
     }
-    $reportLink = if ([string]::IsNullOrWhiteSpace([string]$previewPair.reportHtmlRelativePath)) {
-      ''
-    } else {
-      '<p><a href="' + (Escape-Html ([string]$previewPair.reportHtmlRelativePath)) + '">open report</a></p>'
+    $surfaceBlocks = New-Object System.Collections.Generic.List[string]
+    foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
+      $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+      $reportLink = if ([string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
+        ''
+      } else {
+        '<p><a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">open ' + (Escape-Html $surfaceLabel.ToLowerInvariant()) + ' report</a></p>'
+      }
+      $surfaceBlocks.Add(@"
+  <section class="preview-surface">
+    <h4>$(Escape-Html $surfaceLabel)</h4>
+    <div class="preview-image-grid">
+      <figure>
+        <img alt="$(Escape-Html ($surfaceLabel + ' base'))" src="$(Escape-Html ([string]$surface.baseImageRelativePath))">
+        <figcaption>Base</figcaption>
+      </figure>
+      <figure>
+        <img alt="$(Escape-Html ($surfaceLabel + ' head'))" src="$(Escape-Html ([string]$surface.headImageRelativePath))">
+        <figcaption>Head</figcaption>
+      </figure>
+    </div>
+    $reportLink
+  </section>
+"@) | Out-Null
     }
     $cards.Add(@"
 <article class="preview-card">
@@ -372,17 +524,7 @@ function New-HtmlPreviewGallery {
     <strong>Revisions</strong><span><code>$(Escape-Html $revisionContext)</code></span>
   </div>
   $detailHtml
-  <div class="preview-image-grid">
-    <figure>
-      <img alt="$(Escape-Html ($subtitle + ' base'))" src="$(Escape-Html ([string]$previewPair.baseImageRelativePath))">
-      <figcaption>Base</figcaption>
-    </figure>
-    <figure>
-      <img alt="$(Escape-Html ($subtitle + ' head'))" src="$(Escape-Html ([string]$previewPair.headImageRelativePath))">
-      <figcaption>Head</figcaption>
-    </figure>
-  </div>
-  $reportLink
+  $($surfaceBlocks -join "`n  ")
 </article>
 "@) | Out-Null
   }
@@ -459,7 +601,7 @@ $indexPreviewPairCount = 0
 $indexPreviewPairOmittedCount = 0
 $commentPreviewPairCap = 0
 $indexPreviewPairCap = 0
-$indexPreviewPairs = @()
+$indexPreviewCards = @()
 $previewTargetPairCountById = @{}
 if ($null -ne $targetManifest) {
   $targets = @($targetManifest.targets | ForEach-Object { $_ })
@@ -491,7 +633,10 @@ if ($null -ne $targetManifest) {
   $indexPreviewPairCap = [int]$previewManifest.summary.indexPreviewPairCap
   $indexPreviewPairCount = [int]$previewManifest.summary.indexPreviewPairCount
   $indexPreviewPairOmittedCount = [int]$previewManifest.summary.indexPreviewPairOmittedCount
-  $indexPreviewPairs = @($previewManifest.indexPreviewPairs | ForEach-Object { $_ })
+  $indexPreviewCards = @(New-ReviewerPreviewCards `
+      -SelectedPreviewPairs @($previewManifest.indexPreviewPairs | ForEach-Object { $_ }) `
+      -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
+      -ExistingCards @($previewManifest.indexPreviewCards | ForEach-Object { $_ }))
   foreach ($previewTarget in @($previewManifest.targets | ForEach-Object { $_ })) {
     $previewTargetPairCountById[[string]$previewTarget.targetId] = [int]$previewTarget.previewPairCount
   }
@@ -601,7 +746,7 @@ if ($reviewerPreviewPairCount -gt 0) {
   }
 }
 $indexLines.Add('') | Out-Null
-$previewGalleryMarkdown = New-MarkdownPreviewGallery -PreviewPairs $indexPreviewPairs
+$previewGalleryMarkdown = New-MarkdownPreviewGallery -PreviewCards $indexPreviewCards
 if (-not [string]::IsNullOrWhiteSpace($previewGalleryMarkdown)) {
   $indexLines.Add($previewGalleryMarkdown) | Out-Null
   $indexLines.Add('') | Out-Null
@@ -684,6 +829,8 @@ $indexHtml = @"
     .preview-card { background: #ffffff; border: 1px solid #cbd5e1; padding: 1rem; }
     .preview-card-subtitle { color: #334155; margin-top: -0.35rem; margin-bottom: 1rem; }
     .preview-card-meta { display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 0.75rem; margin-bottom: 1rem; }
+    .preview-surface + .preview-surface { margin-top: 1rem; }
+    .preview-surface h4 { margin-bottom: 0.75rem; }
     .preview-image-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }
     .preview-image-grid figure { margin: 0; }
     .preview-image-grid img { max-width: 100%; height: auto; border: 1px solid #cbd5e1; background: #ffffff; }
@@ -703,7 +850,7 @@ $indexHtml = @"
     $(if ($reviewerPreviewPairCount -gt 0) { '<li>Reviewer preview gallery: <code>' + $indexPreviewPairCount + '</code> shown, <code>' + $indexPreviewPairOmittedCount + '</code> omitted, cap <code>' + $indexPreviewPairCap + '</code></li>' } else { '' })
     $(if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) { '<li>Raw preview surfaces collapsed for review: <code>' + $rawPreviewPairCount + '</code> raw -> <code>' + $reviewerPreviewPairCount + '</code> reviewer-canonical</li>' } else { '' })
   </ul>
-  $(New-HtmlPreviewGallery -PreviewPairs $indexPreviewPairs)
+  $(New-HtmlPreviewGallery -PreviewCards $indexPreviewCards)
   <table>
     <thead>
       <tr>

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -402,6 +402,40 @@ function Get-PreviewPairReviewerIdentityKey {
     $(if ([string]::IsNullOrWhiteSpace([string]$PreviewPair.headImageSha256)) { [string]$PreviewPair.headImageRelativePath } else { [string]$PreviewPair.headImageSha256 })
 }
 
+function Get-ReviewerPreviewSurfaceKind {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  switch ([string]$PreviewPair.mode) {
+    'front-panel' { return 'front-panel' }
+    'block-diagram' { return 'block-diagram' }
+    default { return $null }
+  }
+}
+
+function Get-ReviewerPreviewSurfaceLabel {
+  param(
+    [AllowNull()]
+    [string]$SurfaceKind,
+    [AllowNull()]
+    [string]$FallbackLabel
+  )
+
+  switch ($SurfaceKind) {
+    'front-panel' { return 'Front panel' }
+    'block-diagram' { return 'Block diagram' }
+    default {
+      if (-not [string]::IsNullOrWhiteSpace($FallbackLabel)) {
+        return $FallbackLabel
+      }
+
+      return 'Preview'
+    }
+  }
+}
+
 function Get-ReviewerPreviewPairArray {
   param(
     [AllowNull()]
@@ -437,6 +471,106 @@ function Select-PreviewPairs {
     Get-ReviewerPreviewPairArray -Value $PreviewPairs |
       Select-Object -First $Limit
   )
+}
+
+function Get-ReviewerPreviewCardKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return '{0}|{1}' -f `
+    [string]$PreviewPair.targetId, `
+    [int](Get-NestedValue -Object $PreviewPair -Path @('comparison', 'index') -Default 0)
+}
+
+function New-ReviewerPreviewSurface {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  $surfaceKind = Get-ReviewerPreviewSurfaceKind -PreviewPair $PreviewPair
+  if ([string]::IsNullOrWhiteSpace($surfaceKind)) {
+    $surfaceKind = 'preview'
+  }
+
+  return [ordered]@{
+    surfaceKind = $surfaceKind
+    surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel ([string]$PreviewPair.label)
+    mode = Get-OptionalString -Value $PreviewPair.mode
+    label = [string]$PreviewPair.label
+    reportHtmlRelativePath = Get-OptionalString -Value $PreviewPair.reportHtmlRelativePath
+    baseImageRelativePath = [string]$PreviewPair.baseImageRelativePath
+    headImageRelativePath = [string]$PreviewPair.headImageRelativePath
+    baseByteLength = [int64](Get-NestedValue -Object $PreviewPair -Path @('baseByteLength') -Default 0)
+    headByteLength = [int64](Get-NestedValue -Object $PreviewPair -Path @('headByteLength') -Default 0)
+    baseImageSha256 = Get-OptionalString -Value $PreviewPair.baseImageSha256
+    headImageSha256 = Get-OptionalString -Value $PreviewPair.headImageSha256
+    sortKey = Get-OptionalString -Value $PreviewPair.sortKey
+  }
+}
+
+function New-ReviewerPreviewCards {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$SelectedPreviewPairs,
+    [AllowEmptyCollection()]
+    [object[]]$AllPreviewPairs = @()
+  )
+
+  $orderedAllPreviewPairs = @(ConvertTo-PreviewPairArray -Value $AllPreviewPairs)
+  if ($orderedAllPreviewPairs.Count -eq 0) {
+    $orderedAllPreviewPairs = @(ConvertTo-PreviewPairArray -Value $SelectedPreviewPairs)
+  }
+
+  $cards = New-Object System.Collections.Generic.List[object]
+  $seenCards = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($selectedPreviewPair in @(ConvertTo-PreviewPairArray -Value $SelectedPreviewPairs)) {
+    $cardKey = Get-ReviewerPreviewCardKey -PreviewPair $selectedPreviewPair
+    if (-not $seenCards.Add($cardKey)) {
+      continue
+    }
+
+    $matchingPairs = @(
+      $orderedAllPreviewPairs |
+        Where-Object {
+          (Get-ReviewerPreviewCardKey -PreviewPair $_) -eq $cardKey
+        }
+    )
+    if ($matchingPairs.Count -eq 0) {
+      $matchingPairs = @($selectedPreviewPair)
+    }
+
+    $surfaces = New-Object System.Collections.Generic.List[object]
+    $seenSurfaceKinds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($matchingPair in $matchingPairs) {
+      $surfaceKind = Get-ReviewerPreviewSurfaceKind -PreviewPair $matchingPair
+      if ([string]::IsNullOrWhiteSpace($surfaceKind)) {
+        continue
+      }
+
+      if (-not $seenSurfaceKinds.Add($surfaceKind)) {
+        continue
+      }
+
+      $surfaces.Add((New-ReviewerPreviewSurface -PreviewPair $matchingPair)) | Out-Null
+    }
+
+    if ($surfaces.Count -eq 0) {
+      $surfaces.Add((New-ReviewerPreviewSurface -PreviewPair $selectedPreviewPair)) | Out-Null
+    }
+
+    $cards.Add([ordered]@{
+        targetId = [string]$selectedPreviewPair.targetId
+        targetPath = [string]$selectedPreviewPair.targetPath
+        comparison = $selectedPreviewPair.comparison
+        sortKey = Get-OptionalString -Value $selectedPreviewPair.sortKey
+        surfaces = @($surfaces | ForEach-Object { $_ })
+      }) | Out-Null
+  }
+
+  return @($cards | ForEach-Object { $_ })
 }
 
 function Get-ReportPreviewPairs {
@@ -610,10 +744,19 @@ $orderedPreviewPairs = @(ConvertTo-PreviewPairArray -Value $allPreviewPairs)
 $reviewerPreviewPairs = @(Get-ReviewerPreviewPairArray -Value $orderedPreviewPairs)
 $commentPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $CommentPreviewPairCap)
 $indexPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $IndexPreviewPairCap)
+$reviewerPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $reviewerPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
+$commentPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $commentPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
+$indexPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $indexPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
 $targetReceiptArray = @($targetReceipts | ForEach-Object { $_ })
 $orderedPreviewPairArray = @($orderedPreviewPairs | ForEach-Object { $_ })
 $commentPreviewPairArray = @($commentPreviewPairs | ForEach-Object { $_ })
 $indexPreviewPairArray = @($indexPreviewPairs | ForEach-Object { $_ })
+$reviewerPreviewCardArray = @($reviewerPreviewCards | ForEach-Object { $_ })
+$commentPreviewCardArray = @($commentPreviewCards | ForEach-Object { $_ })
+$indexPreviewCardArray = @($indexPreviewCards | ForEach-Object { $_ })
+$reviewerPreviewSurfaceCount = [int](@($reviewerPreviewCards | ForEach-Object { @(ConvertTo-ObjectArray -Value $_.surfaces).Count } | Measure-Object -Sum).Sum)
+$commentPreviewSurfaceCount = [int](@($commentPreviewCards | ForEach-Object { @(ConvertTo-ObjectArray -Value $_.surfaces).Count } | Measure-Object -Sum).Sum)
+$indexPreviewSurfaceCount = [int](@($indexPreviewCards | ForEach-Object { @(ConvertTo-ObjectArray -Value $_.surfaces).Count } | Measure-Object -Sum).Sum)
 
 $receipt = [ordered]@{
   schema = 'comparevi-history/pr-preview-manifest@v1'
@@ -625,19 +768,30 @@ $receipt = [ordered]@{
     previewPairCount = $orderedPreviewPairs.Count
     rawPreviewPairCount = $orderedPreviewPairs.Count
     reviewerPreviewPairCount = $reviewerPreviewPairs.Count
+    reviewerPreviewCardCount = $reviewerPreviewCards.Count
+    reviewerPreviewSurfaceCount = $reviewerPreviewSurfaceCount
     commentPreviewPairCap = [int]$CommentPreviewPairCap
     commentSelectionPolicy = 'reviewer-canonical@v1'
     commentPreviewPairCount = $commentPreviewPairs.Count
     commentPreviewPairOmittedCount = [Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0)
+    commentPreviewCardCount = $commentPreviewCards.Count
+    commentPreviewSurfaceCount = $commentPreviewSurfaceCount
+    commentCardSelectionPolicy = 'reviewer-multisurface@v1'
     indexPreviewPairCap = [int]$IndexPreviewPairCap
     indexSelectionPolicy = 'reviewer-canonical@v1'
     indexPreviewPairCount = $indexPreviewPairs.Count
     indexPreviewPairOmittedCount = [Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0)
+    indexPreviewCardCount = $indexPreviewCards.Count
+    indexPreviewSurfaceCount = $indexPreviewSurfaceCount
+    indexCardSelectionPolicy = 'reviewer-multisurface@v1'
   }
   targets = $targetReceiptArray
   previewPairs = $orderedPreviewPairArray
   commentPreviewPairs = $commentPreviewPairArray
   indexPreviewPairs = $indexPreviewPairArray
+  reviewerPreviewCards = $reviewerPreviewCardArray
+  commentPreviewCards = $commentPreviewCardArray
+  indexPreviewCards = $indexPreviewCardArray
 }
 
 $receipt | ConvertTo-Json -Depth 64 | Set-Content -LiteralPath $outputPathResolved -Encoding utf8
@@ -650,6 +804,12 @@ Write-ActionOutput -Key 'comment-preview-pair-count' -Value ([string]$commentPre
 Write-ActionOutput -Key 'comment-preview-pair-omitted-count' -Value ([string][Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0))
 Write-ActionOutput -Key 'index-preview-pair-count' -Value ([string]$indexPreviewPairs.Count)
 Write-ActionOutput -Key 'index-preview-pair-omitted-count' -Value ([string][Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0))
+Write-ActionOutput -Key 'reviewer-preview-card-count' -Value ([string]$reviewerPreviewCards.Count)
+Write-ActionOutput -Key 'reviewer-preview-surface-count' -Value ([string]$reviewerPreviewSurfaceCount)
+Write-ActionOutput -Key 'comment-preview-card-count' -Value ([string]$commentPreviewCards.Count)
+Write-ActionOutput -Key 'comment-preview-surface-count' -Value ([string]$commentPreviewSurfaceCount)
+Write-ActionOutput -Key 'index-preview-card-count' -Value ([string]$indexPreviewCards.Count)
+Write-ActionOutput -Key 'index-preview-surface-count' -Value ([string]$indexPreviewSurfaceCount)
 
 if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
   @(
@@ -657,7 +817,7 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     ''
     ('- Preview manifest: `{0}`' -f $outputPathResolved)
     ('- Raw preview pairs: `{0}`' -f $orderedPreviewPairs.Count)
-    ('- Reviewer preview pairs: `{0}`' -f $reviewerPreviewPairs.Count)
+    ('- Reviewer preview cards: `{0}` across `{1}` visual surfaces' -f $reviewerPreviewCards.Count, $reviewerPreviewSurfaceCount)
     ('- Comment preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairs.Count, [Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0), [int]$CommentPreviewPairCap)
     ('- Index preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairs.Count, [Math]::Max($reviewerPreviewPairs.Count - $indexPreviewPairs.Count, 0), [int]$IndexPreviewPairCap)
   ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append


### PR DESCRIPTION
## Summary
- build reviewer preview cards from raw PR preview pairs so each history pair can surface both front-panel and block-diagram images
- render those multisurface cards in the artifact index and sticky PR comment without leaking execution-mode labels into reviewer headings
- publish the extra preview images and extend the publication/preview receipts so the reviewer layer stays machine-readable

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check
