### PR TITLE
#130 Fix reviewer preview image selection

### DIFF
--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -22,9 +22,10 @@ function New-PreviewReportFixture {
   $artifactDir = Join-Path $ModeRoot ('{0}-{1:D3}-artifacts' -f $ArtifactPrefix, $ComparisonIndex)
   $reportFilesDir = Join-Path $artifactDir 'compare-report_files'
   New-Item -ItemType Directory -Path $reportFilesDir -Force | Out-Null
-  foreach ($imageName in @('fp_1.png', 'fp_2.png')) {
-    [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir $imageName), @(0xCA, 0xFE, 0xBA, 0xBE))
-  }
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_1.png'), @(0xCA, 0xFE, 0xBA, 0xBE))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_2.png'), @(0xBE, 0xBA, 0xFE, 0xCA))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_1.png'), @(0x0B, 0xD1, 0xA6, 0x01))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_2.png'), @(0x10, 0x0C, 0xD1, 0xA6))
 
   $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
   @'
@@ -34,7 +35,9 @@ function New-PreviewReportFixture {
 <div class="compared-VIs">
 <details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
 <table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
-<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr></table></details>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
 </div>
 </body>
 </html>
@@ -375,8 +378,8 @@ try {
   if ($receipt.summary.totalProcessed -ne 5 -or $receipt.summary.totalDiffs -ne 2) {
     throw 'Aggregate totals mismatch.'
   }
-  if ($receipt.summary.previewPairCount -ne 6 -or
-    $receipt.summary.rawPreviewPairCount -ne 6 -or
+  if ($receipt.summary.previewPairCount -ne 4 -or
+    $receipt.summary.rawPreviewPairCount -ne 4 -or
     $receipt.summary.reviewerPreviewPairCount -ne 2 -or
     $receipt.summary.commentPreviewPairCount -ne 2 -or
     $receipt.summary.commentPreviewPairOmittedCount -ne 0 -or
@@ -415,7 +418,7 @@ try {
   if ($commentBody -notmatch [regex]::Escape('comparevi-history-pr-diagnostics-123456789')) {
     throw 'PR comment body should point reviewers at the artifact bundle.'
   }
-  if ($commentBody -notmatch [regex]::Escape('Reviewer preview gallery: `2` shown, `0` omitted, cap `4`')) {
+  if ($commentBody -notmatch [regex]::Escape('Reviewer preview gallery: `2` history pairs shown, `0` omitted, cap `4`')) {
     throw 'PR comment body should surface the corrected preview pair counts.'
   }
   if ($commentBody -match [regex]::Escape('| front-panel |') -or
@@ -462,9 +465,9 @@ try {
 
   $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png',
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_1.png'
   )
   if (-not ($markdownPositions[0] -lt $markdownPositions[1] -and
       $markdownPositions[1] -lt $markdownPositions[2] -and
@@ -496,9 +499,9 @@ try {
 
   $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png',
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png',
-    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_1.png'
+    'targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_1.png'
   )
   if (-not ($htmlPositions[0] -lt $htmlPositions[1] -and
       $htmlPositions[1] -lt $htmlPositions[2] -and
@@ -507,8 +510,8 @@ try {
   }
 
   $previewManifest = Get-Content -LiteralPath $receipt.outputs.previewManifestPath -Raw | ConvertFrom-Json -Depth 64
-  if ($previewManifest.summary.previewPairCount -ne 6 -or
-    $previewManifest.summary.rawPreviewPairCount -ne 6 -or
+  if ($previewManifest.summary.previewPairCount -ne 4 -or
+    $previewManifest.summary.rawPreviewPairCount -ne 4 -or
     $previewManifest.summary.reviewerPreviewPairCount -ne 2 -or
     $previewManifest.summary.commentPreviewPairCount -ne 2 -or
     $previewManifest.summary.indexPreviewPairCount -ne 2 -or
@@ -526,8 +529,8 @@ try {
   $stepSummary = Get-Content -LiteralPath $receipt.outputs.publicStepSummaryPath -Raw
   if ($stepSummary -notmatch 'automatic pull request run' -or
     $stepSummary -notmatch 'Final status: `failed`' -or
-    $stepSummary -notmatch 'Reviewer preview gallery: `2` shown, `0` omitted, cap `4`' -or
-    $stepSummary -notmatch 'Raw preview surfaces collapsed for review: `6` raw -> `2` reviewer-canonical') {
+    $stepSummary -notmatch 'Reviewer preview gallery: `2` history pairs shown, `0` omitted, cap `4`' -or
+    $stepSummary -notmatch 'Raw preview surfaces collapsed for review: `4` raw -> `2` reviewer-canonical') {
     throw 'Public step summary content mismatch.'
   }
 

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -28,13 +28,13 @@ function New-PreviewPair {
     }
     sectionKind = 'overview'
     sectionOrdinal = 0
-    label = 'Front Panel Overview'
+    label = if ($Mode -eq 'block-diagram') { 'Block Diagram Overview' } else { 'Front Panel Overview' }
     reportHtmlRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report.html' -f $Mode, $ComparisonIndex)
-    baseImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/fp_1.png' -f $Mode, $ComparisonIndex)
-    headImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/fp_2.png' -f $Mode, $ComparisonIndex)
+    baseImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/{2}_1.png' -f $Mode, $ComparisonIndex, $(if ($Mode -eq 'block-diagram') { 'bd' } else { 'fp' }))
+    headImageRelativePath = ('targets/001/history/{0}/Demo.vi-{1:D3}-artifacts/compare-report_files/{2}_2.png' -f $Mode, $ComparisonIndex, $(if ($Mode -eq 'block-diagram') { 'bd' } else { 'fp' }))
     baseByteLength = 4
     headByteLength = 4
-    sortKey = ('Tooling/demo/Demo.vi|{0}|{1:D4}|00|0000|front-panel-overview' -f $Mode, $ComparisonIndex)
+    sortKey = ('Tooling/demo/Demo.vi|{0}|{1:D4}|00|0000|{2}' -f $Mode, $ComparisonIndex, $(if ($Mode -eq 'block-diagram') { 'block-diagram-overview' } else { 'front-panel-overview' }))
   }
 }
 
@@ -97,12 +97,9 @@ function New-PublicationArtifactZip {
   $previewPairs = @(
     (New-PreviewPair -Mode 'front-panel' -ComparisonIndex 1),
     (New-PreviewPair -Mode 'block-diagram' -ComparisonIndex 1),
-    (New-PreviewPair -Mode 'attributes' -ComparisonIndex 1),
     (New-PreviewPair -Mode 'front-panel' -ComparisonIndex 2),
-    (New-PreviewPair -Mode 'block-diagram' -ComparisonIndex 2),
-    (New-PreviewPair -Mode 'attributes' -ComparisonIndex 2)
+    (New-PreviewPair -Mode 'block-diagram' -ComparisonIndex 2)
   )
-  $commentPreviewPairs = @($previewPairs | Select-Object -First 4)
   $commentPreviewCards = @(
     (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 1),
     (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 2)
@@ -160,9 +157,9 @@ function New-PublicationArtifactZip {
         workflowRunUrl = 'https://github.com/example/repo/actions/runs/321'
         artifactName = 'comparevi-history-pr-diagnostics-321'
       }
-      summary = [ordered]@{
-        finalStatus = $FinalStatus
-        finalReason = 'completed'
+        summary = [ordered]@{
+          finalStatus = $FinalStatus
+          finalReason = 'completed'
         changedViCount = 1
         eligibleChangedViCount = 1
         excludedViCount = 0
@@ -173,8 +170,8 @@ function New-PublicationArtifactZip {
         failedTargetCount = 0
         totalProcessed = 5
         totalDiffs = 2
-        previewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
-        rawPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 6 } else { 0 })
+        previewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
+        rawPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
         reviewerPreviewPairCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         reviewerPreviewCardCount = $(if ($IncludePreviewManifest.IsPresent) { 2 } else { 0 })
         reviewerPreviewSurfaceCount = $(if ($IncludePreviewManifest.IsPresent) { 4 } else { 0 })
@@ -212,8 +209,8 @@ function New-PublicationArtifactZip {
         resultsDir = 'C:/results'
         summary = [ordered]@{
           targetCount = 1
-          previewPairCount = 6
-          rawPreviewPairCount = 6
+          previewPairCount = 4
+          rawPreviewPairCount = 4
           reviewerPreviewPairCount = 2
           reviewerPreviewCardCount = 2
           reviewerPreviewSurfaceCount = 4
@@ -238,7 +235,7 @@ function New-PublicationArtifactZip {
             targetPath = 'Tooling/demo/Demo.vi'
             finalStatus = 'succeeded'
             finalReason = 'completed'
-            previewPairCount = 6
+            previewPairCount = 4
             previewPairs = $previewPairs
           }
         )

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -20,9 +20,10 @@ function New-PreviewReportFixture {
   $artifactDir = Join-Path $ModeRoot ('Demo.vi-{0:D3}-artifacts' -f $ComparisonIndex)
   $reportFilesDir = Join-Path $artifactDir 'compare-report_files'
   New-Item -ItemType Directory -Path $reportFilesDir -Force | Out-Null
-  foreach ($imageName in @('fp_1.png', 'fp_2.png')) {
-    [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir $imageName), @(0xCA, 0xFE, 0xBA, 0xBE))
-  }
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_1.png'), @(0xCA, 0xFE, 0xBA, 0xBE))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_2.png'), @(0xBE, 0xBA, 0xFE, 0xCA))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_1.png'), @(0x0B, 0xD1, 0xA6, 0x01))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_2.png'), @(0x10, 0x0C, 0xD1, 0xA6))
 
   $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
   @'
@@ -32,7 +33,9 @@ function New-PreviewReportFixture {
 <div class="compared-VIs">
 <details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
 <table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
-<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr></table></details>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
 </div>
 </body>
 </html>
@@ -128,10 +131,10 @@ try {
   if ($receipt.schema -ne 'comparevi-history/pr-preview-manifest@v1') {
     throw 'Preview manifest schema mismatch.'
   }
-  if ($receipt.summary.previewPairCount -ne 6) {
-    throw 'Expected six preview pairs from the PR31-shaped fixture.'
+  if ($receipt.summary.previewPairCount -ne 4) {
+    throw 'Expected four raw preview pairs from the PR31-shaped fixture.'
   }
-  if ($receipt.summary.rawPreviewPairCount -ne 6 -or $receipt.summary.reviewerPreviewPairCount -ne 2) {
+  if ($receipt.summary.rawPreviewPairCount -ne 4 -or $receipt.summary.reviewerPreviewPairCount -ne 2) {
     throw 'Expected explicit raw and reviewer preview pair counts in the preview manifest summary.'
   }
   if ($receipt.summary.reviewerPreviewCardCount -ne 2 -or
@@ -157,7 +160,7 @@ try {
     $receipt.summary.indexCardSelectionPolicy -ne 'reviewer-multisurface@v1') {
     throw 'Index preview card summary mismatch.'
   }
-  if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 6) {
+  if ($receipt.targets.Count -ne 1 -or $receipt.targets[0].previewPairCount -ne 4) {
     throw 'Target preview pair count mismatch.'
   }
 
@@ -206,7 +209,7 @@ try {
     throw 'Reviewer cards should use reviewer-facing surface labels.'
   }
   if ($receipt.commentPreviewCards[0].surfaces[0].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png' -or
-    $receipt.commentPreviewCards[0].surfaces[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/fp_1.png') {
+    $receipt.commentPreviewCards[0].surfaces[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/bd_1.png') {
     throw 'Reviewer cards should preserve both front-panel and block-diagram image paths for the same history pair.'
   }
 
@@ -214,7 +217,7 @@ try {
   foreach ($requiredKey in @(
       'preview-manifest-path=',
       'preview-pair-count=2',
-      'raw-preview-pair-count=6',
+      'raw-preview-pair-count=4',
       'reviewer-preview-pair-count=2',
       'comment-preview-pair-count=2',
       'comment-preview-pair-omitted-count=0',

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -597,8 +597,10 @@ $rawPreviewPairCount = 0
 $reviewerPreviewPairCount = 0
 $commentPreviewPairCount = 0
 $commentPreviewPairOmittedCount = 0
+$commentPreviewCardCount = 0
 $indexPreviewPairCount = 0
 $indexPreviewPairOmittedCount = 0
+$indexPreviewCardCount = 0
 $commentPreviewPairCap = 0
 $indexPreviewPairCap = 0
 $indexPreviewCards = @()
@@ -630,9 +632,11 @@ if ($null -ne $targetManifest) {
   $commentPreviewPairCap = [int]$previewManifest.summary.commentPreviewPairCap
   $commentPreviewPairCount = [int]$previewManifest.summary.commentPreviewPairCount
   $commentPreviewPairOmittedCount = [int]$previewManifest.summary.commentPreviewPairOmittedCount
+  $commentPreviewCardCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'commentPreviewCardCount') -Default 0)
   $indexPreviewPairCap = [int]$previewManifest.summary.indexPreviewPairCap
   $indexPreviewPairCount = [int]$previewManifest.summary.indexPreviewPairCount
   $indexPreviewPairOmittedCount = [int]$previewManifest.summary.indexPreviewPairOmittedCount
+  $indexPreviewCardCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'indexPreviewCardCount') -Default 0)
   $indexPreviewCards = @(New-ReviewerPreviewCards `
       -SelectedPreviewPairs @($previewManifest.indexPreviewPairs | ForEach-Object { $_ }) `
       -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
@@ -682,7 +686,7 @@ $commentLines.Add(('- Failed targets: `{0}`' -f $failedTargetCount)) | Out-Null
 $commentLines.Add(('- Total processed pairs: `{0}`' -f $totalProcessed)) | Out-Null
 $commentLines.Add(('- Total diffs: `{0}`' -f $totalDiffs)) | Out-Null
 if ($reviewerPreviewPairCount -gt 0) {
-  $commentLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
+  $commentLines.Add(('- Reviewer preview gallery: `{0}` history pairs shown, `{1}` omitted, cap `{2}`' -f $commentPreviewCardCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
   if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
     $commentLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
   }
@@ -740,7 +744,7 @@ if ($null -ne $previewManifestPathResolved -and (Test-Path -LiteralPath $preview
   $indexLines.Add(('- Preview manifest: [pr-preview-manifest.json](pr-preview-manifest.json)')) | Out-Null
 }
 if ($reviewerPreviewPairCount -gt 0) {
-  $indexLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
+  $indexLines.Add(('- Reviewer preview gallery: `{0}` history pairs shown, `{1}` omitted, cap `{2}`' -f $indexPreviewCardCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
   if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
     $indexLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
   }
@@ -847,7 +851,7 @@ $indexHtml = @"
     <li>Discovery receipt: <a href="changed-vi-discovery.json">changed-vi-discovery.json</a></li>
     <li>Aggregate receipt: <a href="pr-run.json">pr-run.json</a></li>
     $(if ($null -ne $previewManifestPathResolved -and (Test-Path -LiteralPath $previewManifestPathResolved -PathType Leaf)) { '<li>Preview manifest: <a href="pr-preview-manifest.json">pr-preview-manifest.json</a></li>' } else { '' })
-    $(if ($reviewerPreviewPairCount -gt 0) { '<li>Reviewer preview gallery: <code>' + $indexPreviewPairCount + '</code> shown, <code>' + $indexPreviewPairOmittedCount + '</code> omitted, cap <code>' + $indexPreviewPairCap + '</code></li>' } else { '' })
+    $(if ($reviewerPreviewPairCount -gt 0) { '<li>Reviewer preview gallery: <code>' + $indexPreviewCardCount + '</code> history pairs shown, <code>' + $indexPreviewPairOmittedCount + '</code> omitted, cap <code>' + $indexPreviewPairCap + '</code></li>' } else { '' })
     $(if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) { '<li>Raw preview surfaces collapsed for review: <code>' + $rawPreviewPairCount + '</code> raw -> <code>' + $reviewerPreviewPairCount + '</code> reviewer-canonical</li>' } else { '' })
   </ul>
   $(New-HtmlPreviewGallery -PreviewCards $indexPreviewCards)
@@ -881,8 +885,8 @@ $stepSummaryLines.Add(('- Aggregate receipt: `{0}`' -f $prRunPath)) | Out-Null
 $stepSummaryLines.Add(('- Index markdown: `{0}`' -f $indexMdPath)) | Out-Null
 $stepSummaryLines.Add(('- Index HTML: `{0}`' -f $indexHtmlPath)) | Out-Null
 $stepSummaryLines.Add(('- Preview manifest: `{0}`' -f $(if ($null -eq $previewManifestPathResolved) { 'n/a' } else { $previewManifestPathResolved }))) | Out-Null
-$stepSummaryLines.Add(('- Reviewer preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
-$stepSummaryLines.Add(('- Index preview gallery: `{0}` shown, `{1}` omitted, cap `{2}`' -f $indexPreviewPairCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
+$stepSummaryLines.Add(('- Reviewer preview gallery: `{0}` history pairs shown, `{1}` omitted, cap `{2}`' -f $commentPreviewCardCount, $commentPreviewPairOmittedCount, $commentPreviewPairCap)) | Out-Null
+$stepSummaryLines.Add(('- Index preview gallery: `{0}` history pairs shown, `{1}` omitted, cap `{2}`' -f $indexPreviewCardCount, $indexPreviewPairOmittedCount, $indexPreviewPairCap)) | Out-Null
 if ($rawPreviewPairCount -gt $reviewerPreviewPairCount) {
   $stepSummaryLines.Add(('- Raw preview surfaces collapsed for review: `{0}` raw -> `{1}` reviewer-canonical' -f $rawPreviewPairCount, $reviewerPreviewPairCount)) | Out-Null
 }

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -436,6 +436,112 @@ function Get-ReviewerPreviewSurfaceLabel {
   }
 }
 
+function New-PreviewSurfaceCandidate {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Label,
+    [Parameter(Mandatory = $true)]
+    [string]$BaseImagePath,
+    [Parameter(Mandatory = $true)]
+    [string]$HeadImagePath
+  )
+
+  return [ordered]@{
+    label = $Label
+    baseImagePath = $BaseImagePath
+    headImagePath = $HeadImagePath
+  }
+}
+
+function Get-ReportPreviewSurfaceCandidates {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TableHtml,
+    [Parameter(Mandatory = $true)]
+    [string]$ReportDirectory
+  )
+
+  $candidates = New-Object System.Collections.Generic.List[object]
+  $surfacePattern = '(?is)<tr class="compared-vi-image-captions">.*?<td class="compared-vi-image-caption">(?<caption>.*?)</td>.*?</tr>\s*<tr class="compared-images">(?<images>.*?)</tr>'
+  foreach ($surfaceMatch in [regex]::Matches($TableHtml, $surfacePattern)) {
+    $caption = ConvertFrom-HtmlText -Value ([string]$surfaceMatch.Groups['caption'].Value)
+    $imageSources = @(
+      [regex]::Matches([string]$surfaceMatch.Groups['images'].Value, '(?is)<img[^>]+src="(?<src>[^"]+)"') |
+        ForEach-Object { Get-OptionalString -Value ([string]$_.Groups['src'].Value) } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($imageSources.Count -lt 2) {
+      continue
+    }
+
+    $baseImagePath = Resolve-ExistingPath -Path $imageSources[0] -BasePath $ReportDirectory -PathType Leaf
+    $headImagePath = Resolve-ExistingPath -Path $imageSources[1] -BasePath $ReportDirectory -PathType Leaf
+    if ($null -eq $baseImagePath -or $null -eq $headImagePath) {
+      continue
+    }
+
+    $candidates.Add((New-PreviewSurfaceCandidate -Label $caption -BaseImagePath $baseImagePath -HeadImagePath $headImagePath)) | Out-Null
+  }
+
+  return @($candidates | ForEach-Object { $_ })
+}
+
+function Test-PreviewSurfaceMatchesMode {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Candidate,
+    [Parameter(Mandatory = $true)]
+    [string]$Mode
+  )
+
+  $label = ([string]$Candidate.label).ToLowerInvariant()
+  $baseName = [System.IO.Path]::GetFileName([string]$Candidate.baseImagePath).ToLowerInvariant()
+  $headName = [System.IO.Path]::GetFileName([string]$Candidate.headImagePath).ToLowerInvariant()
+
+  switch ($Mode) {
+    'front-panel' {
+      return $label -match 'front panel' -or $baseName -like 'fp_*' -or $headName -like 'fp_*'
+    }
+    'block-diagram' {
+      return $label -match 'block diagram' -or $baseName -like 'bd_*' -or $headName -like 'bd_*'
+    }
+    'attributes' {
+      return $label -match 'attribute'
+    }
+    default {
+      return $false
+    }
+  }
+}
+
+function Select-PreviewSurfaceCandidateForMode {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Candidates,
+    [Parameter(Mandatory = $true)]
+    [string]$Mode
+  )
+
+  if ($Candidates.Count -eq 0) {
+    return $null
+  }
+
+  $matchingCandidate = @(
+    $Candidates |
+      Where-Object { Test-PreviewSurfaceMatchesMode -Candidate $_ -Mode $Mode } |
+      Select-Object -First 1
+  )
+  if ($matchingCandidate.Count -gt 0) {
+    return $matchingCandidate[0]
+  }
+
+  if ($Mode -eq 'front-panel') {
+    return $Candidates[0]
+  }
+
+  return $null
+}
+
 function Get-ReviewerPreviewPairArray {
   param(
     [AllowNull()]
@@ -445,7 +551,7 @@ function Get-ReviewerPreviewPairArray {
   $selected = New-Object System.Collections.Generic.List[object]
   $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
   foreach ($previewPair in @(ConvertTo-PreviewPairArray -Value $Value)) {
-    $identityKey = Get-PreviewPairReviewerIdentityKey -PreviewPair $previewPair
+    $identityKey = Get-ReviewerPreviewCardKey -PreviewPair $previewPair
     if (-not $seen.Add($identityKey)) {
       continue
     }
@@ -609,34 +715,17 @@ function Get-ReportPreviewPairs {
     $summaryAttrs = [string]$match.Groups['summaryAttrs'].Value
     $summaryText = ConvertFrom-HtmlText -Value ([string]$match.Groups['summary'].Value)
     $tableHtml = [string]$match.Groups['table'].Value
-    $captionMatches = [regex]::Matches($tableHtml, '(?is)<td class="compared-vi-image-caption">(?<caption>.*?)</td>')
-    $captions = @(
-      $captionMatches |
-        ForEach-Object { ConvertFrom-HtmlText -Value ([string]$_.Groups['caption'].Value) } |
-        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    )
-    $imageSources = @(
-      [regex]::Matches($tableHtml, '(?is)<img[^>]+src="(?<src>[^"]+)"') |
-        ForEach-Object { Get-OptionalString -Value ([string]$_.Groups['src'].Value) } |
-        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    )
-    if ($imageSources.Count -lt 2) {
-      continue
-    }
-
-    $baseImagePath = Resolve-ExistingPath -Path $imageSources[0] -BasePath $reportDirectory -PathType Leaf
-    $headImagePath = Resolve-ExistingPath -Path $imageSources[1] -BasePath $reportDirectory -PathType Leaf
-    if ($null -eq $baseImagePath -or $null -eq $headImagePath) {
+    $surfaceCandidates = @(Get-ReportPreviewSurfaceCandidates -TableHtml $tableHtml -ReportDirectory $reportDirectory)
+    $selectedSurface = Select-PreviewSurfaceCandidateForMode -Candidates $surfaceCandidates -Mode $Mode
+    if ($null -eq $selectedSurface) {
       continue
     }
 
     $sectionKind = if ($summaryAttrs -match 'difference-heading') { 'overview' } else { 'detail' }
-    $label = if ($sectionKind -eq 'overview' -and $captions.Count -gt 0) {
-      $captions[0]
+    $label = if (-not [string]::IsNullOrWhiteSpace([string]$selectedSurface.label)) {
+      [string]$selectedSurface.label
     } elseif (-not [string]::IsNullOrWhiteSpace($summaryText)) {
       $summaryText
-    } elseif ($captions.Count -gt 0) {
-      $captions[0]
     } else {
       'Preview'
     }
@@ -660,12 +749,12 @@ function Get-ReportPreviewPairs {
         sectionOrdinal = $sectionOrdinal
         label = $label
         reportHtmlRelativePath = $reportHtmlRelativePath
-        baseImageRelativePath = Resolve-RelativePath -Path $baseImagePath -ResultsRoot $ResultsRoot
-        headImageRelativePath = Resolve-RelativePath -Path $headImagePath -ResultsRoot $ResultsRoot
-        baseByteLength = [int64](Get-Item -LiteralPath $baseImagePath).Length
-        headByteLength = [int64](Get-Item -LiteralPath $headImagePath).Length
-        baseImageSha256 = Get-FileSha256Hex -Path $baseImagePath
-        headImageSha256 = Get-FileSha256Hex -Path $headImagePath
+        baseImageRelativePath = Resolve-RelativePath -Path ([string]$selectedSurface.baseImagePath) -ResultsRoot $ResultsRoot
+        headImageRelativePath = Resolve-RelativePath -Path ([string]$selectedSurface.headImagePath) -ResultsRoot $ResultsRoot
+        baseByteLength = [int64](Get-Item -LiteralPath ([string]$selectedSurface.baseImagePath)).Length
+        headByteLength = [int64](Get-Item -LiteralPath ([string]$selectedSurface.headImagePath)).Length
+        baseImageSha256 = Get-FileSha256Hex -Path ([string]$selectedSurface.baseImagePath)
+        headImageSha256 = Get-FileSha256Hex -Path ([string]$selectedSurface.headImagePath)
         sortKey = $sortKey
       }) | Out-Null
 


### PR DESCRIPTION
## Summary
- fix reviewer preview extraction so block-diagram cards use block-diagram images instead of front-panel images
- keep reviewer gallery counts aligned to history-pair cards while preserving raw preview surface counts
- update focused preview manifest, aggregate run, and publication regressions around the PR31-shaped fixture

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

Closes #130
