### PR TITLE
#140 Add semantic change-detail grouping and deep links

### DIFF
--- a/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
@@ -181,7 +181,9 @@
                         "sectionCount",
                         "detailCount",
                         "sampleDetails",
-                        "omittedDetailCount"
+                        "omittedDetailCount",
+                        "primaryReportHtmlRelativePath",
+                        "sectionLinks"
                       ],
                       "properties": {
                         "heading": { "type": "string", "minLength": 1 },
@@ -191,7 +193,25 @@
                           "type": "array",
                           "items": { "type": "string", "minLength": 1 }
                         },
-                        "omittedDetailCount": { "type": "integer", "minimum": 0 }
+                        "omittedDetailCount": { "type": "integer", "minimum": 0 },
+                        "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+                        "sectionLinks": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "sectionOrdinal",
+                              "label",
+                              "reportHtmlRelativePath"
+                            ],
+                            "properties": {
+                              "sectionOrdinal": { "type": "integer", "minimum": 0 },
+                              "label": { "type": "string", "minLength": 1 },
+                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
+                            }
+                          }
+                        }
                       }
                     }
                   }

--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -229,7 +229,9 @@
         "sectionCount",
         "detailCount",
         "sampleDetails",
-        "omittedDetailCount"
+        "omittedDetailCount",
+        "primaryReportHtmlRelativePath",
+        "sectionLinks"
       ],
       "properties": {
         "heading": { "type": "string", "minLength": 1 },
@@ -239,7 +241,26 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         },
-        "omittedDetailCount": { "type": "integer", "minimum": 0 }
+        "omittedDetailCount": { "type": "integer", "minimum": 0 },
+        "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+        "sectionLinks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailSectionLink" }
+        }
+      }
+    },
+    "changeDetailSectionLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sectionOrdinal",
+        "label",
+        "reportHtmlRelativePath"
+      ],
+      "properties": {
+        "sectionOrdinal": { "type": "integer", "minimum": 0 },
+        "label": { "type": "string", "minLength": 1 },
+        "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
       }
     },
     "changeDetails": {

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -371,8 +371,15 @@ function New-CommentChangeDetailsMarkdown {
     $lines.Add(('<li><strong>Included categories:</strong> {0}</li>' -f (ConvertTo-HtmlText ($includedCategories -join ', ')))) | Out-Null
   }
   foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $headingText = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $headingMarkup = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+      ConvertTo-HtmlText $headingText
+    } else {
+      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $primaryReportHtmlRelativePath), (ConvertTo-HtmlText $headingText)
+    }
     $lines.Add(('<li><strong>{0}:</strong> {1} details across {2} sections' -f `
-          (ConvertTo-HtmlText (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading')))), `
+          $headingMarkup, `
           [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0), `
           [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0))) | Out-Null
     $lines.Add('<ul>') | Out-Null
