### PR TITLE
#142 Sync published templates for v1.3.20

### DIFF
--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -132,7 +132,7 @@ Consumer repositories should not contain:
   `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics-canary-evaluate.yml@v1`. It
   exists so a same-repo `workflow_run` can evaluate the publication artifact, confirm the PR is an `agent-canary`
   draft lane, and fail closed without re-running execution or checking out candidate PR code.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.19`. That is the right default when
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.20`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
 - The automatic changed-VI execution template keeps the checked-in PR policy and hosted NI Linux adapter on the pull

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -23,7 +23,7 @@ jobs:
       DEFAULT_COMPARE_MODES: attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.3.19
+      FACADE_REF: v1.3.20
       COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.19
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.20
         with:
           target_spec_path: .github/comparevi-history-targets.json
           target_id: ${{ steps.request.outputs['target-id'] }}
@@ -148,7 +148,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.19
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.20
           COMMENT_PATH: ${{ steps.history.outputs['public-comment-path'] }}
         run: |
           Set-StrictMode -Version Latest


### PR DESCRIPTION
## Summary
- sync the published comment-gated example to `v1.3.20`
- sync the safe PR diagnostics template docs to `v1.3.20`
- keep the backend ref pinned to `v0.6.3-tools.9`

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- pwsh -NoLogo -NoProfile -File scripts/Resolve-CompareVIHistoryReleasePublishReadiness.ps1 -BackendTag v0.6.3-tools.9 -ImmutableTag v1.3.20
- git diff --check

Closes #142.