### PR TITLE
#136 Surface reviewer change details from attributes reports

### DIFF
--- a/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
@@ -142,6 +142,61 @@
               "targetId": { "type": "string", "minLength": 1 },
               "targetPath": { "type": "string", "minLength": 1 },
               "comparison": { "type": "object" },
+              "changeDetails": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "required": [
+                  "label",
+                  "sourceMode",
+                  "reportHtmlRelativePath",
+                  "includedCategories",
+                  "groupCount",
+                  "omittedGroupCount",
+                  "sectionCount",
+                  "detailCount",
+                  "groups"
+                ],
+                "properties": {
+                  "label": { "type": "string", "minLength": 1 },
+                  "sourceMode": { "const": "attributes" },
+                  "reportHtmlRelativePath": { "type": ["string", "null"] },
+                  "includedCategories": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 }
+                  },
+                  "groupCount": { "type": "integer", "minimum": 0 },
+                  "omittedGroupCount": { "type": "integer", "minimum": 0 },
+                  "sectionCount": { "type": "integer", "minimum": 0 },
+                  "detailCount": { "type": "integer", "minimum": 0 },
+                  "groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "heading",
+                        "sectionCount",
+                        "detailCount",
+                        "sampleDetails",
+                        "omittedDetailCount"
+                      ],
+                      "properties": {
+                        "heading": { "type": "string", "minLength": 1 },
+                        "sectionCount": { "type": "integer", "minimum": 0 },
+                        "detailCount": { "type": "integer", "minimum": 0 },
+                        "sampleDetails": {
+                          "type": "array",
+                          "items": { "type": "string", "minLength": 1 }
+                        },
+                        "omittedDetailCount": { "type": "integer", "minimum": 0 }
+                      }
+                    }
+                  }
+                }
+              },
               "surfaces": {
                 "type": "array",
                 "items": {

--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -214,9 +214,63 @@
         "targetPath": { "type": "string", "minLength": 1 },
         "comparison": { "$ref": "#/$defs/comparison" },
         "sortKey": { "type": ["string", "null"] },
+        "changeDetails": { "$ref": "#/$defs/changeDetails" },
         "surfaces": {
           "type": "array",
           "items": { "$ref": "#/$defs/previewSurface" }
+        }
+      }
+    },
+    "changeDetailGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "heading",
+        "sectionCount",
+        "detailCount",
+        "sampleDetails",
+        "omittedDetailCount"
+      ],
+      "properties": {
+        "heading": { "type": "string", "minLength": 1 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "sampleDetails": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "omittedDetailCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "changeDetails": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "sourceMode",
+        "reportHtmlRelativePath",
+        "includedCategories",
+        "groupCount",
+        "omittedGroupCount",
+        "sectionCount",
+        "detailCount",
+        "groups"
+      ],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "sourceMode": { "const": "attributes" },
+        "reportHtmlRelativePath": { "type": ["string", "null"] },
+        "includedCategories": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "groupCount": { "type": "integer", "minimum": 0 },
+        "omittedGroupCount": { "type": "integer", "minimum": 0 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "groups": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailGroup" }
         }
       }
     },

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -349,6 +349,56 @@ function Get-ReviewerPreviewSurfaceLabel {
   }
 }
 
