### PR TITLE
#150 Link reviewer cards to exact evidence

### DIFF
--- a/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
+++ b/docs/schemas/comparevi-history-pr-comment-publication-v1.schema.json
@@ -186,6 +186,7 @@
                         "sectionCount": { "type": "integer", "minimum": 0 },
                         "summary": { "type": "string", "minLength": 1 },
                         "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+                        "primaryReportUrl": { "type": ["string", "null"] },
                         "sectionLinks": {
                           "type": "array",
                           "items": {
@@ -199,7 +200,8 @@
                             "properties": {
                               "sectionOrdinal": { "type": "integer", "minimum": 0 },
                               "label": { "type": "string", "minLength": 1 },
-                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
+                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 },
+                              "reportUrl": { "type": ["string", "null"] }
                             }
                           }
                         }
@@ -229,6 +231,7 @@
                   "label": { "type": "string", "minLength": 1 },
                   "sourceMode": { "const": "attributes" },
                   "reportHtmlRelativePath": { "type": ["string", "null"] },
+                  "reportUrl": { "type": ["string", "null"] },
                   "includedCategories": {
                     "type": "array",
                     "items": { "type": "string", "minLength": 1 }
@@ -261,6 +264,7 @@
                         },
                         "omittedDetailCount": { "type": "integer", "minimum": 0 },
                         "primaryReportHtmlRelativePath": { "type": ["string", "null"] },
+                        "primaryReportUrl": { "type": ["string", "null"] },
                         "sectionLinks": {
                           "type": "array",
                           "items": {
@@ -274,7 +278,8 @@
                             "properties": {
                               "sectionOrdinal": { "type": "integer", "minimum": 0 },
                               "label": { "type": "string", "minLength": 1 },
-                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 }
+                              "reportHtmlRelativePath": { "type": "string", "minLength": 1 },
+                              "reportUrl": { "type": ["string", "null"] }
                             }
                           }
                         }
@@ -304,7 +309,9 @@
                     "baseImagePath": { "type": "string", "minLength": 1 },
                     "baseImageUrl": { "type": "string", "minLength": 1 },
                     "headImagePath": { "type": "string", "minLength": 1 },
-                    "headImageUrl": { "type": "string", "minLength": 1 }
+                    "headImageUrl": { "type": "string", "minLength": 1 },
+                    "evidencePath": { "type": ["string", "null"] },
+                    "evidenceUrl": { "type": ["string", "null"] }
                   }
                 }
               }
@@ -340,7 +347,9 @@
               "baseImagePath": { "type": "string", "minLength": 1 },
               "baseImageUrl": { "type": "string", "minLength": 1 },
               "headImagePath": { "type": "string", "minLength": 1 },
-              "headImageUrl": { "type": "string", "minLength": 1 }
+              "headImageUrl": { "type": "string", "minLength": 1 },
+              "evidencePath": { "type": ["string", "null"] },
+              "evidenceUrl": { "type": ["string", "null"] }
             }
           }
         }

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -372,11 +372,13 @@ function New-CommentChangeDetailsMarkdown {
   }
   foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
     $headingText = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+    $primaryReportUrl = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportUrl'))
     $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
