### PR TITLE
#149 Add reviewer interpretation summary contract

### DIFF
--- a/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
@@ -136,12 +136,78 @@
               "targetId",
               "targetPath",
               "comparison",
-              "surfaces"
+              "surfaces",
+              "reviewerSummary"
             ],
             "properties": {
               "targetId": { "type": "string", "minLength": 1 },
               "targetPath": { "type": "string", "minLength": 1 },
               "comparison": { "type": "object" },
+              "reviewerSummary": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": false,
+                "required": [
+                  "label",
+                  "overallSeverity",
+                  "headline",
+                  "signalCount",
+                  "omittedSignalCount",
+                  "signals"
+                ],
+                "properties": {
+                  "label": { "const": "Reviewer summary" },
+                  "overallSeverity": { "enum": ["high", "medium", "low"] },
+                  "headline": { "type": "string", "minLength": 1 },
+                  "signalCount": { "type": "integer", "minimum": 0 },
+                  "omittedSignalCount": { "type": "integer", "minimum": 0 },
+                  "signals": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "signalKey",
+                        "label",
+                        "severity",
+                        "detailCount",
+                        "sectionCount",
+                        "summary",
+                        "primaryReportHtmlRelativePath",
+                        "sectionLinks"
+                      ],
+                      "properties": {
+                        "signalKey": { "type": "string", "minLength": 1 },
+                        "label": { "type": "string", "minLength": 1 },
+                        "severity": { "enum": ["high", "medium", "low"] },
+                        "detailCount": { "type": "integer", "minimum": 0 },
+                        "sectionCount": { "type": "integer", "minimum": 0 },
+                        "summary": { "type": "string", "minLength": 1 },
+                        "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+                        "sectionLinks": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                              "sectionOrdinal",
+                              "label",
+                              "reportHtmlRelativePath"
+                            ],
+                            "properties": {
+                              "sectionOrdinal": { "type": "integer", "minimum": 0 },
+                              "label": { "type": "string", "minLength": 1 },
+                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               "changeDetails": {
                 "type": [
                   "object",

--- a/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-preview-manifest-v1.schema.json
@@ -207,13 +207,15 @@
         "targetId",
         "targetPath",
         "comparison",
-        "surfaces"
+        "surfaces",
+        "reviewerSummary"
       ],
       "properties": {
         "targetId": { "type": "string", "minLength": 1 },
         "targetPath": { "type": "string", "minLength": 1 },
         "comparison": { "$ref": "#/$defs/comparison" },
         "sortKey": { "type": ["string", "null"] },
+        "reviewerSummary": { "$ref": "#/$defs/reviewerSummary" },
         "changeDetails": { "$ref": "#/$defs/changeDetails" },
         "surfaces": {
           "type": "array",
@@ -261,6 +263,56 @@
         "sectionOrdinal": { "type": "integer", "minimum": 0 },
         "label": { "type": "string", "minLength": 1 },
         "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
+      }
+    },
+    "reviewerSignal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "signalKey",
+        "label",
+        "severity",
+        "detailCount",
+        "sectionCount",
+        "summary",
+        "primaryReportHtmlRelativePath",
+        "sectionLinks"
+      ],
+      "properties": {
+        "signalKey": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "severity": { "enum": ["high", "medium", "low"] },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "summary": { "type": "string", "minLength": 1 },
+        "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+        "sectionLinks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailSectionLink" }
+        }
+      }
+    },
+    "reviewerSummary": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "overallSeverity",
+        "headline",
+        "signalCount",
+        "omittedSignalCount",
+        "signals"
+      ],
+      "properties": {
+        "label": { "const": "Reviewer summary" },
+        "overallSeverity": { "enum": ["high", "medium", "low"] },
+        "headline": { "type": "string", "minLength": 1 },
+        "signalCount": { "type": "integer", "minimum": 0 },
+        "omittedSignalCount": { "type": "integer", "minimum": 0 },
+        "signals": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reviewerSignal" }
+        }
       }
     },
     "changeDetails": {

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -422,6 +422,69 @@ function New-CommentChangeDetailsMarkdown {
   return $lines -join "`n"
 }
 
+function New-CommentReviewerSummaryMarkdown {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return ''
+  }
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('<p><strong>Reviewer summary</strong></p>') | Out-Null
+  $lines.Add('<ul>') | Out-Null
+  $headline = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('headline'))
+  if (-not [string]::IsNullOrWhiteSpace($headline)) {
+    $lines.Add(('<li><strong>Headline:</strong> {0}</li>' -f (ConvertTo-HtmlText $headline))) | Out-Null
+  }
+  $overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+  if (-not [string]::IsNullOrWhiteSpace($overallSeverity)) {
+    $lines.Add(('<li><strong>Overall severity:</strong> {0}</li>' -f (ConvertTo-HtmlText $overallSeverity))) | Out-Null
+  }
+  foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
+    $labelText = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $labelMarkup = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+      ConvertTo-HtmlText $labelText
+    } else {
+      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $primaryReportHtmlRelativePath), (ConvertTo-HtmlText $labelText)
+    }
+    $lines.Add(('<li><strong>{0}:</strong> {1} severity, {2} details across {3} sections' -f `
+          $labelMarkup, `
+          (ConvertTo-HtmlText (Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity')))), `
+          [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0), `
+          [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0))) | Out-Null
+    $lines.Add('<ul>') | Out-Null
+    $sectionLinks = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()) |
+        ForEach-Object {
+          $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
+          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
+            return $null
+          }
+
+          '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $path), (ConvertTo-HtmlText $label)
+        } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($sectionLinks.Count -gt 0) {
+      $lines.Add(('<li><strong>Exact sections:</strong> {0}</li>' -f ($sectionLinks -join ', '))) | Out-Null
+    }
+    $lines.Add('</ul>') | Out-Null
+    $lines.Add('</li>') | Out-Null
+  }
+  $omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+  if ($omittedSignalCount -gt 0) {
+    $lines.Add(('<li><strong>Additional reviewer signals omitted:</strong> {0}</li>' -f $omittedSignalCount)) | Out-Null
+  }
+  $lines.Add('</ul>') | Out-Null
+
+  return $lines -join "`n"
+}
+
 function Get-ReviewerPreviewCardKey {
   param([Parameter(Mandatory = $true)][object]$PreviewPair)
 
@@ -703,6 +766,10 @@ function New-CommentPreviewMarkdown {
     if (-not [string]::IsNullOrWhiteSpace($detailHtml)) {
       $lines.Add($detailHtml) | Out-Null
     }
+    $reviewerSummaryMarkdown = New-CommentReviewerSummaryMarkdown -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary'))
+    if (-not [string]::IsNullOrWhiteSpace($reviewerSummaryMarkdown)) {
+      $lines.Add($reviewerSummaryMarkdown) | Out-Null
+    }
     $changeDetailsMarkdown = New-CommentChangeDetailsMarkdown -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails'))
     if (-not [string]::IsNullOrWhiteSpace($changeDetailsMarkdown)) {
       $lines.Add($changeDetailsMarkdown) | Out-Null
@@ -845,6 +912,7 @@ function Publish-CommentPreviewSurface {
       targetId = [string]$previewCard.targetId
       targetPath = [string]$previewCard.targetPath
       comparison = $previewCard.comparison
+      reviewerSummary = Get-NestedValue -Object $previewCard -Path @('reviewerSummary')
       changeDetails = Get-NestedValue -Object $previewCard -Path @('changeDetails')
       surfaces = @($publishedSurfaces | ForEach-Object { $_ })
     }

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -517,6 +517,15 @@ try {
     [regex]::Matches($indexMarkdown, [regex]::Escape('#### Block diagram')).Count -ne 2) {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
+  if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Reviewer summary')).Count -ne 2 -or
+    $indexMarkdown -notmatch [regex]::Escape('- Headline: `Material logic-affecting movement and structure resizing`') -or
+    $indexMarkdown -notmatch [regex]::Escape('- Overall severity: `medium`') -or
+    $indexMarkdown -notmatch [regex]::Escape('- [`Logic-affecting movement`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects): `medium` severity, `3` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('- [`Structure resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects): `low` severity, `2` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape('- Headline: `Material version or compatibility changes`') -or
+    $indexMarkdown -notmatch [regex]::Escape('- [`Version or compatibility changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous): `medium` severity, `1` details across `1` sections')) {
+    throw 'Index markdown should render reviewer-summary headlines, severity, and exact linked signals.'
+  }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Change details')).Count -ne 2 -or
     $indexMarkdown -notmatch [regex]::Escape('[`Block diagram moves`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects): `3` details across `1` sections') -or
     $indexMarkdown -notmatch [regex]::Escape('[`Block diagram resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects): `2` details across `1` sections') -or
@@ -559,6 +568,15 @@ try {
     [regex]::Matches($indexHtml, [regex]::Escape('<h4>Block diagram</h4>')).Count -ne 2) {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
+  if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Reviewer summary</h4>')).Count -ne 2 -or
+    $indexHtml -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or
+    $indexHtml -notmatch [regex]::Escape('<strong>Overall severity:</strong> medium') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
+    $indexHtml -notmatch [regex]::Escape('<strong>Headline:</strong> Material version or compatibility changes') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
+    throw 'Index HTML should render reviewer-summary headlines, severity, and exact linked signals.'
+  }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Change details</h4>')).Count -ne 2 -or
     $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
     $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
@@ -591,6 +609,20 @@ try {
     $previewManifest.summary.indexPreviewCardCount -ne 2 -or
     $previewManifest.summary.indexPreviewSurfaceCount -ne 4) {
     throw 'Preview manifest summary mismatch.'
+  }
+  if ([string]$previewManifest.indexPreviewCards[0].reviewerSummary.label -ne 'Reviewer summary' -or
+    [string]$previewManifest.indexPreviewCards[0].reviewerSummary.overallSeverity -ne 'medium' -or
+    [string]$previewManifest.indexPreviewCards[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
+    [int]$previewManifest.indexPreviewCards[0].reviewerSummary.signalCount -ne 2 -or
+    [string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[0].label -ne 'Logic-affecting movement' -or
+    [string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[1].label -ne 'Structure resizing' -or
+    [string]$previewManifest.indexPreviewCards[1].reviewerSummary.headline -ne 'Material version or compatibility changes' -or
+    [string]$previewManifest.indexPreviewCards[1].reviewerSummary.signals[0].label -ne 'Version or compatibility changes') {
+    throw 'Preview manifest should carry reviewer-summary headlines and signals into the aggregate PR run.'
+  }
+  if ([string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$previewManifest.indexPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous') {
+    throw 'Preview manifest should carry exact reviewer-summary links into the aggregate PR run.'
   }
   if ([string]$previewManifest.indexPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -62,6 +62,58 @@ function New-PreviewCard {
     targetId = 'dynamic-demo-target'
     targetPath = 'Tooling/demo/Demo.vi'
     comparison = $matchingPairs[0].comparison
+    reviewerSummary = [ordered]@{
+      label = 'Reviewer summary'
+      overallSeverity = $(if ($ComparisonIndex -eq 1) { 'medium' } else { 'medium' })
+      headline = $(if ($ComparisonIndex -eq 1) {
+          'Material logic-affecting movement and structure resizing'
+        } else {
+          'Material version or compatibility changes'
+        })
+      signalCount = $(if ($ComparisonIndex -eq 1) { 2 } else { 1 })
+      omittedSignalCount = 0
+      signals = @(
+        [ordered]@{
+          signalKey = $(if ($ComparisonIndex -eq 1) { 'block-diagram-moves' } else { 'vi-version-changes' })
+          label = $(if ($ComparisonIndex -eq 1) { 'Logic-affecting movement' } else { 'Version or compatibility changes' })
+          severity = 'medium'
+          detailCount = $(if ($ComparisonIndex -eq 1) { 3 } else { 1 })
+          sectionCount = 1
+          summary = $(if ($ComparisonIndex -eq 1) {
+              'Block diagram objects moved across 1 exact sections.'
+            } else {
+              'Version or compatibility changes detected across 1 exact sections.'
+            })
+          primaryReportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html#comparevi-change-001-{1}' -f $ComparisonIndex, $(if ($ComparisonIndex -eq 1) { 'block-diagram-objects' } else { 'vi-attribute-miscellaneous' }))
+          sectionLinks = @(
+            [ordered]@{
+              sectionOrdinal = 1
+              label = 'section 1'
+              reportHtmlRelativePath = ('targets/001/history/attributes/Demo.vi-{0:D3}-artifacts/compare-report.html#comparevi-change-001-{1}' -f $ComparisonIndex, $(if ($ComparisonIndex -eq 1) { 'block-diagram-objects' } else { 'vi-attribute-miscellaneous' }))
+            }
+          )
+        }
+        $(if ($ComparisonIndex -eq 1) {
+            ,
+            [ordered]@{
+              signalKey = 'block-diagram-resizing'
+              label = 'Structure resizing'
+              severity = 'low'
+              detailCount = 2
+              sectionCount = 1
+              summary = 'Structure resizing detected across 1 exact sections.'
+              primaryReportHtmlRelativePath = 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects'
+              sectionLinks = @(
+                [ordered]@{
+                  sectionOrdinal = 2
+                  label = 'section 2'
+                  reportHtmlRelativePath = 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects'
+                }
+              )
+            }
+          })
+      )
+    }
     changeDetails = [ordered]@{
       label = 'Change details'
       sourceMode = 'attributes'
@@ -495,6 +547,15 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Block diagram</strong></p>')).Count -ne 2) {
     throw 'Created PR comment body should render both front-panel and block-diagram surfaces for each history pair.'
   }
+  if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Reviewer summary</strong></p>')).Count -ne 2 -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Overall severity:</strong> medium') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material version or compatibility changes') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
+    throw 'Created PR comment body should render reviewer-summary headlines, severity, and exact linked signals.'
+  }
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Change details</strong></p>')).Count -ne 2 -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
@@ -531,6 +592,18 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($createReceipt.previewPublication.commentPreviewCards.Count -ne 2 -or
     (@($createReceipt.previewPublication.commentPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
     throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
+  }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.label -ne 'Reviewer summary' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].label -ne 'Logic-affecting movement' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[1].label -ne 'Structure resizing' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.headline -ne 'Material version or compatibility changes' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].label -ne 'Version or compatibility changes') {
+    throw 'Preview publication should retain reviewer-summary headlines and signals.'
+  }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
+    throw 'Preview publication should retain exact reviewer-summary links.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -267,6 +267,21 @@ try {
     $receipt.commentPreviewCards[0].surfaces[1].baseImageRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report_files/bd_1.png') {
     throw 'Reviewer cards should preserve both front-panel and block-diagram image paths for the same history pair.'
   }
+  if ([string]$receipt.commentPreviewCards[0].reviewerSummary.label -ne 'Reviewer summary' -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.overallSeverity -ne 'medium' -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
+    [int]$receipt.commentPreviewCards[0].reviewerSummary.signalCount -ne 2 -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.signals[0].label -ne 'Logic-affecting movement' -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.signals[0].severity -ne 'medium' -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.signals[1].label -ne 'Structure resizing' -or
+    [string]$receipt.commentPreviewCards[0].reviewerSummary.signals[1].severity -ne 'low') {
+    throw 'Reviewer cards should emit deterministic reviewer-summary buckets and severities.'
+  }
+  if ([string]$receipt.commentPreviewCards[1].reviewerSummary.overallSeverity -ne 'medium' -or
+    [string]$receipt.commentPreviewCards[1].reviewerSummary.headline -ne 'Material version or compatibility changes' -or
+    [string]$receipt.commentPreviewCards[1].reviewerSummary.signals[0].label -ne 'Version or compatibility changes') {
+    throw 'Reviewer cards should emit reviewer summaries for later history pairs as well.'
+  }
   if ([string]$receipt.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$receipt.commentPreviewCards[0].changeDetails.sourceMode -ne 'attributes') {
     throw 'Reviewer cards should attach bounded change-detail summaries from the attributes compare report.'

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -415,6 +415,52 @@ function New-MarkdownChangeDetailsLines {
   return @($lines | ForEach-Object { $_ })
 }
 
+function New-MarkdownReviewerSummaryLines {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return @()
+  }
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $lines.Add('#### Reviewer summary') | Out-Null
+  $lines.Add('') | Out-Null
+  $headline = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('headline'))
+  if (-not [string]::IsNullOrWhiteSpace($headline)) {
+    $lines.Add(('- Headline: `{0}`' -f $headline)) | Out-Null
+  }
+  $overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+  if (-not [string]::IsNullOrWhiteSpace($overallSeverity)) {
+    $lines.Add(('- Overall severity: `{0}`' -f $overallSeverity)) | Out-Null
+  }
+  foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
+    $label = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+    $primaryPath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
+    $sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
+    $severity = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity'))
+    $labelText = if ([string]::IsNullOrWhiteSpace($primaryPath)) {
+      ('`{0}`' -f $label)
+    } else {
+      ('[`{0}`]({1})' -f $label, $primaryPath)
+    }
+    $lines.Add(('- {0}: `{1}` severity, `{2}` details across `{3}` sections' -f $labelText, $severity, $detailCount, $sectionCount)) | Out-Null
+    $sectionLinkLine = New-MarkdownChangeDetailSectionLinkLine -SectionLinks @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()))
+    if (-not [string]::IsNullOrWhiteSpace($sectionLinkLine)) {
+      $lines.Add($sectionLinkLine) | Out-Null
+    }
+  }
+  $omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+  if ($omittedSignalCount -gt 0) {
+    $lines.Add(('- Additional reviewer signals omitted: `{0}`' -f $omittedSignalCount)) | Out-Null
+  }
+  $lines.Add('') | Out-Null
+  return @($lines | ForEach-Object { $_ })
+}
+
 function New-HtmlChangeDetailsBlock {
   param(
     [AllowNull()]
@@ -469,6 +515,52 @@ function New-HtmlChangeDetailsBlock {
   }
 
   return '<section class="preview-change-details"><h4>Change details</h4><ul>' + ($items -join '') + '</ul></section>'
+}
+
+function New-HtmlReviewerSummaryBlock {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return ''
+  }
+
+  $items = New-Object System.Collections.Generic.List[string]
+  $headline = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('headline'))
+  if (-not [string]::IsNullOrWhiteSpace($headline)) {
+    $items.Add('<li><strong>Headline:</strong> ' + (Escape-Html $headline) + '</li>') | Out-Null
+  }
+  $overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+  if (-not [string]::IsNullOrWhiteSpace($overallSeverity)) {
+    $items.Add('<li><strong>Overall severity:</strong> ' + (Escape-Html $overallSeverity) + '</li>') | Out-Null
+  }
+  foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
+    $labelText = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+    $primaryPath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
+    $sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
+    $severity = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity'))
+    $heading = if ([string]::IsNullOrWhiteSpace($primaryPath)) {
+      Escape-Html $labelText
+    } else {
+      '<a href="' + (Escape-Html $primaryPath) + '">' + (Escape-Html $labelText) + '</a>'
+    }
+    $signalItems = New-Object System.Collections.Generic.List[string]
+    $sectionLinksHtml = New-HtmlChangeDetailSectionLinks -SectionLinks @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()))
+    if (-not [string]::IsNullOrWhiteSpace($sectionLinksHtml)) {
+      $signalItems.Add($sectionLinksHtml) | Out-Null
+    }
+    $nestedList = if ($signalItems.Count -gt 0) { '<ul>' + ($signalItems -join '') + '</ul>' } else { '' }
+    $items.Add('<li><strong>' + $heading + ':</strong> ' + (Escape-Html $severity) + ' severity, ' + $detailCount + ' details across ' + $sectionCount + ' sections' + $nestedList + '</li>') | Out-Null
+  }
+  $omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+  if ($omittedSignalCount -gt 0) {
+    $items.Add('<li><strong>Additional reviewer signals omitted:</strong> ' + $omittedSignalCount + '</li>') | Out-Null
+  }
+
+  return '<section class="preview-reviewer-summary"><h4>Reviewer summary</h4><ul>' + ($items -join '') + '</ul></section>'
 }
 
 function New-ReviewerPreviewSurface {
@@ -609,6 +701,9 @@ function New-MarkdownPreviewGallery {
     if ($detailLines.Count -gt 0) {
       $lines.Add('') | Out-Null
     }
+    foreach ($reviewerSummaryLine in @(New-MarkdownReviewerSummaryLines -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary')))) {
+      $lines.Add($reviewerSummaryLine) | Out-Null
+    }
     foreach ($changeDetailLine in @(New-MarkdownChangeDetailsLines -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails')))) {
       $lines.Add($changeDetailLine) | Out-Null
     }
@@ -661,6 +756,7 @@ function New-HtmlPreviewGallery {
     } else {
       '<div class="preview-card-history">' + (($detailLines | ForEach-Object { '<p>' + (Escape-Html $_) + '</p>' }) -join '') + '</div>'
     }
+    $reviewerSummaryHtml = New-HtmlReviewerSummaryBlock -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary'))
     $changeDetailsHtml = New-HtmlChangeDetailsBlock -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails'))
     $surfaceBlocks = New-Object System.Collections.Generic.List[string]
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
@@ -696,6 +792,7 @@ function New-HtmlPreviewGallery {
     <strong>Revisions</strong><span><code>$(Escape-Html $revisionContext)</code></span>
   </div>
   $detailHtml
+  $reviewerSummaryHtml
   $changeDetailsHtml
   $($surfaceBlocks -join "`n  ")
 </article>

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -26,6 +26,7 @@ $sectionKindOrder = @{
 
 $reviewerChangeDetailGroupCap = 3
 $reviewerChangeDetailSampleCap = 3
+$reviewerSummarySignalCap = 3
 
 function Write-ActionOutput {
   param(
@@ -582,6 +583,223 @@ function Get-ReviewerSemanticHeadingFromSection {
   }
 }
 
+function Get-ReviewerSeverityRank {
+  param([AllowNull()][string]$Severity)
+
+  switch ($Severity) {
+    'high' { return 3 }
+    'medium' { return 2 }
+    'low' { return 1 }
+    default { return 0 }
+  }
+}
+
+function Get-ReviewerSignalDescriptor {
+  param(
+    [AllowNull()][string]$Heading,
+    [int]$DetailCount,
+    [int]$SectionCount
+  )
+
+  $normalizedHeading = Normalize-ReviewerChangeDetailHeading -Heading (Get-OptionalString -Value $Heading)
+  switch -Regex ($normalizedHeading) {
+    '^Block diagram moves$' {
+      return [ordered]@{
+        signalKey = 'logic-movement'
+        label = 'Logic-affecting movement'
+        headlineLabel = 'logic-affecting movement'
+        severity = $(if ($DetailCount -ge 10 -or $SectionCount -ge 3) { 'high' } else { 'medium' })
+        sortOrder = 10
+      }
+    }
+    '^Block diagram resizing$' {
+      return [ordered]@{
+        signalKey = 'structure-resizing'
+        label = 'Structure resizing'
+        headlineLabel = 'structure resizing'
+        severity = $(if ($DetailCount -ge 5 -or $SectionCount -ge 2) { 'medium' } else { 'low' })
+        sortOrder = 20
+      }
+    }
+    '^(Added|Removed) block diagram objects$' {
+      return [ordered]@{
+        signalKey = 'object-topology'
+        label = 'Object additions or removals'
+        headlineLabel = 'object additions or removals'
+        severity = 'high'
+        sortOrder = 5
+      }
+    }
+    '^(Front panel layout moves|Front panel resizing|Front panel object changes|Added front panel objects|Removed front panel objects)$' {
+      return [ordered]@{
+        signalKey = 'layout-changes'
+        label = 'Layout changes'
+        headlineLabel = 'layout changes'
+        severity = $(if ($DetailCount -ge 8 -or $SectionCount -ge 3) { 'medium' } else { 'low' })
+        sortOrder = 40
+      }
+    }
+    '^Execution changes$' {
+      return [ordered]@{
+        signalKey = 'execution-behavior'
+        label = 'Execution behavior changes'
+        headlineLabel = 'execution behavior changes'
+        severity = 'high'
+        sortOrder = 15
+      }
+    }
+    '^VI version changes$' {
+      return [ordered]@{
+        signalKey = 'version-compatibility'
+        label = 'Version or compatibility changes'
+        headlineLabel = 'version or compatibility changes'
+        severity = 'medium'
+        sortOrder = 30
+      }
+    }
+    '^Icon changes$' {
+      return [ordered]@{
+        signalKey = 'visual-presentation'
+        label = 'Visual presentation changes'
+        headlineLabel = 'visual presentation changes'
+        severity = 'low'
+        sortOrder = 60
+      }
+    }
+    '^VI attribute changes$' {
+      return [ordered]@{
+        signalKey = 'metadata'
+        label = 'Metadata changes'
+        headlineLabel = 'metadata changes'
+        severity = 'low'
+        sortOrder = 50
+      }
+    }
+    default {
+      return [ordered]@{
+        signalKey = 'diagnostic-change'
+        label = 'Additional diagnostic changes'
+        headlineLabel = 'additional diagnostic changes'
+        severity = 'low'
+        sortOrder = 90
+      }
+    }
+  }
+}
+
+function New-ReviewerSummaryFromChangeDetails {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return $null
+  }
+
+  $signalMap = @{}
+  foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+    $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+    $descriptor = Get-ReviewerSignalDescriptor -Heading $heading -DetailCount $detailCount -SectionCount $sectionCount
+    $signalKey = [string]$descriptor.signalKey
+    if (-not $signalMap.ContainsKey($signalKey)) {
+      $signalMap[$signalKey] = [ordered]@{
+        signalKey = $signalKey
+        label = [string]$descriptor.label
+        headlineLabel = [string]$descriptor.headlineLabel
+        severity = [string]$descriptor.severity
+        sortOrder = [int]$descriptor.sortOrder
+        detailCount = 0
+        sectionCount = 0
+        primaryReportHtmlRelativePath = $null
+        sectionLinks = New-Object System.Collections.Generic.List[object]
+        sectionLinkKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+      }
+    }
+
+    $signalRecord = $signalMap[$signalKey]
+    if ((Get-ReviewerSeverityRank -Severity ([string]$descriptor.severity)) -gt (Get-ReviewerSeverityRank -Severity ([string]$signalRecord.severity))) {
+      $signalRecord.severity = [string]$descriptor.severity
+    }
+    $signalRecord.detailCount = [int]$signalRecord.detailCount + $detailCount
+    $signalRecord.sectionCount = [int]$signalRecord.sectionCount + $sectionCount
+    if ([string]::IsNullOrWhiteSpace([string]$signalRecord.primaryReportHtmlRelativePath)) {
+      $signalRecord.primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    }
+
+    foreach ($sectionLink in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()))) {
+      $sectionPath = Get-OptionalString -Value (Get-NestedValue -Object $sectionLink -Path @('reportHtmlRelativePath'))
+      $sectionLabel = Get-OptionalString -Value (Get-NestedValue -Object $sectionLink -Path @('label'))
+      if ([string]::IsNullOrWhiteSpace($sectionPath) -or [string]::IsNullOrWhiteSpace($sectionLabel)) {
+        continue
+      }
+
+      if ($signalRecord.sectionLinkKeys.Add($sectionPath)) {
+        $signalRecord.sectionLinks.Add([ordered]@{
+            sectionOrdinal = [int](Get-NestedValue -Object $sectionLink -Path @('sectionOrdinal') -Default 0)
+            label = $sectionLabel
+            reportHtmlRelativePath = $sectionPath
+          }) | Out-Null
+      }
+    }
+  }
+
+  $orderedSignals = @(
+    $signalMap.Values |
+      Sort-Object `
+        @{ Expression = { -(Get-ReviewerSeverityRank -Severity ([string]$_.severity)) } }, `
+        @{ Expression = { [int]$_.sortOrder } }, `
+        @{ Expression = { [string]$_.label } }
+  )
+  if ($orderedSignals.Count -eq 0) {
+    return $null
+  }
+
+  $signalItems = New-Object System.Collections.Generic.List[object]
+  foreach ($signalRecord in @($orderedSignals | Select-Object -First $reviewerSummarySignalCap)) {
+    $signalItems.Add([ordered]@{
+        signalKey = [string]$signalRecord.signalKey
+        label = [string]$signalRecord.label
+        severity = [string]$signalRecord.severity
+        detailCount = [int]$signalRecord.detailCount
+        sectionCount = [int]$signalRecord.sectionCount
+        summary = ('{0} details across {1} sections' -f [int]$signalRecord.detailCount, [int]$signalRecord.sectionCount)
+        primaryReportHtmlRelativePath = Get-OptionalString -Value $signalRecord.primaryReportHtmlRelativePath
+        sectionLinks = @($signalRecord.sectionLinks | ForEach-Object { $_ })
+      }) | Out-Null
+  }
+
+  $overallSeverity = [string]$orderedSignals[0].severity
+  $headlineLabels = @(
+    $orderedSignals |
+      Select-Object -First 2 |
+      ForEach-Object { [string]$_.headlineLabel }
+  )
+  $headlineBody = switch ($headlineLabels.Count) {
+    0 { '' }
+    1 { $headlineLabels[0] }
+    2 { '{0} and {1}' -f $headlineLabels[0], $headlineLabels[1] }
+    default { '{0}, {1}, and more' -f $headlineLabels[0], $headlineLabels[1] }
+  }
+  $headlinePrefix = switch ($overallSeverity) {
+    'high' { 'High-change' }
+    'medium' { 'Material' }
+    'low' { 'Scoped' }
+    default { 'Observed' }
+  }
+
+  return [ordered]@{
+    label = 'Reviewer summary'
+    overallSeverity = $overallSeverity
+    headline = $(if ([string]::IsNullOrWhiteSpace($headlineBody)) { $headlinePrefix } else { '{0} {1}' -f $headlinePrefix, $headlineBody })
+    signalCount = $orderedSignals.Count
+    omittedSignalCount = [Math]::Max($orderedSignals.Count - $signalItems.Count, 0)
+    signals = @($signalItems | ForEach-Object { $_ })
+  }
+}
+
 function Get-ReviewerAnchoredReportPath {
   param(
     [Parameter(Mandatory = $true)]
@@ -1092,13 +1310,16 @@ function New-ReviewerPreviewCards {
       $surfaces.Add((New-ReviewerPreviewSurface -PreviewPair $selectedPreviewPair)) | Out-Null
     }
 
+    $changeDetails = Get-NestedValue -Object $changeDetailsByCardKey -Path @($cardKey)
+
     $cards.Add([ordered]@{
         targetId = [string]$selectedPreviewPair.targetId
         targetPath = [string]$selectedPreviewPair.targetPath
         comparison = $selectedPreviewPair.comparison
         sortKey = Get-OptionalString -Value $selectedPreviewPair.sortKey
         surfaces = @($surfaces | ForEach-Object { $_ })
-        changeDetails = Get-NestedValue -Object $changeDetailsByCardKey -Path @($cardKey)
+        reviewerSummary = New-ReviewerSummaryFromChangeDetails -ChangeDetails $changeDetails
+        changeDetails = $changeDetails
       }) | Out-Null
   }
 


### PR DESCRIPTION
## Summary
- add a deterministic reviewer-summary interpretation layer to PR preview cards
- render reviewer-summary headlines and linked severity signals in the artifact index and sticky PR comment
- extend preview/publication schemas and focused regressions for the new reviewer-facing contract

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #149