@@ -382,6 +389,22 @@ function New-CommentChangeDetailsMarkdown {
     $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
     if ($omittedDetailCount -gt 0) {
       $lines.Add(('<li>+{0} more details in report</li>' -f $omittedDetailCount)) | Out-Null
+    }
+    $sectionLinks = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
+        ForEach-Object {
+          $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
+          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
+            return $null
+          }
+
+          '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $path), (ConvertTo-HtmlText $label)
+        } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($sectionLinks.Count -gt 0) {
+      $lines.Add(('<li><strong>Exact sections:</strong> {0}</li>' -f ($sectionLinks -join ', '))) | Out-Null
     }
     $lines.Add('</ul>') | Out-Null
     $lines.Add('</li>') | Out-Null

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -62,7 +62,8 @@ $(if ($ComparisonIndex -eq 1) {
 <details open>
 <summary class="difference-heading">2. Block Diagram objects</summary>
 <ol class="detailed-description-list" type="A">
-<li class="diff-detail">Boolean Constant - moved : changed from "(675,231)" to "(675,231)"</li>
+<li class="diff-detail">Case Structure - resized : changed from "702*298" to "702*370"</li>
+<li class="diff-detail"> - resized : changed from "690*23" to "690*25"</li>
 </ol>
 </details>
 '@
@@ -517,9 +518,10 @@ try {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Change details')).Count -ne 2 -or
-    $indexMarkdown -notmatch [regex]::Escape('`Block Diagram objects`: `4` details across `2` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('+1 more details in report') -or
-    $indexMarkdown -notmatch [regex]::Escape('`VI Attribute - Miscellaneous`: `1` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram moves`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects): `3` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects): `2` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('Exact sections: [section 1](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects)') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`VI version changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous): `1` details across `1` sections') -or
     $indexMarkdown -notmatch [regex]::Escape('Included categories: `Block Diagram Functional`, `VI Attribute`')) {
     throw 'Index markdown should render bounded change-detail summaries from the attributes compare report.'
   }
@@ -558,9 +560,10 @@ try {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Change details</h4>')).Count -ne 2 -or
-    $indexHtml -notmatch [regex]::Escape('Block Diagram objects') -or
-    $indexHtml -notmatch [regex]::Escape('+1 more details in report') -or
-    $indexHtml -notmatch [regex]::Escape('VI Attribute - Miscellaneous') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
     $indexHtml -notmatch [regex]::Escape('open change details report')) {
     throw 'Index HTML should render bounded change-detail summaries from the attributes compare report.'
   }
@@ -590,9 +593,14 @@ try {
     throw 'Preview manifest summary mismatch.'
   }
   if ([string]$previewManifest.indexPreviewCards[0].changeDetails.label -ne 'Change details' -or
-    [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
-    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous') {
+    [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
+    [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[1].heading -ne 'Block diagram resizing' -or
+    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview manifest should carry reviewer-facing change-detail summaries into the aggregate PR run.'
+  }
+  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
+    throw 'Preview manifest should carry exact attribute-section links into the aggregate PR run.'
   }
   if ($previewManifest.indexPreviewCards.Count -ne 2 -or
     (@($previewManifest.indexPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -67,15 +67,15 @@ function New-PreviewCard {
       sourceMode = 'attributes'
       reportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html' -f $ComparisonIndex)
       includedCategories = $(if ($ComparisonIndex -eq 1) { @('Block Diagram Functional', 'VI Attribute') } else { @('VI Attribute') })
-      groupCount = 1
+      groupCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
       omittedGroupCount = 0
       sectionCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
-      detailCount = $(if ($ComparisonIndex -eq 1) { 4 } else { 1 })
+      detailCount = $(if ($ComparisonIndex -eq 1) { 5 } else { 1 })
       groups = @(
         [ordered]@{
-          heading = $(if ($ComparisonIndex -eq 1) { 'Block Diagram objects' } else { 'VI Attribute - Miscellaneous' })
-          sectionCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
-          detailCount = $(if ($ComparisonIndex -eq 1) { 4 } else { 1 })
+          heading = $(if ($ComparisonIndex -eq 1) { 'Block diagram moves' } else { 'VI version changes' })
+          sectionCount = 1
+          detailCount = $(if ($ComparisonIndex -eq 1) { 3 } else { 1 })
           sampleDetails = $(if ($ComparisonIndex -eq 1) {
               @(
                 'Property Node - moved : changed from "(-35,102)" to "(-55,77)"',
@@ -85,8 +85,37 @@ function New-PreviewCard {
             } else {
               @('VI Version : changed from "21.0" to "20.0"')
             })
-          omittedDetailCount = $(if ($ComparisonIndex -eq 1) { 1 } else { 0 })
+          omittedDetailCount = 0
+          primaryReportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html#comparevi-change-001-{1}' -f $ComparisonIndex, $(if ($ComparisonIndex -eq 1) { 'block-diagram-objects' } else { 'vi-attribute-miscellaneous' }))
+          sectionLinks = @(
+            [ordered]@{
+              sectionOrdinal = 1
+              label = 'section 1'
+              reportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html#comparevi-change-001-{1}' -f $ComparisonIndex, $(if ($ComparisonIndex -eq 1) { 'block-diagram-objects' } else { 'vi-attribute-miscellaneous' }))
+            }
+          )
         }
+        $(if ($ComparisonIndex -eq 1) {
+            ,
+            [ordered]@{
+              heading = 'Block diagram resizing'
+              sectionCount = 1
+              detailCount = 2
+              sampleDetails = @(
+                'Case Structure - resized : changed from "702*298" to "702*370"',
+                ' - resized : changed from "690*23" to "690*25"'
+              )
+              omittedDetailCount = 0
+              primaryReportHtmlRelativePath = 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects'
+              sectionLinks = @(
+                [ordered]@{
+                  sectionOrdinal = 2
+                  label = 'section 2'
+                  reportHtmlRelativePath = 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects'
+                }
+              )
+            }
+          })
       )
     }
     surfaces = @(
@@ -467,9 +496,10 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     throw 'Created PR comment body should render both front-panel and block-diagram surfaces for each history pair.'
   }
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Change details</strong></p>')).Count -ne 2 -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('Block Diagram objects') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('+1 more details in report') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Attribute - Miscellaneous') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Version : changed from &quot;21.0&quot; to &quot;20.0&quot;') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('open change details report')) {
     throw 'Created PR comment body should render bounded change-detail summaries from the attributes compare report.'
@@ -503,9 +533,14 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous') {
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[1].heading -ne 'Block diagram resizing' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview publication should retain reviewer-facing change-detail summaries.'
+  }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
+    throw 'Preview publication should retain exact section links for reviewer change details.'
   }
 
   $writeOrder = @(

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -60,7 +60,8 @@ $(if ($ComparisonIndex -eq 1) {
 <details open>
 <summary class="difference-heading">2. Block Diagram objects</summary>
 <ol class="detailed-description-list" type="A">
-<li class="diff-detail">Boolean Constant - moved : changed from "(675,231)" to "(675,231)"</li>
+<li class="diff-detail">Case Structure - resized : changed from "702*298" to "702*370"</li>
+<li class="diff-detail"> - resized : changed from "690*23" to "690*25"</li>
 </ol>
 </details>
 '@
@@ -273,19 +274,36 @@ try {
   if ((@($receipt.commentPreviewCards[0].changeDetails.includedCategories) -join ',') -ne 'Block Diagram Functional,VI Attribute') {
     throw 'Reviewer cards should preserve included categories from the attributes compare report.'
   }
-  if ([string]$receipt.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block Diagram objects' -or
-    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].detailCount -ne 4 -or
-    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionCount -ne 2 -or
-    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].omittedDetailCount -ne 1) {
-    throw 'Reviewer cards should aggregate repeated attributes-report sections into a bounded change-detail summary.'
+  if ([string]$receipt.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].detailCount -ne 3 -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionCount -ne 1 -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[0].omittedDetailCount -ne 0) {
+    throw 'Reviewer cards should split coarse block diagram sections into semantic move groups.'
   }
   if ($receipt.commentPreviewCards[0].changeDetails.groups[0].sampleDetails.Count -ne 3 -or
     $receipt.commentPreviewCards[0].changeDetails.groups[0].sampleDetails[0] -notmatch 'Property Node - moved') {
     throw 'Reviewer cards should preserve the first bounded change-detail samples.'
   }
-  if ([string]$receipt.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI Attribute - Miscellaneous' -or
+  if ([string]$receipt.commentPreviewCards[0].changeDetails.groups[1].heading -ne 'Block diagram resizing' -or
+    [int]$receipt.commentPreviewCards[0].changeDetails.groups[1].detailCount -ne 2 -or
+    [string]$receipt.commentPreviewCards[0].changeDetails.groups[1].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects') {
+    throw 'Reviewer cards should surface semantic resize groups with exact section anchors.'
+  }
+  if ($receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks.Count -ne 1 -or
+    [string]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].label -ne 'section 1') {
+    throw 'Reviewer cards should expose exact section links for semantic groups.'
+  }
+  if ([string]$receipt.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes' -or
+    [string]$receipt.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous' -or
     $receipt.commentPreviewCards[1].changeDetails.groups[0].sampleDetails[0] -notmatch 'VI Version : changed from "21\.0" to "20\.0"') {
     throw 'Reviewer cards should preserve distinct VI attribute change summaries for later history pairs.'
+  }
+
+  $anchoredReportHtml = Get-Content -LiteralPath (Join-Path $targetRoot 'attributes/Demo.vi-001-artifacts/compare-report.html') -Raw
+  if ($anchoredReportHtml -notmatch [regex]::Escape('id="comparevi-change-001-block-diagram-objects"') -or
+    $anchoredReportHtml -notmatch [regex]::Escape('id="comparevi-change-002-block-diagram-objects"')) {
+    throw 'Attributes compare reports should be stamped with deterministic section anchors for reviewer deep links.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -303,6 +303,60 @@ function Get-ReviewerPreviewSurfaceLabel {
   }
 }
 
+function New-MarkdownChangeDetailSectionLinkLine {
+  param(
+    [AllowNull()]
+    [object[]]$SectionLinks = @()
+  )
+
+  $sectionLinkItems = @(
+    ConvertTo-ObjectArray -Value $SectionLinks |
+      ForEach-Object {
+        $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
+        $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+        if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
+          return $null
+        }
+
+        '[{0}]({1})' -f $label, $path
+      } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  if ($sectionLinkItems.Count -eq 0) {
+    return $null
+  }
+
+  return '  - Exact sections: {0}' -f ($sectionLinkItems -join ', ')
+}
+
+function New-HtmlChangeDetailSectionLinks {
+  param(
+    [AllowNull()]
+    [object[]]$SectionLinks = @()
+  )
+
+  $linkItems = @(
+    ConvertTo-ObjectArray -Value $SectionLinks |
+      ForEach-Object {
+        $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
+        $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+        if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
+          return $null
+        }
+
+        '<a href="' + (Escape-Html $path) + '">' + (Escape-Html $label) + '</a>'
+      } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  if ($linkItems.Count -eq 0) {
+    return ''
+  }
+
+  return '<li><strong>Exact sections:</strong> ' + ($linkItems -join ', ') + '</li>'
+}
+
 function New-MarkdownChangeDetailsLines {
   param(
     [AllowNull()]
@@ -328,15 +382,25 @@ function New-MarkdownChangeDetailsLines {
   }
   foreach ($group in $groups) {
     $heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
     $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
     $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
-    $lines.Add(('- `{0}`: `{1}` details across `{2}` sections' -f $heading, $detailCount, $sectionCount)) | Out-Null
+    $headingLabel = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+      ('`{0}`' -f $heading)
+    } else {
+      ('[`{0}`]({1})' -f $heading, $primaryReportHtmlRelativePath)
+    }
+    $lines.Add(('- {0}: `{1}` details across `{2}` sections' -f $headingLabel, $detailCount, $sectionCount)) | Out-Null
     foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
       $lines.Add(('  - {0}' -f [string]$sampleDetail)) | Out-Null
     }
     $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
     if ($omittedDetailCount -gt 0) {
       $lines.Add(('  - +{0} more details in report' -f $omittedDetailCount)) | Out-Null
+    }
+    $sectionLinkLine = New-MarkdownChangeDetailSectionLinkLine -SectionLinks @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()))
+    if (-not [string]::IsNullOrWhiteSpace($sectionLinkLine)) {
+      $lines.Add($sectionLinkLine) | Out-Null
     }
   }
   $omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
@@ -371,7 +435,13 @@ function New-HtmlChangeDetailsBlock {
     $items.Add('<li><strong>Included categories:</strong> ' + (Escape-Html ($includedCategories -join ', ')) + '</li>') | Out-Null
   }
   foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
-    $heading = Escape-Html (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading')))
+    $headingText = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $heading = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+      Escape-Html $headingText
+    } else {
+      '<a href="' + (Escape-Html $primaryReportHtmlRelativePath) + '">' + (Escape-Html $headingText) + '</a>'
+    }
     $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
     $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
     $sampleList = New-Object System.Collections.Generic.List[string]
@@ -381,6 +451,10 @@ function New-HtmlChangeDetailsBlock {
     $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
     if ($omittedDetailCount -gt 0) {
       $sampleList.Add('<li>+' + $omittedDetailCount + ' more details in report</li>') | Out-Null
+    }
+    $sectionLinksHtml = New-HtmlChangeDetailSectionLinks -SectionLinks @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()))
+    if (-not [string]::IsNullOrWhiteSpace($sectionLinksHtml)) {
+      $sampleList.Add($sectionLinksHtml) | Out-Null
     }
     $nestedList = if ($sampleList.Count -gt 0) { '<ul>' + ($sampleList -join '') + '</ul>' } else { '' }
     $items.Add('<li><strong>' + $heading + ':</strong> ' + $detailCount + ' details across ' + $sectionCount + ' sections' + $nestedList + '</li>') | Out-Null

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -453,6 +453,242 @@ function Normalize-ReviewerChangeDetailHeading {
   return (($normalizedHeading -replace '^\d+\.\s*', '').Trim())
 }
 
+function Get-ReviewerChangeDetailSectionOrdinal {
+  param(
+    [AllowNull()]
+    [string]$Heading
+  )
+
+  $normalizedHeading = Get-OptionalString -Value $Heading
+  if ([string]::IsNullOrWhiteSpace($normalizedHeading)) {
+    return $null
+  }
+
+  $ordinalMatch = [regex]::Match($normalizedHeading, '^\s*(?<ordinal>\d+)\.')
+  if (-not $ordinalMatch.Success) {
+    return $null
+  }
+
+  return [int]$ordinalMatch.Groups['ordinal'].Value
+}
+
+function Get-ReviewerChangeDetailLineParts {
+  param(
+    [AllowNull()]
+    [string]$DetailLine
+  )
+
+  $normalizedDetailLine = Get-OptionalString -Value $DetailLine
+  if ([string]::IsNullOrWhiteSpace($normalizedDetailLine)) {
+    return [ordered]@{
+      subject = $null
+      action = $null
+    }
+  }
+
+  $prefix = $normalizedDetailLine
+  $colonIndex = $prefix.IndexOf(':')
+  if ($colonIndex -ge 0) {
+    $prefix = $prefix.Substring(0, $colonIndex)
+  }
+
+  $prefix = ($prefix -replace '\s+', ' ').Trim()
+  if ([string]::IsNullOrWhiteSpace($prefix)) {
+    return [ordered]@{
+      subject = $null
+      action = $null
+    }
+  }
+
+  $subject = $prefix
+  $action = $null
+  $actionMatch = [regex]::Match($prefix, '^(?<subject>.*?)\s*-\s*(?<action>[^-].+?)$')
+  if ($actionMatch.Success) {
+    $subject = ($actionMatch.Groups['subject'].Value -replace '\s+', ' ').Trim()
+    $action = ($actionMatch.Groups['action'].Value -replace '\s+', ' ').Trim()
+  }
+
+  if ([string]::IsNullOrWhiteSpace($subject)) {
+    $subject = $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($action)) {
+    $action = $null
+  }
+
+  return [ordered]@{
+    subject = $subject
+    action = $action
+  }
+}
+
+function Get-ReviewerSemanticHeadingFromSection {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SectionHeading,
+    [AllowNull()]
+    [string]$DetailLine
+  )
+
+  $normalizedHeading = Normalize-ReviewerChangeDetailHeading -Heading $SectionHeading
+  if ([string]::IsNullOrWhiteSpace($normalizedHeading)) {
+    return 'Change details'
+  }
+
+  $detailParts = Get-ReviewerChangeDetailLineParts -DetailLine $DetailLine
+  $subject = Get-OptionalString -Value $detailParts.subject
+  $action = (Get-OptionalString -Value $detailParts.action)
+  if (-not [string]::IsNullOrWhiteSpace($action)) {
+    $action = $action.ToLowerInvariant()
+  }
+
+  switch -Regex ($normalizedHeading) {
+    '^Block Diagram objects$' {
+      switch ($action) {
+        'moved' { return 'Block diagram moves' }
+        'resized' { return 'Block diagram resizing' }
+        'deleted' { return 'Removed block diagram objects' }
+        'added' { return 'Added block diagram objects' }
+        default { return 'Block diagram object changes' }
+      }
+    }
+    '^Front Panel objects$' {
+      switch ($action) {
+        'moved' { return 'Front panel layout moves' }
+        'resized' { return 'Front panel resizing' }
+        'deleted' { return 'Removed front panel objects' }
+        'added' { return 'Added front panel objects' }
+        default { return 'Front panel object changes' }
+      }
+    }
+    '^VI Attribute\b' {
+      if ($subject -match '^VI Version$') {
+        return 'VI version changes'
+      }
+
+      if ($subject -match '^Execution\b') {
+        return 'Execution changes'
+      }
+
+      if ($subject -match '^Icon\b') {
+        return 'Icon changes'
+      }
+
+      return 'VI attribute changes'
+    }
+    default {
+      return $normalizedHeading
+    }
+  }
+}
+
+function Get-ReviewerChangeDetailSectionsFromReport {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportHtmlPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
+  )
+
+  if (-not (Test-Path -LiteralPath $ReportHtmlPath -PathType Leaf)) {
+    return [ordered]@{
+      reportHtml = $null
+      sections = @()
+    }
+  }
+
+  $reportHtml = Get-Content -LiteralPath $ReportHtmlPath -Raw
+  if ([string]::IsNullOrWhiteSpace($reportHtml)) {
+    return [ordered]@{
+      reportHtml = $reportHtml
+      sections = @()
+    }
+  }
+
+  $sections = New-Object System.Collections.Generic.List[object]
+  $detailPattern = '(?is)(?<open><details(?<detailsAttributes>[^>]*)>)\s*<summary(?<summaryAttributes>[^>]*)>(?<summary>.*?)</summary>(?<body>.*?)</details>'
+  $matches = [regex]::Matches($reportHtml, $detailPattern)
+  if ($matches.Count -eq 0) {
+    return [ordered]@{
+      reportHtml = $reportHtml
+      sections = @()
+    }
+  }
+
+  $builder = New-Object System.Text.StringBuilder
+  $cursor = 0
+  $sectionIndex = 0
+  $htmlChanged = $false
+
+  foreach ($match in $matches) {
+    $null = $builder.Append($reportHtml.Substring($cursor, $match.Index - $cursor))
+
+    $blockHtml = [string]$match.Value
+    $bodyHtml = [string]$match.Groups['body'].Value
+    if ($bodyHtml -match 'detailed-description-list') {
+      $sectionIndex += 1
+      $summaryText = ConvertFrom-HtmlText -Value ([string]$match.Groups['summary'].Value)
+      $heading = Normalize-ReviewerChangeDetailHeading -Heading $summaryText
+      if ([string]::IsNullOrWhiteSpace($heading)) {
+        $heading = 'Change details'
+      }
+
+      $sectionOrdinal = Get-ReviewerChangeDetailSectionOrdinal -Heading $summaryText
+      if ($null -eq $sectionOrdinal) {
+        $sectionOrdinal = $sectionIndex
+      }
+
+      $existingIdMatch = [regex]::Match([string]$match.Groups['detailsAttributes'].Value, '\bid="(?<id>[^"]+)"')
+      $anchorId = Get-OptionalString -Value $existingIdMatch.Groups['id'].Value
+      if ([string]::IsNullOrWhiteSpace($anchorId)) {
+        $anchorId = 'comparevi-change-{0:D3}-{1}' -f $sectionOrdinal, (ConvertTo-Slug -Value $heading -Fallback 'change-detail')
+        $openTag = [string]$match.Groups['open'].Value
+        $updatedOpenTag = if ($openTag -match '\bid="[^"]+"') {
+          $openTag
+        } else {
+          $openTag.Insert($openTag.Length - 1, (' id="{0}"' -f $anchorId))
+        }
+        $blockHtml = $updatedOpenTag + $blockHtml.Substring($openTag.Length)
+        $htmlChanged = $true
+      }
+
+      $detailLines = @(
+        [regex]::Matches($bodyHtml, '(?is)<li class="[^"]*diff-detail[^"]*">(?<detail>.*?)</li>') |
+          ForEach-Object { ConvertFrom-HtmlText -Value ([string]$_.Groups['detail'].Value) } |
+          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+      )
+
+      if ($detailLines.Count -gt 0) {
+        $sections.Add([ordered]@{
+            index = $sectionIndex
+            ordinal = [int]$sectionOrdinal
+            heading = $heading
+            anchorId = $anchorId
+            reportHtmlRelativePath = ('{0}#{1}' -f (Resolve-RelativePath -Path $ReportHtmlPath -ResultsRoot $ResultsRoot), $anchorId)
+            detailLines = $detailLines
+          }) | Out-Null
+      }
+    }
+
+    $null = $builder.Append($blockHtml)
+    $cursor = $match.Index + $match.Length
+  }
+
+  if ($cursor -lt $reportHtml.Length) {
+    $null = $builder.Append($reportHtml.Substring($cursor))
+  }
+
+  $updatedReportHtml = $builder.ToString()
+  if ($htmlChanged -and -not [string]::Equals($updatedReportHtml, $reportHtml, [System.StringComparison]::Ordinal)) {
+    Set-Content -LiteralPath $ReportHtmlPath -Encoding utf8 -Value $updatedReportHtml
+  }
+
+  return [ordered]@{
+    reportHtml = $updatedReportHtml
+    sections = @($sections | ForEach-Object { $_ })
+  }
+}
+
 function Get-ReportIncludedCategories {
   param(
     [Parameter(Mandatory = $true)]
@@ -497,7 +733,8 @@ function Get-ReviewerChangeDetailsFromReport {
     return $null
   }
 
-  $reportHtml = Get-Content -LiteralPath $ReportHtmlPath -Raw
+  $sectionReceipt = Get-ReviewerChangeDetailSectionsFromReport -ReportHtmlPath $ReportHtmlPath -ResultsRoot $ResultsRoot
+  $reportHtml = [string](Get-NestedValue -Object $sectionReceipt -Path @('reportHtml') -Default '')
   if ([string]::IsNullOrWhiteSpace($reportHtml)) {
     return $null
   }
@@ -505,46 +742,40 @@ function Get-ReviewerChangeDetailsFromReport {
   $includedCategories = @(Get-ReportIncludedCategories -ReportHtml $reportHtml)
   $groupMap = @{}
   $groupOrder = New-Object System.Collections.Generic.List[string]
-  $detailPattern = '(?is)<details[^>]*>\s*<summary[^>]*>(?<summary>.*?)</summary>(?<body>.*?)</details>'
-  foreach ($detailMatch in [regex]::Matches($reportHtml, $detailPattern)) {
-    $bodyHtml = [string]$detailMatch.Groups['body'].Value
-    if ($bodyHtml -notmatch 'detailed-description-list') {
-      continue
+  foreach ($section in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $sectionReceipt -Path @('sections') -Default @()))) {
+    $sectionHeading = Get-OptionalString -Value (Get-NestedValue -Object $section -Path @('heading'))
+    $sectionOrdinal = [int](Get-NestedValue -Object $section -Path @('ordinal') -Default 0)
+    $sectionPath = Get-OptionalString -Value (Get-NestedValue -Object $section -Path @('reportHtmlRelativePath'))
+    $sectionLinkRecord = [ordered]@{
+      sectionOrdinal = $sectionOrdinal
+      label = ('section {0}' -f $sectionOrdinal)
+      reportHtmlRelativePath = $sectionPath
     }
 
-    $heading = Normalize-ReviewerChangeDetailHeading -Heading (ConvertFrom-HtmlText -Value ([string]$detailMatch.Groups['summary'].Value))
-    if ([string]::IsNullOrWhiteSpace($heading)) {
-      $heading = 'Change details'
-    }
-
-    $detailLines = @(
-      [regex]::Matches($bodyHtml, '(?is)<li class="[^"]*diff-detail[^"]*">(?<detail>.*?)</li>') |
-        ForEach-Object { ConvertFrom-HtmlText -Value ([string]$_.Groups['detail'].Value) } |
-        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
-    )
-    if ($detailLines.Count -eq 0) {
-      continue
-    }
-
-    if (-not $groupMap.ContainsKey($heading)) {
-      $groupMap[$heading] = [ordered]@{
-        heading = $heading
-        sectionCount = 0
-        detailCount = 0
-        sampleDetails = New-Object System.Collections.Generic.List[string]
-      }
-      $groupOrder.Add($heading) | Out-Null
-    }
-
-    $groupRecord = $groupMap[$heading]
-    $groupRecord.sectionCount = [int]$groupRecord.sectionCount + 1
-    $groupRecord.detailCount = [int]$groupRecord.detailCount + $detailLines.Count
-    foreach ($detailLine in $detailLines) {
-      if ($groupRecord.sampleDetails.Count -ge $reviewerChangeDetailSampleCap) {
-        continue
+    $sectionGroupKeys = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($detailLine in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $section -Path @('detailLines') -Default @()))) {
+      $semanticHeading = Get-ReviewerSemanticHeadingFromSection -SectionHeading $sectionHeading -DetailLine ([string]$detailLine)
+      if (-not $groupMap.ContainsKey($semanticHeading)) {
+        $groupMap[$semanticHeading] = [ordered]@{
+          heading = $semanticHeading
+          sectionCount = 0
+          detailCount = 0
+          sampleDetails = New-Object System.Collections.Generic.List[string]
+          sectionLinks = New-Object System.Collections.Generic.List[object]
+        }
+        $groupOrder.Add($semanticHeading) | Out-Null
       }
 
-      $groupRecord.sampleDetails.Add($detailLine) | Out-Null
+      $groupRecord = $groupMap[$semanticHeading]
+      if ($sectionGroupKeys.Add($semanticHeading)) {
+        $groupRecord.sectionCount = [int]$groupRecord.sectionCount + 1
+        $groupRecord.sectionLinks.Add($sectionLinkRecord) | Out-Null
+      }
+
+      $groupRecord.detailCount = [int]$groupRecord.detailCount + 1
+      if ($groupRecord.sampleDetails.Count -lt $reviewerChangeDetailSampleCap) {
+        $groupRecord.sampleDetails.Add([string]$detailLine) | Out-Null
+      }
     }
   }
 
@@ -566,6 +797,8 @@ function Get-ReviewerChangeDetailsFromReport {
         detailCount = [int]$groupRecord.detailCount
         sampleDetails = $sampleDetails
         omittedDetailCount = [Math]::Max([int]$groupRecord.detailCount - $sampleDetails.Count, 0)
+        primaryReportHtmlRelativePath = $(if ($groupRecord.sectionLinks.Count -gt 0) { Get-OptionalString -Value $groupRecord.sectionLinks[0].reportHtmlRelativePath } else { $null })
+        sectionLinks = @($groupRecord.sectionLinks | ForEach-Object { $_ })
       }) | Out-Null
   }
 


### PR DESCRIPTION
## Summary
- split large attribute-derived reviewer change details into semantic groups instead of only raw report headings
- stamp deterministic anchors into attributes compare reports and carry exact section links through the preview manifest and publication receipts
- render those deep links in the artifact index and sticky PR comment so reviewer cards land on exact report sections

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

Closes #140.