-    $headingMarkup = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $headingLink = if ([string]::IsNullOrWhiteSpace($primaryReportUrl)) { $primaryReportHtmlRelativePath } else { $primaryReportUrl }
+    $headingMarkup = if ([string]::IsNullOrWhiteSpace($headingLink)) {
       ConvertTo-HtmlText $headingText
     } else {
-      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $primaryReportHtmlRelativePath), (ConvertTo-HtmlText $headingText)
+      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $headingLink), (ConvertTo-HtmlText $headingText)
     }
     $lines.Add(('<li><strong>{0}:</strong> {1} details across {2} sections' -f `
           $headingMarkup, `
@@ -394,7 +396,10 @@ function New-CommentChangeDetailsMarkdown {
       ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
         ForEach-Object {
           $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
-          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportUrl'))
+          if ([string]::IsNullOrWhiteSpace($path)) {
+            $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          }
           if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
             return $null
           }
@@ -413,9 +418,12 @@ function New-CommentChangeDetailsMarkdown {
   if ($omittedGroupCount -gt 0) {
     $lines.Add(('<li><strong>Additional change-detail groups omitted:</strong> {0}</li>' -f $omittedGroupCount)) | Out-Null
   }
-  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
-  if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
-    $lines.Add(('<li><a href="{0}">open change details report</a></li>' -f (ConvertTo-HtmlText $reportHtmlRelativePath))) | Out-Null
+  $reportUrl = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportUrl'))
+  if ([string]::IsNullOrWhiteSpace($reportUrl)) {
+    $reportUrl = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+  }
+  if (-not [string]::IsNullOrWhiteSpace($reportUrl)) {
+    $lines.Add(('<li><a href="{0}">open change details report</a></li>' -f (ConvertTo-HtmlText $reportUrl))) | Out-Null
   }
   $lines.Add('</ul>') | Out-Null
 
@@ -445,11 +453,13 @@ function New-CommentReviewerSummaryMarkdown {
   }
   foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
     $labelText = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+    $primaryReportUrl = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportUrl'))
     $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
-    $labelMarkup = if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $labelLink = if ([string]::IsNullOrWhiteSpace($primaryReportUrl)) { $primaryReportHtmlRelativePath } else { $primaryReportUrl }
+    $labelMarkup = if ([string]::IsNullOrWhiteSpace($labelLink)) {
       ConvertTo-HtmlText $labelText
     } else {
-      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $primaryReportHtmlRelativePath), (ConvertTo-HtmlText $labelText)
+      '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $labelLink), (ConvertTo-HtmlText $labelText)
     }
     $lines.Add(('<li><strong>{0}:</strong> {1} severity, {2} details across {3} sections' -f `
           $labelMarkup, `
@@ -461,7 +471,10 @@ function New-CommentReviewerSummaryMarkdown {
       ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()) |
         ForEach-Object {
           $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
-          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportUrl'))
+          if ([string]::IsNullOrWhiteSpace($path)) {
+            $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportHtmlRelativePath'))
+          }
           if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
             return $null
           }
@@ -733,6 +746,282 @@ function ConvertTo-BlobGitHubUrl {
   return 'https://github.com/{0}/blob/{1}/{2}' -f $RepositorySlug, $BranchName, ($Path -replace '\\', '/')
 }
 
+function Get-ReportAnchorId {
+  param(
+    [AllowNull()]
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $hashIndex = $Path.IndexOf('#', [System.StringComparison]::Ordinal)
+  if ($hashIndex -lt 0 -or $hashIndex -ge ($Path.Length - 1)) {
+    return $null
+  }
+
+  return $Path.Substring($hashIndex + 1)
+}
+
+function Add-AnchorToUrl {
+  param(
+    [AllowNull()]
+    [string]$Url,
+    [AllowNull()]
+    [string]$AnchorId
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Url)) {
+    return $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($AnchorId)) {
+    return $Url
+  }
+
+  return '{0}#{1}' -f $Url, $AnchorId
+}
+
+function New-CommentChangeDetailsEvidenceMarkdown {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $title = Get-ReviewerPreviewTitle -PreviewPair $PreviewCard
+  $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $PreviewCard
+  $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $PreviewCard
+  $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $PreviewCard)
+  $changeDetails = Get-NestedValue -Object $PreviewCard -Path @('changeDetails')
+  $reviewerSummary = Get-NestedValue -Object $PreviewCard -Path @('reviewerSummary')
+
+  $lines.Add(('# `{0}`' -f $title)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('## {0}' -f $subtitle)) | Out-Null
+  $lines.Add('') | Out-Null
+  if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+    $lines.Add(('`{0}`' -f $revisionContext)) | Out-Null
+    $lines.Add('') | Out-Null
+  }
+  foreach ($detailLine in $detailLines) {
+    $lines.Add(('- {0}' -f $detailLine)) | Out-Null
+  }
+  if ($detailLines.Count -gt 0) {
+    $lines.Add('') | Out-Null
+  }
+
+  if ($null -ne $reviewerSummary) {
+    $lines.Add('## Reviewer summary') | Out-Null
+    $lines.Add('') | Out-Null
+    $headline = Get-OptionalString -Value (Get-NestedValue -Object $reviewerSummary -Path @('headline'))
+    if (-not [string]::IsNullOrWhiteSpace($headline)) {
+      $lines.Add(('- Headline: `{0}`' -f $headline)) | Out-Null
+    }
+    $overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $reviewerSummary -Path @('overallSeverity'))
+    if (-not [string]::IsNullOrWhiteSpace($overallSeverity)) {
+      $lines.Add(('- Overall severity: `{0}`' -f $overallSeverity)) | Out-Null
+    }
+    foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $reviewerSummary -Path @('signals') -Default @()))) {
+      $label = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+      $severity = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity'))
+      $detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
+      $sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
+      $lines.Add(('- `{0}`: `{1}` severity, `{2}` details across `{3}` sections' -f $label, $severity, $detailCount, $sectionCount)) | Out-Null
+    }
+    $lines.Add('') | Out-Null
+  }
+
+  if ($null -ne $changeDetails) {
+    $lines.Add('## Change details') | Out-Null
+    $lines.Add('') | Out-Null
+    $includedCategories = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('includedCategories') -Default @()) |
+        ForEach-Object { Get-OptionalString -Value $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($includedCategories.Count -gt 0) {
+      $lines.Add(('Included categories: `{0}`' -f ($includedCategories -join '`, `'))) | Out-Null
+      $lines.Add('') | Out-Null
+    }
+    foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('groups') -Default @()))) {
+      $anchorId = Get-ReportAnchorId -Path (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath')))
+      if (-not [string]::IsNullOrWhiteSpace($anchorId)) {
+        $lines.Add(('<a id="{0}"></a>' -f (ConvertTo-HtmlText $anchorId))) | Out-Null
+      }
+      $heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+      $lines.Add(('### {0}' -f $heading)) | Out-Null
+      $lines.Add('') | Out-Null
+      $lines.Add(('- `{0}` details across `{1}` sections' -f [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0), [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0))) | Out-Null
+      foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+        $lines.Add(('  - {0}' -f [string]$sampleDetail)) | Out-Null
+      }
+      $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+      if ($omittedDetailCount -gt 0) {
+        $lines.Add(('  - +{0} more details in report' -f $omittedDetailCount)) | Out-Null
+      }
+      $lines.Add('') | Out-Null
+    }
+  }
+
+  return ($lines -join "`n").TrimEnd() + "`n"
+}
+
+function New-CommentSurfaceEvidenceMarkdown {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [object]$Surface,
+    [AllowNull()]
+    [string]$ChangeDetailsEvidenceUrl
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $title = Get-ReviewerPreviewTitle -PreviewPair $PreviewCard
+  $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $PreviewCard
+  $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $PreviewCard
+  $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $PreviewCard)
+  $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $Surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $Surface.surfaceLabel)
+
+  $lines.Add(('# `{0}`' -f $title)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('## {0}' -f $subtitle)) | Out-Null
+  $lines.Add('') | Out-Null
+  if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+    $lines.Add(('`{0}`' -f $revisionContext)) | Out-Null
+    $lines.Add('') | Out-Null
+  }
+  foreach ($detailLine in $detailLines) {
+    $lines.Add(('- {0}' -f $detailLine)) | Out-Null
+  }
+  if ($detailLines.Count -gt 0) {
+    $lines.Add('') | Out-Null
+  }
+  $lines.Add(('## {0}' -f $surfaceLabel)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add('**Base**') | Out-Null
+  $lines.Add(('![{0}]({1})' -f ('{0} base' -f $surfaceLabel), [string]$Surface.baseImageUrl)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add('**Head**') | Out-Null
+  $lines.Add(('![{0}]({1})' -f ('{0} head' -f $surfaceLabel), [string]$Surface.headImageUrl)) | Out-Null
+  if (-not [string]::IsNullOrWhiteSpace($ChangeDetailsEvidenceUrl)) {
+    $lines.Add('') | Out-Null
+    $lines.Add(('[Change details evidence]({0})' -f $ChangeDetailsEvidenceUrl)) | Out-Null
+  }
+
+  return ($lines -join "`n").TrimEnd() + "`n"
+}
+
+function ConvertTo-PublishedSectionLink {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$SectionLink,
+    [AllowNull()]
+    [string]$EvidenceUrl
+  )
+
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('reportHtmlRelativePath'))
+  return [ordered]@{
+    sectionOrdinal = [int](Get-NestedValue -Object $SectionLink -Path @('sectionOrdinal') -Default 0)
+    label = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('label'))
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    reportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $reportHtmlRelativePath)
+  }
+}
+
+function ConvertTo-PublishedChangeDetails {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails,
+    [AllowNull()]
+    [string]$EvidenceUrl
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return $null
+  }
+
+  $groups = New-Object System.Collections.Generic.List[object]
+  foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $groups.Add([ordered]@{
+        heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+        sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+        detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+        sampleDetails = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()) |
+            ForEach-Object { [string]$_ }
+        )
+        omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+        primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $primaryReportHtmlRelativePath)
+        sectionLinks = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
+            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidenceUrl $EvidenceUrl }
+        )
+      }) | Out-Null
+  }
+
+  return [ordered]@{
+    label = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('label'))
+    sourceMode = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('sourceMode'))
+    reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+    reportUrl = $EvidenceUrl
+    includedCategories = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
+        ForEach-Object { [string]$_ }
+    )
+    groupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('groupCount') -Default 0)
+    omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+    sectionCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('detailCount') -Default 0)
+    groups = @($groups | ForEach-Object { $_ })
+  }
+}
+
+function ConvertTo-PublishedReviewerSummary {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary,
+    [AllowNull()]
+    [string]$EvidenceUrl
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return $null
+  }
+
+  $signals = New-Object System.Collections.Generic.List[object]
+  foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $signals.Add([ordered]@{
+        signalKey = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('signalKey'))
+        label = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+        severity = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity'))
+        detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
+        sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
+        summary = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('summary'))
+        primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $primaryReportHtmlRelativePath)
+        sectionLinks = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()) |
+            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidenceUrl $EvidenceUrl }
+        )
+      }) | Out-Null
+  }
+
+  return [ordered]@{
+    label = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('label'))
+    overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+    headline = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('headline'))
+    signalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('signalCount') -Default 0)
+    omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+    signals = @($signals | ForEach-Object { $_ })
+  }
+}
+
 function New-CommentPreviewMarkdown {
   param(
     [Parameter(Mandatory = $true)]
@@ -778,7 +1067,10 @@ function New-CommentPreviewMarkdown {
       $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
       $baseUrl = [string]$surface.baseImageUrl
       $headUrl = [string]$surface.headImageUrl
-      $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
+      $linkUrl = Get-OptionalString -Value (Get-NestedValue -Object $surface -Path @('evidenceUrl'))
+      if ([string]::IsNullOrWhiteSpace($linkUrl)) {
+        $linkUrl = if ([string]::IsNullOrWhiteSpace($RunUrl)) { $headUrl } else { $RunUrl }
+      }
       $baseAlt = '{0} base' -f $surfaceLabel
       $headAlt = '{0} head' -f $surfaceLabel
       $lines.Add('') | Out-Null
@@ -790,9 +1082,6 @@ function New-CommentPreviewMarkdown {
       $lines.Add(('<td><a href="{0}"><img alt="{1}" src="{2}" width="320"></a></td>' -f (ConvertTo-HtmlText $linkUrl), (ConvertTo-HtmlText $headAlt), (ConvertTo-HtmlText $headUrl))) | Out-Null
       $lines.Add('</tr></tbody>') | Out-Null
       $lines.Add('</table>') | Out-Null
-    }
-    if (-not [string]::IsNullOrWhiteSpace($RunUrl)) {
-      $lines.Add(('<p><a href="{0}">workflow run</a></p>' -f (ConvertTo-HtmlText $RunUrl))) | Out-Null
     }
     $lines.Add('') | Out-Null
   }
@@ -867,6 +1156,12 @@ function Publish-CommentPreviewSurface {
   $cardOrdinal = 1
   foreach ($previewCard in $previewCards) {
     $cardRoot = '{0}/{1}-{2}' -f $runRoot, ('{0:D3}' -f $cardOrdinal), ('history-pair-' + ('{0:D2}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $previewCard)))
+    $changeDetailsEvidencePath = '{0}/change-details.md' -f $cardRoot
+    $changeDetailsEvidenceUrl = $null
+    if ($null -ne (Get-NestedValue -Object $previewCard -Path @('changeDetails')) -or
+      $null -ne (Get-NestedValue -Object $previewCard -Path @('reviewerSummary'))) {
+      $changeDetailsEvidenceUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $changeDetailsEvidencePath
+    }
     $publishedSurfaces = New-Object System.Collections.Generic.List[object]
     $surfaceOrdinal = 1
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
@@ -888,6 +1183,7 @@ function Publish-CommentPreviewSurface {
       $headExtension = [System.IO.Path]::GetExtension($headImagePath)
       $basePublishPath = '{0}/base{1}' -f $surfaceRoot, $baseExtension
       $headPublishPath = '{0}/head{1}' -f $surfaceRoot, $headExtension
+      $surfaceEvidencePath = '{0}/evidence.md' -f $surfaceRoot
 
       $messageBase = 'comparevi-history: publish PR preview images for run {0}' -f $ExecutionRunId
       Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath -Bytes ([System.IO.File]::ReadAllBytes($baseImagePath)) -Message $messageBase | Out-Null
@@ -903,17 +1199,29 @@ function Publish-CommentPreviewSurface {
         baseImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath
         headImagePath = $headPublishPath
         headImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $headPublishPath
+        evidencePath = $surfaceEvidencePath
+        evidenceUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $surfaceEvidencePath
       }
+      $surfaceEvidenceMarkdown = New-CommentSurfaceEvidenceMarkdown -PreviewCard $previewCard -Surface $publishedSurface -ChangeDetailsEvidenceUrl $changeDetailsEvidenceUrl
+      Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $surfaceEvidencePath -Bytes ([System.Text.Encoding]::UTF8.GetBytes($surfaceEvidenceMarkdown)) -Message ('comparevi-history: publish PR preview evidence for run {0}' -f $ExecutionRunId) | Out-Null
       $publishedSurfaces.Add($publishedSurface) | Out-Null
       $surfaceOrdinal += 1
     }
+
+    if (-not [string]::IsNullOrWhiteSpace($changeDetailsEvidenceUrl)) {
+      $changeDetailsEvidenceMarkdown = New-CommentChangeDetailsEvidenceMarkdown -PreviewCard $previewCard
+      Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $changeDetailsEvidencePath -Bytes ([System.Text.Encoding]::UTF8.GetBytes($changeDetailsEvidenceMarkdown)) -Message ('comparevi-history: publish PR preview evidence for run {0}' -f $ExecutionRunId) | Out-Null
+    }
+
+    $publishedReviewerSummary = ConvertTo-PublishedReviewerSummary -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary')) -EvidenceUrl $changeDetailsEvidenceUrl
+    $publishedChangeDetails = ConvertTo-PublishedChangeDetails -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails')) -EvidenceUrl $changeDetailsEvidenceUrl
 
     $publishedCard = [ordered]@{
       targetId = [string]$previewCard.targetId
       targetPath = [string]$previewCard.targetPath
       comparison = $previewCard.comparison
-      reviewerSummary = Get-NestedValue -Object $previewCard -Path @('reviewerSummary')
-      changeDetails = Get-NestedValue -Object $previewCard -Path @('changeDetails')
+      reviewerSummary = $publishedReviewerSummary
+      changeDetails = $publishedChangeDetails
       surfaces = @($publishedSurfaces | ForEach-Object { $_ })
     }
     $publishedPreviewCards.Add($publishedCard) | Out-Null
@@ -932,6 +1240,8 @@ function Publish-CommentPreviewSurface {
           baseImageUrl = [string]$representativeSurface.baseImageUrl
           headImagePath = [string]$representativeSurface.headImagePath
           headImageUrl = [string]$representativeSurface.headImageUrl
+          evidencePath = Get-OptionalString -Value $representativeSurface.evidencePath
+          evidenceUrl = Get-OptionalString -Value $representativeSurface.evidenceUrl
         }) | Out-Null
     }
 

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -517,6 +517,12 @@ try {
     [regex]::Matches($indexMarkdown, [regex]::Escape('#### Block diagram')).Count -ne 2) {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
+  if ($indexMarkdown -notmatch [regex]::Escape('[![Front panel base](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png)](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)') -or
+    $indexMarkdown -notmatch [regex]::Escape('[![Block diagram base](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png)](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)') -or
+    $indexMarkdown -notmatch [regex]::Escape('[![Front panel head](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png)](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html)') -or
+    $indexMarkdown -notmatch [regex]::Escape('[![Block diagram head](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png)](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html)')) {
+    throw 'Index markdown should make preview images one-click links to exact visual report surfaces.'
+  }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Reviewer summary')).Count -ne 2 -or
     $indexMarkdown -notmatch [regex]::Escape('- Headline: `Material logic-affecting movement and structure resizing`') -or
     $indexMarkdown -notmatch [regex]::Escape('- Overall severity: `medium`') -or
@@ -567,6 +573,12 @@ try {
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Front panel</h4>')).Count -ne 2 -or
     [regex]::Matches($indexHtml, [regex]::Escape('<h4>Block diagram</h4>')).Count -ne 2) {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
+  }
+  if ($indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html"><img alt="Front panel base" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png"></a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html"><img alt="Block diagram base" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png"></a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html"><img alt="Front panel head" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png"></a>') -or
+    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html"><img alt="Block diagram head" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png"></a>')) {
+    throw 'Index HTML should make preview images one-click links to exact visual report surfaces.'
   }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Reviewer summary</h4>')).Count -ne 2 -or
     $indexHtml -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -550,20 +550,25 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Reviewer summary</strong></p>')).Count -ne 2 -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Overall severity:</strong> medium') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material version or compatibility changes') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
     throw 'Created PR comment body should render reviewer-summary headlines, severity, and exact linked signals.'
   }
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Change details</strong></p>')).Count -ne 2 -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">section 1</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Version : changed from &quot;21.0&quot; to &quot;20.0&quot;') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('open change details report')) {
     throw 'Created PR comment body should render bounded change-detail summaries from the attributes compare report.'
+  }
+  if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<td><a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md"><img alt="Front panel base"') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<td><a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/evidence.md"><img alt="Block diagram head"') -or
+    $global:RecordedPosts[0].body -match [regex]::Escape('<p><a href="https://github.com/example/repo/actions/runs/321">workflow run</a></p>')) {
+    throw 'Created PR comment body should link preview images to exact published evidence pages instead of the workflow run.'
   }
   if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
     [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
@@ -578,8 +583,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'
   }
