### PR TITLE
#144 Avoid in-place writes for reviewer deep links

### DIFF
--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -518,10 +518,10 @@ try {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Change details')).Count -ne 2 -or
-    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram moves`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects): `3` details across `1` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects): `2` details across `1` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('Exact sections: [section 1](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects)') -or
-    $indexMarkdown -notmatch [regex]::Escape('[`VI version changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous): `1` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram moves`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects): `3` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects): `2` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('Exact sections: [section 1](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects)') -or
+    $indexMarkdown -notmatch [regex]::Escape('[`VI version changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous): `1` details across `1` sections') -or
     $indexMarkdown -notmatch [regex]::Escape('Included categories: `Block Diagram Functional`, `VI Attribute`')) {
     throw 'Index markdown should render bounded change-detail summaries from the attributes compare report.'
   }
@@ -560,10 +560,10 @@ try {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Change details</h4>')).Count -ne 2 -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
     $indexHtml -notmatch [regex]::Escape('open change details report')) {
     throw 'Index HTML should render bounded change-detail summaries from the attributes compare report.'
   }
@@ -598,8 +598,8 @@ try {
     [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview manifest should carry reviewer-facing change-detail summaries into the aggregate PR run.'
   }
-  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
+  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous') {
     throw 'Preview manifest should carry exact attribute-section links into the aggregate PR run.'
   }
   if ($previewManifest.indexPreviewCards.Count -ne 2 -or

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -286,24 +286,35 @@ try {
   }
   if ([string]$receipt.commentPreviewCards[0].changeDetails.groups[1].heading -ne 'Block diagram resizing' -or
     [int]$receipt.commentPreviewCards[0].changeDetails.groups[1].detailCount -ne 2 -or
-    [string]$receipt.commentPreviewCards[0].changeDetails.groups[1].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects') {
+    [string]$receipt.commentPreviewCards[0].changeDetails.groups[1].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects') {
     throw 'Reviewer cards should surface semantic resize groups with exact section anchors.'
   }
   if ($receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks.Count -ne 1 -or
-    [string]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
     [string]$receipt.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].label -ne 'section 1') {
     throw 'Reviewer cards should expose exact section links for semantic groups.'
   }
   if ([string]$receipt.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes' -or
-    [string]$receipt.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous' -or
+    [string]$receipt.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous' -or
     $receipt.commentPreviewCards[1].changeDetails.groups[0].sampleDetails[0] -notmatch 'VI Version : changed from "21\.0" to "20\.0"') {
     throw 'Reviewer cards should preserve distinct VI attribute change summaries for later history pairs.'
   }
 
-  $anchoredReportHtml = Get-Content -LiteralPath (Join-Path $targetRoot 'attributes/Demo.vi-001-artifacts/compare-report.html') -Raw
+  $sourceReportHtml = Get-Content -LiteralPath (Join-Path $targetRoot 'attributes/Demo.vi-001-artifacts/compare-report.html') -Raw
+  if ($sourceReportHtml -match [regex]::Escape('id="comparevi-change-001-block-diagram-objects"') -or
+    $sourceReportHtml -match [regex]::Escape('id="comparevi-change-002-block-diagram-objects"')) {
+    throw 'Source attributes compare reports should stay unchanged when reviewer anchors are generated.'
+  }
+
+  $anchoredReportPath = Join-Path $targetRoot 'attributes/Demo.vi-001-artifacts/compare-report.reviewer-anchors.html'
+  if (-not (Test-Path -LiteralPath $anchoredReportPath -PathType Leaf)) {
+    throw 'Expected a reviewer-anchored sidecar report for exact section deep links.'
+  }
+
+  $anchoredReportHtml = Get-Content -LiteralPath $anchoredReportPath -Raw
   if ($anchoredReportHtml -notmatch [regex]::Escape('id="comparevi-change-001-block-diagram-objects"') -or
     $anchoredReportHtml -notmatch [regex]::Escape('id="comparevi-change-002-block-diagram-objects"')) {
-    throw 'Attributes compare reports should be stamped with deterministic section anchors for reviewer deep links.'
+    throw 'Reviewer-anchored sidecar reports should carry deterministic section anchors for deep links.'
   }
 
   $outputText = Get-Content -LiteralPath $outputPath -Raw

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -582,6 +582,18 @@ function Get-ReviewerSemanticHeadingFromSection {
   }
 }
 
+function Get-ReviewerAnchoredReportPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportHtmlPath
+  )
+
+  $directory = Split-Path -Parent $ReportHtmlPath
+  $fileNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($ReportHtmlPath)
+  $extension = [System.IO.Path]::GetExtension($ReportHtmlPath)
+  return Join-Path $directory ('{0}.reviewer-anchors{1}' -f $fileNameWithoutExtension, $extension)
+}
+
 function Get-ReviewerChangeDetailSectionsFromReport {
   param(
     [Parameter(Mandatory = $true)]
@@ -664,7 +676,6 @@ function Get-ReviewerChangeDetailSectionsFromReport {
             ordinal = [int]$sectionOrdinal
             heading = $heading
             anchorId = $anchorId
-            reportHtmlRelativePath = ('{0}#{1}' -f (Resolve-RelativePath -Path $ReportHtmlPath -ResultsRoot $ResultsRoot), $anchorId)
             detailLines = $detailLines
           }) | Out-Null
       }
@@ -679,12 +690,20 @@ function Get-ReviewerChangeDetailSectionsFromReport {
   }
 
   $updatedReportHtml = $builder.ToString()
+  $effectiveReportHtmlPath = $ReportHtmlPath
   if ($htmlChanged -and -not [string]::Equals($updatedReportHtml, $reportHtml, [System.StringComparison]::Ordinal)) {
-    Set-Content -LiteralPath $ReportHtmlPath -Encoding utf8 -Value $updatedReportHtml
+    $effectiveReportHtmlPath = Get-ReviewerAnchoredReportPath -ReportHtmlPath $ReportHtmlPath
+    Set-Content -LiteralPath $effectiveReportHtmlPath -Encoding utf8 -Value $updatedReportHtml
+  }
+
+  $effectiveReportHtmlRelativePath = Resolve-RelativePath -Path $effectiveReportHtmlPath -ResultsRoot $ResultsRoot
+  foreach ($section in @($sections | ForEach-Object { $_ })) {
+    $section['reportHtmlRelativePath'] = '{0}#{1}' -f $effectiveReportHtmlRelativePath, [string]$section['anchorId']
   }
 
   return [ordered]@{
     reportHtml = $updatedReportHtml
+    reportHtmlRelativePath = $effectiveReportHtmlRelativePath
     sections = @($sections | ForEach-Object { $_ })
   }
 }
@@ -737,6 +756,11 @@ function Get-ReviewerChangeDetailsFromReport {
   $reportHtml = [string](Get-NestedValue -Object $sectionReceipt -Path @('reportHtml') -Default '')
   if ([string]::IsNullOrWhiteSpace($reportHtml)) {
     return $null
+  }
+
+  $effectiveReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $sectionReceipt -Path @('reportHtmlRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($effectiveReportHtmlRelativePath)) {
+    $effectiveReportHtmlRelativePath = Resolve-RelativePath -Path $ReportHtmlPath -ResultsRoot $ResultsRoot
   }
 
   $includedCategories = @(Get-ReportIncludedCategories -ReportHtml $reportHtml)
@@ -817,7 +841,7 @@ function Get-ReviewerChangeDetailsFromReport {
     changeDetails = [ordered]@{
       label = 'Change details'
       sourceMode = 'attributes'
-      reportHtmlRelativePath = Resolve-RelativePath -Path $ReportHtmlPath -ResultsRoot $ResultsRoot
+      reportHtmlRelativePath = $effectiveReportHtmlRelativePath
       includedCategories = $includedCategories
       groupCount = $groupOrder.Count
       omittedGroupCount = [Math]::Max($groupOrder.Count - $groupItems.Count, 0)


### PR DESCRIPTION
## Summary
- stop mutating generated compare reports in place when building reviewer deep links
- write deterministic anchored sidecar reports instead
- update preview-manifest and aggregate-run regressions to expect the sidecar paths

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