+function New-CommentChangeDetailsMarkdown {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return ''
+  }
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('<p><strong>Change details</strong></p>') | Out-Null
+  $lines.Add('<ul>') | Out-Null
+  $includedCategories = @(
+    ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
+      ForEach-Object { Get-OptionalString -Value $_ } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  if ($includedCategories.Count -gt 0) {
+    $lines.Add(('<li><strong>Included categories:</strong> {0}</li>' -f (ConvertTo-HtmlText ($includedCategories -join ', ')))) | Out-Null
+  }
+  foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $lines.Add(('<li><strong>{0}:</strong> {1} details across {2} sections' -f `
+          (ConvertTo-HtmlText (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading')))), `
+          [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0), `
+          [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0))) | Out-Null
+    $lines.Add('<ul>') | Out-Null
+    foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+      $lines.Add(('<li>{0}</li>' -f (ConvertTo-HtmlText ([string]$sampleDetail)))) | Out-Null
+    }
+    $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+    if ($omittedDetailCount -gt 0) {
+      $lines.Add(('<li>+{0} more details in report</li>' -f $omittedDetailCount)) | Out-Null
+    }
+    $lines.Add('</ul>') | Out-Null
+    $lines.Add('</li>') | Out-Null
+  }
+  $omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+  if ($omittedGroupCount -gt 0) {
+    $lines.Add(('<li><strong>Additional change-detail groups omitted:</strong> {0}</li>' -f $omittedGroupCount)) | Out-Null
+  }
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+  if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $lines.Add(('<li><a href="{0}">open change details report</a></li>' -f (ConvertTo-HtmlText $reportHtmlRelativePath))) | Out-Null
+  }
+  $lines.Add('</ul>') | Out-Null
+
+  return $lines -join "`n"
+}
+
 function Get-ReviewerPreviewCardKey {
   param([Parameter(Mandatory = $true)][object]$PreviewPair)
 
@@ -630,6 +680,10 @@ function New-CommentPreviewMarkdown {
     if (-not [string]::IsNullOrWhiteSpace($detailHtml)) {
       $lines.Add($detailHtml) | Out-Null
     }
+    $changeDetailsMarkdown = New-CommentChangeDetailsMarkdown -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails'))
+    if (-not [string]::IsNullOrWhiteSpace($changeDetailsMarkdown)) {
+      $lines.Add($changeDetailsMarkdown) | Out-Null
+    }
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
       $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
       $baseUrl = [string]$surface.baseImageUrl
@@ -768,6 +822,7 @@ function Publish-CommentPreviewSurface {
       targetId = [string]$previewCard.targetId
       targetPath = [string]$previewCard.targetPath
       comparison = $previewCard.comparison
+      changeDetails = Get-NestedValue -Object $previewCard -Path @('changeDetails')
       surfaces = @($publishedSurfaces | ForEach-Object { $_ })
     }
     $publishedPreviewCards.Add($publishedCard) | Out-Null

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -10,6 +10,8 @@ function New-PreviewReportFixture {
     [Parameter(Mandatory = $true)]
     [string]$ModeRoot,
     [Parameter(Mandatory = $true)]
+    [string]$ModeName,
+    [Parameter(Mandatory = $true)]
     [string]$ArtifactPrefix,
     [Parameter(Mandatory = $true)]
     [int]$ComparisonIndex,
@@ -28,7 +30,57 @@ function New-PreviewReportFixture {
   [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_2.png'), @(0x10, 0x0C, 0xD1, 0xA6))
 
   $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
-  @'
+  $reportHtml = if ($ModeName -eq 'attributes') {
+@"
+<!DOCTYPE html>
+<html>
+<body>
+<div class="compared-VIs">
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
+<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
+</div>
+<div class="included-attributes">
+<ul class="inclusion-list">
+<li class="checked">Block Diagram Functional</li>
+<li class="checked">VI Attribute</li>
+</ul>
+</div>
+<h2 class="section-header">Detailed Information</h2>
+$(if ($ComparisonIndex -eq 1) {
+@'
+<details open>
+<summary class="difference-heading">1. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Property Node - moved : changed from "(-35,102)" to "(-55,77)"</li>
+<li class="diff-detail">Tunnel - moved : changed from "(141,124)" to "(141,124)"</li>
+<li class="diff-detail">Case Selector - moved : changed from "(141,143)" to "(141,143)"</li>
+</ol>
+</details>
+<details open>
+<summary class="difference-heading">2. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Boolean Constant - moved : changed from "(675,231)" to "(675,231)"</li>
+</ol>
+</details>
+'@
+} else {
+@'
+<details open>
+<summary class="difference-heading">1. VI Attribute - Miscellaneous</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">VI Version : changed from "21.0" to "20.0"</li>
+</ol>
+</details>
+'@
+})
+</body>
+</html>
+"@
+  } else {
+@'
 <!DOCTYPE html>
 <html>
 <body>
@@ -41,7 +93,9 @@ function New-PreviewReportFixture {
 </div>
 </body>
 </html>
-'@ | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
+'@
+  }
+  $reportHtml | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
 
   return [ordered]@{
     index = $ComparisonIndex
@@ -73,8 +127,8 @@ function New-PreviewModeFixture {
   New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
   $modeManifestPath = Join-Path $modeRoot 'manifest.json'
   $comparisons = @(
-    (New-PreviewReportFixture -ModeRoot $modeRoot -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $ModeName) -HeadRef ('{0}-head-1' -f $ModeName)),
-    (New-PreviewReportFixture -ModeRoot $modeRoot -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $ModeName) -HeadRef ('{0}-head-2' -f $ModeName))
+    (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $ModeName -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $ModeName) -HeadRef ('{0}-head-1' -f $ModeName)),
+    (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $ModeName -ArtifactPrefix $ArtifactPrefix -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $ModeName) -HeadRef ('{0}-head-2' -f $ModeName))
   )
 
   ([ordered]@{
@@ -462,6 +516,13 @@ try {
     [regex]::Matches($indexMarkdown, [regex]::Escape('#### Block diagram')).Count -ne 2) {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
+  if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Change details')).Count -ne 2 -or
+    $indexMarkdown -notmatch [regex]::Escape('`Block Diagram objects`: `4` details across `2` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('+1 more details in report') -or
+    $indexMarkdown -notmatch [regex]::Escape('`VI Attribute - Miscellaneous`: `1` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('Included categories: `Block Diagram Functional`, `VI Attribute`')) {
+    throw 'Index markdown should render bounded change-detail summaries from the attributes compare report.'
+  }
 
   $markdownPositions = Get-OrdinalPositions -Content $indexMarkdown -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
@@ -496,6 +557,13 @@ try {
     [regex]::Matches($indexHtml, [regex]::Escape('<h4>Block diagram</h4>')).Count -ne 2) {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
+  if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Change details</h4>')).Count -ne 2 -or
+    $indexHtml -notmatch [regex]::Escape('Block Diagram objects') -or
+    $indexHtml -notmatch [regex]::Escape('+1 more details in report') -or
+    $indexHtml -notmatch [regex]::Escape('VI Attribute - Miscellaneous') -or
+    $indexHtml -notmatch [regex]::Escape('open change details report')) {
+    throw 'Index HTML should render bounded change-detail summaries from the attributes compare report.'
+  }
 
   $htmlPositions = Get-OrdinalPositions -Content $indexHtml -Needles @(
     'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png',
@@ -520,6 +588,11 @@ try {
     $previewManifest.summary.indexPreviewCardCount -ne 2 -or
     $previewManifest.summary.indexPreviewSurfaceCount -ne 4) {
     throw 'Preview manifest summary mismatch.'
+  }
+  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.label -ne 'Change details' -or
+    [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
+    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous') {
+    throw 'Preview manifest should carry reviewer-facing change-detail summaries into the aggregate PR run.'
   }
   if ($previewManifest.indexPreviewCards.Count -ne 2 -or
     (@($previewManifest.indexPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -62,6 +62,33 @@ function New-PreviewCard {
     targetId = 'dynamic-demo-target'
     targetPath = 'Tooling/demo/Demo.vi'
     comparison = $matchingPairs[0].comparison
+    changeDetails = [ordered]@{
+      label = 'Change details'
+      sourceMode = 'attributes'
+      reportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html' -f $ComparisonIndex)
+      includedCategories = $(if ($ComparisonIndex -eq 1) { @('Block Diagram Functional', 'VI Attribute') } else { @('VI Attribute') })
+      groupCount = 1
+      omittedGroupCount = 0
+      sectionCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
+      detailCount = $(if ($ComparisonIndex -eq 1) { 4 } else { 1 })
+      groups = @(
+        [ordered]@{
+          heading = $(if ($ComparisonIndex -eq 1) { 'Block Diagram objects' } else { 'VI Attribute - Miscellaneous' })
+          sectionCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
+          detailCount = $(if ($ComparisonIndex -eq 1) { 4 } else { 1 })
+          sampleDetails = $(if ($ComparisonIndex -eq 1) {
+              @(
+                'Property Node - moved : changed from "(-35,102)" to "(-55,77)"',
+                'Tunnel - moved : changed from "(141,124)" to "(141,124)"',
+                'Case Selector - moved : changed from "(141,143)" to "(141,143)"'
+              )
+            } else {
+              @('VI Version : changed from "21.0" to "20.0"')
+            })
+          omittedDetailCount = $(if ($ComparisonIndex -eq 1) { 1 } else { 0 })
+        }
+      )
+    }
     surfaces = @(
       $matchingPairs |
         ForEach-Object {
@@ -439,6 +466,14 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Block diagram</strong></p>')).Count -ne 2) {
     throw 'Created PR comment body should render both front-panel and block-diagram surfaces for each history pair.'
   }
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Change details</strong></p>')).Count -ne 2 -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('Block Diagram objects') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('+1 more details in report') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Attribute - Miscellaneous') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Version : changed from &quot;21.0&quot; to &quot;20.0&quot;') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('open change details report')) {
+    throw 'Created PR comment body should render bounded change-detail summaries from the attributes compare report.'
+  }
   if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
     [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
     throw 'Created PR comment body should embed eight preview image URLs.'
@@ -466,6 +501,11 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($createReceipt.previewPublication.commentPreviewCards.Count -ne 2 -or
     (@($createReceipt.previewPublication.commentPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
     throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
+  }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous') {
+    throw 'Preview publication should retain reviewer-facing change-detail summaries.'
   }
 
   $writeOrder = @(

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -10,6 +10,8 @@ function New-PreviewReportFixture {
     [Parameter(Mandatory = $true)]
     [string]$ModeRoot,
     [Parameter(Mandatory = $true)]
+    [string]$ModeName,
+    [Parameter(Mandatory = $true)]
     [int]$ComparisonIndex,
     [Parameter(Mandatory = $true)]
     [string]$BaseRef,
@@ -26,7 +28,57 @@ function New-PreviewReportFixture {
   [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_2.png'), @(0x10, 0x0C, 0xD1, 0xA6))
 
   $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
-  @'
+  $reportHtml = if ($ModeName -eq 'attributes') {
+@"
+<!DOCTYPE html>
+<html>
+<body>
+<div class="compared-VIs">
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
+<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
+</div>
+<div class="included-attributes">
+<ul class="inclusion-list">
+<li class="checked">Block Diagram Functional</li>
+<li class="checked">VI Attribute</li>
+</ul>
+</div>
+<h2 class="section-header">Detailed Information</h2>
+$(if ($ComparisonIndex -eq 1) {
+@'
+<details open>
+<summary class="difference-heading">1. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Property Node - moved : changed from "(-35,102)" to "(-55,77)"</li>
+<li class="diff-detail">Tunnel - moved : changed from "(141,124)" to "(141,124)"</li>
+<li class="diff-detail">Case Selector - moved : changed from "(141,143)" to "(141,143)"</li>
+</ol>
+</details>
+<details open>
+<summary class="difference-heading">2. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Boolean Constant - moved : changed from "(675,231)" to "(675,231)"</li>
+</ol>
+</details>
+'@
+} else {
+@'
+<details open>
+<summary class="difference-heading">1. VI Attribute - Miscellaneous</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">VI Version : changed from "21.0" to "20.0"</li>
+</ol>
+</details>
+'@
+})
+</body>
+</html>
+"@
+  } else {
+@'
 <!DOCTYPE html>
 <html>
 <body>
@@ -39,7 +91,9 @@ function New-PreviewReportFixture {
 </div>
 </body>
 </html>
-'@ | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
+'@
+  }
+  $reportHtml | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
 
   return [ordered]@{
     index = $ComparisonIndex
@@ -68,8 +122,8 @@ try {
     New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
 
     $comparisons = @(
-      (New-PreviewReportFixture -ModeRoot $modeRoot -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $modeName) -HeadRef ('{0}-head-1' -f $modeName)),
-      (New-PreviewReportFixture -ModeRoot $modeRoot -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $modeName) -HeadRef ('{0}-head-2' -f $modeName))
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $modeName) -HeadRef ('{0}-head-1' -f $modeName)),
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $modeName) -HeadRef ('{0}-head-2' -f $modeName))
     )
 
     $modeManifestPath = Join-Path $modeRoot 'manifest.json'
@@ -211,6 +265,27 @@ try {
   if ($receipt.commentPreviewCards[0].surfaces[0].baseImageRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report_files/fp_1.png' -or
     $receipt.commentPreviewCards[0].surfaces[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/bd_1.png') {
     throw 'Reviewer cards should preserve both front-panel and block-diagram image paths for the same history pair.'
+  }
+  if ([string]$receipt.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
+    [string]$receipt.commentPreviewCards[0].changeDetails.sourceMode -ne 'attributes') {
+    throw 'Reviewer cards should attach bounded change-detail summaries from the attributes compare report.'
+  }
+  if ((@($receipt.commentPreviewCards[0].changeDetails.includedCategories) -join ',') -ne 'Block Diagram Functional,VI Attribute') {
+    throw 'Reviewer cards should preserve included categories from the attributes compare report.'
+  }
+  if ([string]$receipt.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].detailCount -ne 4 -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionCount -ne 2 -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].omittedDetailCount -ne 1) {
+    throw 'Reviewer cards should aggregate repeated attributes-report sections into a bounded change-detail summary.'
+  }
+  if ($receipt.commentPreviewCards[0].changeDetails.groups[0].sampleDetails.Count -ne 3 -or
+    $receipt.commentPreviewCards[0].changeDetails.groups[0].sampleDetails[0] -notmatch 'Property Node - moved') {
+    throw 'Reviewer cards should preserve the first bounded change-detail samples.'
+  }
+  if ([string]$receipt.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous' -or
+    $receipt.commentPreviewCards[1].changeDetails.groups[0].sampleDetails[0] -notmatch 'VI Version : changed from "21\.0" to "20\.0"') {
+    throw 'Reviewer cards should preserve distinct VI attribute change summaries for later history pairs.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -303,6 +303,100 @@ function Get-ReviewerPreviewSurfaceLabel {
   }
 }
 
+function New-MarkdownChangeDetailsLines {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return @()
+  }
+
+  $groups = @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))
+  $includedCategories = @(
+    ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
+      ForEach-Object { Get-OptionalString -Value $_ } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('#### Change details') | Out-Null
+  $lines.Add('') | Out-Null
+  if ($includedCategories.Count -gt 0) {
+    $lines.Add(('- Included categories: `{0}`' -f ($includedCategories -join '`, `'))) | Out-Null
+  }
+  foreach ($group in $groups) {
+    $heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+    $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+    $lines.Add(('- `{0}`: `{1}` details across `{2}` sections' -f $heading, $detailCount, $sectionCount)) | Out-Null
+    foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+      $lines.Add(('  - {0}' -f [string]$sampleDetail)) | Out-Null
+    }
+    $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+    if ($omittedDetailCount -gt 0) {
+      $lines.Add(('  - +{0} more details in report' -f $omittedDetailCount)) | Out-Null
+    }
+  }
+  $omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+  if ($omittedGroupCount -gt 0) {
+    $lines.Add(('- Additional change-detail groups omitted: `{0}`' -f $omittedGroupCount)) | Out-Null
+  }
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+  if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $lines.Add(('- Report: [{0}]({0})' -f $reportHtmlRelativePath)) | Out-Null
+  }
+  $lines.Add('') | Out-Null
+  return @($lines | ForEach-Object { $_ })
+}
+
+function New-HtmlChangeDetailsBlock {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return ''
+  }
+
+  $items = New-Object System.Collections.Generic.List[string]
+  $includedCategories = @(
+    ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
+      ForEach-Object { Get-OptionalString -Value $_ } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  if ($includedCategories.Count -gt 0) {
+    $items.Add('<li><strong>Included categories:</strong> ' + (Escape-Html ($includedCategories -join ', ')) + '</li>') | Out-Null
+  }
+  foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $heading = Escape-Html (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading')))
+    $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+    $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+    $sampleList = New-Object System.Collections.Generic.List[string]
+    foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+      $sampleList.Add('<li>' + (Escape-Html ([string]$sampleDetail)) + '</li>') | Out-Null
+    }
+    $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+    if ($omittedDetailCount -gt 0) {
+      $sampleList.Add('<li>+' + $omittedDetailCount + ' more details in report</li>') | Out-Null
+    }
+    $nestedList = if ($sampleList.Count -gt 0) { '<ul>' + ($sampleList -join '') + '</ul>' } else { '' }
+    $items.Add('<li><strong>' + $heading + ':</strong> ' + $detailCount + ' details across ' + $sectionCount + ' sections' + $nestedList + '</li>') | Out-Null
+  }
+  $omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+  if ($omittedGroupCount -gt 0) {
+    $items.Add('<li><strong>Additional change-detail groups omitted:</strong> ' + $omittedGroupCount + '</li>') | Out-Null
+  }
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+  if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $items.Add('<li><a href="' + (Escape-Html $reportHtmlRelativePath) + '">open change details report</a></li>') | Out-Null
+  }
+
+  return '<section class="preview-change-details"><h4>Change details</h4><ul>' + ($items -join '') + '</ul></section>'
+}
+
 function New-ReviewerPreviewSurface {
   param(
     [Parameter(Mandatory = $true)]
@@ -441,6 +535,9 @@ function New-MarkdownPreviewGallery {
     if ($detailLines.Count -gt 0) {
       $lines.Add('') | Out-Null
     }
+    foreach ($changeDetailLine in @(New-MarkdownChangeDetailsLines -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails')))) {
+      $lines.Add($changeDetailLine) | Out-Null
+    }
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
       $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
       $lines.Add(('#### {0}' -f $surfaceLabel)) | Out-Null
@@ -490,6 +587,7 @@ function New-HtmlPreviewGallery {
     } else {
       '<div class="preview-card-history">' + (($detailLines | ForEach-Object { '<p>' + (Escape-Html $_) + '</p>' }) -join '') + '</div>'
     }
+    $changeDetailsHtml = New-HtmlChangeDetailsBlock -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails'))
     $surfaceBlocks = New-Object System.Collections.Generic.List[string]
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
       $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
@@ -524,6 +622,7 @@ function New-HtmlPreviewGallery {
     <strong>Revisions</strong><span><code>$(Escape-Html $revisionContext)</code></span>
   </div>
   $detailHtml
+  $changeDetailsHtml
   $($surfaceBlocks -join "`n  ")
 </article>
 "@) | Out-Null

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -24,6 +24,9 @@ $sectionKindOrder = @{
   'detail' = 1
 }
 
+$reviewerChangeDetailGroupCap = 3
+$reviewerChangeDetailSampleCap = 3
+
 function Write-ActionOutput {
   param(
     [Parameter(Mandatory = $true)]
@@ -436,6 +439,162 @@ function Get-ReviewerPreviewSurfaceLabel {
   }
 }
 
+function Normalize-ReviewerChangeDetailHeading {
+  param(
+    [AllowNull()]
+    [string]$Heading
+  )
+
+  $normalizedHeading = Get-OptionalString -Value $Heading
+  if ([string]::IsNullOrWhiteSpace($normalizedHeading)) {
+    return $null
+  }
+
+  return (($normalizedHeading -replace '^\d+\.\s*', '').Trim())
+}
+
+function Get-ReportIncludedCategories {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportHtml
+  )
+
+  $includedCategories = New-Object System.Collections.Generic.List[string]
+  $includedBlockMatch = [regex]::Match($ReportHtml, '(?is)<div class="included-attributes".*?<ul[^>]*>(?<list>.*?)</ul>')
+  if (-not $includedBlockMatch.Success) {
+    return @()
+  }
+
+  foreach ($itemMatch in [regex]::Matches([string]$includedBlockMatch.Groups['list'].Value, '(?is)<li class="checked">(?<item>.*?)</li>')) {
+    $itemText = ConvertFrom-HtmlText -Value ([string]$itemMatch.Groups['item'].Value)
+    if ([string]::IsNullOrWhiteSpace($itemText)) {
+      continue
+    }
+
+    $includedCategories.Add($itemText) | Out-Null
+  }
+
+  return @($includedCategories | ForEach-Object { $_ })
+}
+
+function Get-ReviewerChangeDetailsFromReport {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportHtmlPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$TargetId,
+    [Parameter(Mandatory = $true)]
+    [string]$TargetPath,
+    [Parameter(Mandatory = $true)]
+    [object]$Comparison,
+    [AllowNull()]
+    [string]$RepositoryRoot
+  )
+
+  if (-not (Test-Path -LiteralPath $ReportHtmlPath -PathType Leaf)) {
+    return $null
+  }
+
+  $reportHtml = Get-Content -LiteralPath $ReportHtmlPath -Raw
+  if ([string]::IsNullOrWhiteSpace($reportHtml)) {
+    return $null
+  }
+
+  $includedCategories = @(Get-ReportIncludedCategories -ReportHtml $reportHtml)
+  $groupMap = @{}
+  $groupOrder = New-Object System.Collections.Generic.List[string]
+  $detailPattern = '(?is)<details[^>]*>\s*<summary[^>]*>(?<summary>.*?)</summary>(?<body>.*?)</details>'
+  foreach ($detailMatch in [regex]::Matches($reportHtml, $detailPattern)) {
+    $bodyHtml = [string]$detailMatch.Groups['body'].Value
+    if ($bodyHtml -notmatch 'detailed-description-list') {
+      continue
+    }
+
+    $heading = Normalize-ReviewerChangeDetailHeading -Heading (ConvertFrom-HtmlText -Value ([string]$detailMatch.Groups['summary'].Value))
+    if ([string]::IsNullOrWhiteSpace($heading)) {
+      $heading = 'Change details'
+    }
+
+    $detailLines = @(
+      [regex]::Matches($bodyHtml, '(?is)<li class="[^"]*diff-detail[^"]*">(?<detail>.*?)</li>') |
+        ForEach-Object { ConvertFrom-HtmlText -Value ([string]$_.Groups['detail'].Value) } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($detailLines.Count -eq 0) {
+      continue
+    }
+
+    if (-not $groupMap.ContainsKey($heading)) {
+      $groupMap[$heading] = [ordered]@{
+        heading = $heading
+        sectionCount = 0
+        detailCount = 0
+        sampleDetails = New-Object System.Collections.Generic.List[string]
+      }
+      $groupOrder.Add($heading) | Out-Null
+    }
+
+    $groupRecord = $groupMap[$heading]
+    $groupRecord.sectionCount = [int]$groupRecord.sectionCount + 1
+    $groupRecord.detailCount = [int]$groupRecord.detailCount + $detailLines.Count
+    foreach ($detailLine in $detailLines) {
+      if ($groupRecord.sampleDetails.Count -ge $reviewerChangeDetailSampleCap) {
+        continue
+      }
+
+      $groupRecord.sampleDetails.Add($detailLine) | Out-Null
+    }
+  }
+
+  if ($groupOrder.Count -eq 0 -and $includedCategories.Count -eq 0) {
+    return $null
+  }
+
+  $groupItems = New-Object System.Collections.Generic.List[object]
+  $sectionCount = 0
+  $detailCount = 0
+  foreach ($heading in @($groupOrder | Select-Object -First $reviewerChangeDetailGroupCap)) {
+    $groupRecord = $groupMap[$heading]
+    $sectionCount += [int]$groupRecord.sectionCount
+    $detailCount += [int]$groupRecord.detailCount
+    $sampleDetails = @($groupRecord.sampleDetails | ForEach-Object { $_ })
+    $groupItems.Add([ordered]@{
+        heading = [string]$groupRecord.heading
+        sectionCount = [int]$groupRecord.sectionCount
+        detailCount = [int]$groupRecord.detailCount
+        sampleDetails = $sampleDetails
+        omittedDetailCount = [Math]::Max([int]$groupRecord.detailCount - $sampleDetails.Count, 0)
+      }) | Out-Null
+  }
+
+  foreach ($heading in @($groupOrder | Select-Object -Skip $reviewerChangeDetailGroupCap)) {
+    $groupRecord = $groupMap[$heading]
+    $sectionCount += [int]$groupRecord.sectionCount
+    $detailCount += [int]$groupRecord.detailCount
+  }
+
+  $comparisonReceipt = New-PreviewPairComparison -Comparison $Comparison -RepositoryRoot $RepositoryRoot
+  return [ordered]@{
+    targetId = $TargetId
+    targetPath = $TargetPath
+    comparison = $comparisonReceipt
+    sortKey = '{0}|{1:D4}|change-details' -f $TargetPath, [int]$comparisonReceipt.index
+    changeDetails = [ordered]@{
+      label = 'Change details'
+      sourceMode = 'attributes'
+      reportHtmlRelativePath = Resolve-RelativePath -Path $ReportHtmlPath -ResultsRoot $ResultsRoot
+      includedCategories = $includedCategories
+      groupCount = $groupOrder.Count
+      omittedGroupCount = [Math]::Max($groupOrder.Count - $groupItems.Count, 0)
+      sectionCount = $sectionCount
+      detailCount = $detailCount
+      groups = @($groupItems | ForEach-Object { $_ })
+    }
+  }
+}
+
 function New-PreviewSurfaceCandidate {
   param(
     [Parameter(Mandatory = $true)]
@@ -622,7 +781,9 @@ function New-ReviewerPreviewCards {
     [Parameter(Mandatory = $true)]
     [object[]]$SelectedPreviewPairs,
     [AllowEmptyCollection()]
-    [object[]]$AllPreviewPairs = @()
+    [object[]]$AllPreviewPairs = @(),
+    [AllowEmptyCollection()]
+    [object[]]$AllChangeDetails = @()
   )
 
   $orderedAllPreviewPairs = @(ConvertTo-PreviewPairArray -Value $AllPreviewPairs)
@@ -632,6 +793,13 @@ function New-ReviewerPreviewCards {
 
   $cards = New-Object System.Collections.Generic.List[object]
   $seenCards = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $changeDetailsByCardKey = @{}
+  foreach ($changeDetailRecord in @(ConvertTo-ObjectArray -Value $AllChangeDetails)) {
+    $changeDetailKey = '{0}|{1}' -f `
+      [string]$changeDetailRecord.targetId, `
+      [int](Get-NestedValue -Object $changeDetailRecord -Path @('comparison', 'index') -Default 0)
+    $changeDetailsByCardKey[$changeDetailKey] = Get-NestedValue -Object $changeDetailRecord -Path @('changeDetails')
+  }
   foreach ($selectedPreviewPair in @(ConvertTo-PreviewPairArray -Value $SelectedPreviewPairs)) {
     $cardKey = Get-ReviewerPreviewCardKey -PreviewPair $selectedPreviewPair
     if (-not $seenCards.Add($cardKey)) {
@@ -673,6 +841,7 @@ function New-ReviewerPreviewCards {
         comparison = $selectedPreviewPair.comparison
         sortKey = Get-OptionalString -Value $selectedPreviewPair.sortKey
         surfaces = @($surfaces | ForEach-Object { $_ })
+        changeDetails = Get-NestedValue -Object $changeDetailsByCardKey -Path @($cardKey)
       }) | Out-Null
   }
 
@@ -786,6 +955,7 @@ if ([string]$targetRunsManifest.schema -ne 'comparevi-history/pr-target-runs-man
 }
 
 $allPreviewPairs = New-Object System.Collections.Generic.List[object]
+$allChangeDetails = New-Object System.Collections.Generic.List[object]
 $targetReceipts = New-Object System.Collections.Generic.List[object]
 
 foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets)) {
@@ -811,6 +981,13 @@ foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets))
           continue
         }
 
+        if ($modeName -eq 'attributes') {
+          $changeDetailsRecord = Get-ReviewerChangeDetailsFromReport -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Comparison $comparison -RepositoryRoot $targetRepositoryRoot
+          if ($null -ne $changeDetailsRecord) {
+            $allChangeDetails.Add($changeDetailsRecord) | Out-Null
+          }
+        }
+
         foreach ($previewPair in @(Get-ReportPreviewPairs -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Mode $modeName -Comparison $comparison -RepositoryRoot $targetRepositoryRoot)) {
           $targetPreviewPairs.Add($previewPair) | Out-Null
           $allPreviewPairs.Add($previewPair) | Out-Null
@@ -833,9 +1010,10 @@ $orderedPreviewPairs = @(ConvertTo-PreviewPairArray -Value $allPreviewPairs)
 $reviewerPreviewPairs = @(Get-ReviewerPreviewPairArray -Value $orderedPreviewPairs)
 $commentPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $CommentPreviewPairCap)
 $indexPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $IndexPreviewPairCap)
-$reviewerPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $reviewerPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
-$commentPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $commentPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
-$indexPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $indexPreviewPairs -AllPreviewPairs $orderedPreviewPairs)
+$allChangeDetailRecords = @($allChangeDetails | ForEach-Object { $_ })
+$reviewerPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $reviewerPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
+$commentPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $commentPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
+$indexPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $indexPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
 $targetReceiptArray = @($targetReceipts | ForEach-Object { $_ })
 $orderedPreviewPairArray = @($orderedPreviewPairs | ForEach-Object { $_ })
 $commentPreviewPairArray = @($commentPreviewPairs | ForEach-Object { $_ })


### PR DESCRIPTION
## Summary
- surface reviewer-facing change details from attributes reports in PR preview cards
- carry those change details through the aggregate run and sticky comment publication receipts
- cover the new reviewer detail blocks in preview manifest, aggregate run, and comment publication tests

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

Closes #136.