-  if ($global:RecordedContentWrites.Count -ne 9) {
-    throw 'Expected preview publication to write eight images and one manifest.'
+  if ($global:RecordedContentWrites.Count -ne 15) {
+    throw 'Expected preview publication to write eight images, six evidence pages, and one manifest.'
   }
 
   $publishedPairOrder = @(
@@ -593,6 +598,11 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     (@($createReceipt.previewPublication.commentPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
     throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
   }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].evidenceUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewPairs[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md') {
+    throw 'Preview publication should expose exact published evidence-page locations for visual surfaces.'
+  }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.label -ne 'Reviewer summary' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].label -ne 'Logic-affecting movement' -or
@@ -602,8 +612,9 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     throw 'Preview publication should retain reviewer-summary headlines and signals.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
-    throw 'Preview publication should retain exact reviewer-summary links.'
+    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects') {
+    throw 'Preview publication should retain exact reviewer-summary links and publish stable evidence URLs.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
@@ -611,27 +622,36 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview publication should retain reviewer-facing change-detail summaries.'
   }
-  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.reportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
-    throw 'Preview publication should retain exact section links for reviewer change details.'
+    throw 'Preview publication should retain exact section links for reviewer change details and publish stable evidence URLs.'
   }
 
   $writeOrder = @(
     $global:RecordedContentWrites |
       ForEach-Object { [string]$_.path }
   )
-  $expectedImagePrefixes = @(
+  $expectedWritePaths = @(
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/base.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/base.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/evidence.md',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/base.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/evidence.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/base.png',
-    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/head.png'
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/head.png',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/evidence.md',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/preview-manifest.json'
   )
-  foreach ($index in 0..7) {
-    if ([string]$writeOrder[$index] -ne $expectedImagePrefixes[$index]) {
+  foreach ($index in 0..($expectedWritePaths.Count - 1)) {
+    if ([string]$writeOrder[$index] -ne $expectedWritePaths[$index]) {
       throw "Published preview write order mismatch at position $index."
     }
   }

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -709,23 +709,32 @@ function New-MarkdownPreviewGallery {
     }
     foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()))) {
       $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+      $surfaceReportPath = Get-OptionalString -Value $surface.reportHtmlRelativePath
       $lines.Add(('#### {0}' -f $surfaceLabel)) | Out-Null
       $lines.Add('') | Out-Null
       $lines.Add('**Base**') | Out-Null
-      $lines.Add((
-          '![{0}]({1})' -f
-            ('{0} base' -f $surfaceLabel),
-            [string]$surface.baseImageRelativePath
-        )) | Out-Null
+      $baseImageMarkdown = (
+        '![{0}]({1})' -f
+          ('{0} base' -f $surfaceLabel),
+          [string]$surface.baseImageRelativePath
+      )
+      if (-not [string]::IsNullOrWhiteSpace($surfaceReportPath)) {
+        $baseImageMarkdown = '[{0}]({1})' -f $baseImageMarkdown, $surfaceReportPath
+      }
+      $lines.Add($baseImageMarkdown) | Out-Null
       $lines.Add('') | Out-Null
       $lines.Add('**Head**') | Out-Null
-      $lines.Add((
-          '![{0}]({1})' -f
-            ('{0} head' -f $surfaceLabel),
-            [string]$surface.headImageRelativePath
-        )) | Out-Null
-      if (-not [string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
-        $lines.Add(('- Report: [{0}]({0})' -f [string]$surface.reportHtmlRelativePath)) | Out-Null
+      $headImageMarkdown = (
+        '![{0}]({1})' -f
+          ('{0} head' -f $surfaceLabel),
+          [string]$surface.headImageRelativePath
+      )
+      if (-not [string]::IsNullOrWhiteSpace($surfaceReportPath)) {
+        $headImageMarkdown = '[{0}]({1})' -f $headImageMarkdown, $surfaceReportPath
+      }
+      $lines.Add($headImageMarkdown) | Out-Null
+      if (-not [string]::IsNullOrWhiteSpace($surfaceReportPath)) {
+        $lines.Add(('- Report: [{0}]({0})' -f $surfaceReportPath)) | Out-Null
       }
       $lines.Add('') | Out-Null
     }
@@ -766,16 +775,24 @@ function New-HtmlPreviewGallery {
       } else {
         '<p><a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">open ' + (Escape-Html $surfaceLabel.ToLowerInvariant()) + ' report</a></p>'
       }
+      $baseImageHtml = '<img alt="' + (Escape-Html ($surfaceLabel + ' base')) + '" src="' + (Escape-Html ([string]$surface.baseImageRelativePath)) + '">'
+      if (-not [string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
+        $baseImageHtml = '<a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">' + $baseImageHtml + '</a>'
+      }
+      $headImageHtml = '<img alt="' + (Escape-Html ($surfaceLabel + ' head')) + '" src="' + (Escape-Html ([string]$surface.headImageRelativePath)) + '">'
+      if (-not [string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
+        $headImageHtml = '<a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">' + $headImageHtml + '</a>'
+      }
       $surfaceBlocks.Add(@"
   <section class="preview-surface">
     <h4>$(Escape-Html $surfaceLabel)</h4>
     <div class="preview-image-grid">
       <figure>
-        <img alt="$(Escape-Html ($surfaceLabel + ' base'))" src="$(Escape-Html ([string]$surface.baseImageRelativePath))">
+        $baseImageHtml
         <figcaption>Base</figcaption>
       </figure>
       <figure>
-        <img alt="$(Escape-Html ($surfaceLabel + ' head'))" src="$(Escape-Html ([string]$surface.headImageRelativePath))">
+        $headImageHtml
         <figcaption>Head</figcaption>
       </figure>
     </div>


### PR DESCRIPTION
## Summary
- make artifact-index preview images one-click links to exact front-panel and block-diagram report surfaces
- publish deterministic evidence pages in the preview branch so sticky PR comments can link visual cards and attribute summaries to exact evidence instead of the workflow run
- extend publication schema coverage and focused regressions for the new evidence URLs

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #150
