### PR TITLE
#160 Build the canonical review bundle compiler in .NET

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             'scripts/Resolve-CompareVIHistoryRequest.ps1',
             'scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1',
             'scripts/Write-CompareVIHistoryAutomaticPullRequestDiscovery.ps1',
+            'scripts/Invoke-CompareVIHistoryReviewBundleCompiler.ps1',
             'scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1',
             'scripts/Write-CompareVIHistoryRevisionCatalog.ps1',
             'scripts/Write-CompareVIHistoryChunkPlan.ps1',
@@ -148,6 +149,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiagnostics.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
             'scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1',
+            'scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1',
             'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryTemplateContracts.ps1'
@@ -207,6 +209,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestDiagnostics.ps1',
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
             'scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1',
+            'scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1',
             'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryRequest.ps1',

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/CompareVIHistory.ReviewCompiler/bin/
+src/CompareVIHistory.ReviewCompiler/obj/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Legacy direct invocation remains available for maintainers:
   surface, including `selectedTargets`, artifact index paths, and sticky-comment publication inputs.
 - Emits `comparevi-history/pr-preview-manifest@v1` as the normalized preview-image manifest for dynamic PR diagnostics,
   index galleries, and sticky-comment preview publication.
+- Emits `comparevi-history/review-bundle@v1` as the canonical compiled review graph for pair-level normalization,
+  reviewer interpretation, and renderer inputs.
 - Emits `comparevi-history/pr-comment-publication@v1` as the `workflow_run` publication receipt for sticky PR comments.
 - Emits `comparevi-history/agent-canary-policy@v1` as the repo-owned governance contract for same-repo canary proof
   lanes that exercise the PR diagnostics surface without touching production VIs.
@@ -162,6 +164,7 @@ Automatic pull-request diagnostics workflows emit additive PR-scope receipts alo
 
 - `changed-vi-discovery.json` (`comparevi-history/changed-vi-discovery@v1`)
 - `pr-target-runs-manifest.json`
+- `review-bundle.json` (`comparevi-history/review-bundle@v1`)
 - `pr-run.json` (`comparevi-history/pr-run@v1`)
 - `pr-preview-manifest.json` (`comparevi-history/pr-preview-manifest@v1`)
 - `pr-comment.md`

--- a/docs/schemas/comparevi-history-review-bundle-v1.schema.json
+++ b/docs/schemas/comparevi-history-review-bundle-v1.schema.json
@@ -1,0 +1,382 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://labview-community-ci-cd.github.io/comparevi-history/schemas/comparevi-history-review-bundle-v1.schema.json",
+  "title": "comparevi-history review bundle v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAtUtc",
+    "targetRunsManifestPath",
+    "resultsDir",
+    "summary",
+    "targets",
+    "rawPreviewPairs",
+    "reviewPairs"
+  ],
+  "properties": {
+    "schema": {
+      "const": "comparevi-history/review-bundle@v1"
+    },
+    "generatedAtUtc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "targetRunsManifestPath": {
+      "type": "string",
+      "minLength": 1
+    },
+    "resultsDir": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetCount",
+        "rawPreviewPairCount",
+        "reviewPairCount",
+        "primaryReviewerDestinationPolicy"
+      ],
+      "properties": {
+        "targetCount": { "type": "integer", "minimum": 0 },
+        "rawPreviewPairCount": { "type": "integer", "minimum": 0 },
+        "reviewPairCount": { "type": "integer", "minimum": 0 },
+        "primaryReviewerDestinationPolicy": { "type": "string", "minLength": 1 }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/target" }
+    },
+    "rawPreviewPairs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rawPreviewPair" }
+    },
+    "reviewPairs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/reviewPair" }
+    }
+  },
+  "$defs": {
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index",
+        "baseRef",
+        "headRef"
+      ],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "baseRef": { "type": ["string", "null"] },
+        "headRef": { "type": ["string", "null"] },
+        "baseShortRef": { "type": ["string", "null"] },
+        "headShortRef": { "type": ["string", "null"] },
+        "baseSubject": { "type": ["string", "null"] },
+        "headSubject": { "type": ["string", "null"] }
+      }
+    },
+    "reviewerDestination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "relativePath"
+      ],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "relativePath": { "type": ["string", "null"] }
+      }
+    },
+    "debugDestinations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "frontPanelReportHtmlRelativePath",
+        "blockDiagramReportHtmlRelativePath",
+        "changeDetailsReportHtmlRelativePath"
+      ],
+      "properties": {
+        "frontPanelReportHtmlRelativePath": { "type": ["string", "null"] },
+        "blockDiagramReportHtmlRelativePath": { "type": ["string", "null"] },
+        "changeDetailsReportHtmlRelativePath": { "type": ["string", "null"] }
+      }
+    },
+    "rawPreviewPair": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetId",
+        "targetPath",
+        "mode",
+        "comparison",
+        "sectionKind",
+        "sectionOrdinal",
+        "label",
+        "debugReportHtmlRelativePath",
+        "baseImageRelativePath",
+        "headImageRelativePath",
+        "baseByteLength",
+        "headByteLength",
+        "baseImageSha256",
+        "headImageSha256",
+        "sortKey"
+      ],
+      "properties": {
+        "targetId": { "type": "string", "minLength": 1 },
+        "targetPath": { "type": "string", "minLength": 1 },
+        "mode": {
+          "type": "string",
+          "enum": ["attributes", "front-panel", "block-diagram"]
+        },
+        "comparison": { "$ref": "#/$defs/comparison" },
+        "sectionKind": {
+          "type": "string",
+          "enum": ["overview", "detail"]
+        },
+        "sectionOrdinal": { "type": "integer", "minimum": 0 },
+        "label": { "type": "string", "minLength": 1 },
+        "debugReportHtmlRelativePath": { "type": ["string", "null"] },
+        "baseImageRelativePath": { "type": "string", "minLength": 1 },
+        "headImageRelativePath": { "type": "string", "minLength": 1 },
+        "baseByteLength": { "type": "integer", "minimum": 0 },
+        "headByteLength": { "type": "integer", "minimum": 0 },
+        "baseImageSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "headImageSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "sortKey": { "type": "string", "minLength": 1 }
+      }
+    },
+    "reviewSurface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "surfaceKind",
+        "surfaceLabel",
+        "mode",
+        "label",
+        "primaryReviewerRelativePath",
+        "debugReportHtmlRelativePath",
+        "baseImageRelativePath",
+        "headImageRelativePath",
+        "baseByteLength",
+        "headByteLength",
+        "sortKey"
+      ],
+      "properties": {
+        "surfaceKind": { "type": "string", "minLength": 1 },
+        "surfaceLabel": { "type": "string", "minLength": 1 },
+        "mode": { "type": ["string", "null"] },
+        "label": { "type": ["string", "null"] },
+        "primaryReviewerRelativePath": { "type": ["string", "null"] },
+        "debugReportHtmlRelativePath": { "type": ["string", "null"] },
+        "baseImageRelativePath": { "type": "string", "minLength": 1 },
+        "headImageRelativePath": { "type": "string", "minLength": 1 },
+        "baseByteLength": { "type": "integer", "minimum": 0 },
+        "headByteLength": { "type": "integer", "minimum": 0 },
+        "baseImageSha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
+        "headImageSha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
+        "sortKey": { "type": ["string", "null"] }
+      }
+    },
+    "changeDetailSectionLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sectionOrdinal",
+        "label",
+        "reviewerRelativePath",
+        "debugReportHtmlRelativePath"
+      ],
+      "properties": {
+        "sectionOrdinal": { "type": "integer", "minimum": 0 },
+        "label": { "type": "string", "minLength": 1 },
+        "reviewerRelativePath": { "type": ["string", "null"] },
+        "debugReportHtmlRelativePath": { "type": ["string", "null"] }
+      }
+    },
+    "changeDetailGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "heading",
+        "sectionCount",
+        "detailCount",
+        "sampleDetails",
+        "omittedDetailCount",
+        "primaryReviewerRelativePath",
+        "primaryDebugReportHtmlRelativePath",
+        "sectionLinks"
+      ],
+      "properties": {
+        "heading": { "type": "string", "minLength": 1 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "sampleDetails": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "omittedDetailCount": { "type": "integer", "minimum": 0 },
+        "primaryReviewerRelativePath": { "type": ["string", "null"] },
+        "primaryDebugReportHtmlRelativePath": { "type": ["string", "null"] },
+        "sectionLinks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailSectionLink" }
+        }
+      }
+    },
+    "changeDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "sourceMode",
+        "primaryReviewerRelativePath",
+        "debugReportHtmlRelativePath",
+        "includedCategories",
+        "groupCount",
+        "omittedGroupCount",
+        "sectionCount",
+        "detailCount",
+        "groups"
+      ],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "sourceMode": { "type": "string", "minLength": 1 },
+        "primaryReviewerRelativePath": { "type": ["string", "null"] },
+        "debugReportHtmlRelativePath": { "type": ["string", "null"] },
+        "includedCategories": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "groupCount": { "type": "integer", "minimum": 0 },
+        "omittedGroupCount": { "type": "integer", "minimum": 0 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "groups": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailGroup" }
+        }
+      }
+    },
+    "reviewerSignal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "signalKey",
+        "label",
+        "severity",
+        "detailCount",
+        "sectionCount",
+        "summary",
+        "primaryReviewerRelativePath",
+        "primaryDebugReportHtmlRelativePath",
+        "sectionLinks"
+      ],
+      "properties": {
+        "signalKey": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "minLength": 1 },
+        "detailCount": { "type": "integer", "minimum": 0 },
+        "sectionCount": { "type": "integer", "minimum": 0 },
+        "summary": { "type": "string", "minLength": 1 },
+        "primaryReviewerRelativePath": { "type": ["string", "null"] },
+        "primaryDebugReportHtmlRelativePath": { "type": ["string", "null"] },
+        "sectionLinks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/changeDetailSectionLink" }
+        }
+      }
+    },
+    "reviewerSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "overallSeverity",
+        "headline",
+        "signalCount",
+        "omittedSignalCount",
+        "signals"
+      ],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "overallSeverity": { "type": "string", "minLength": 1 },
+        "headline": { "type": "string", "minLength": 1 },
+        "signalCount": { "type": "integer", "minimum": 0 },
+        "omittedSignalCount": { "type": "integer", "minimum": 0 },
+        "signals": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reviewerSignal" }
+        }
+      }
+    },
+    "reviewPair": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reviewPairKey",
+        "targetId",
+        "targetPath",
+        "comparison",
+        "sortKey",
+        "primaryReviewerDestination",
+        "debugDestinations",
+        "surfaces",
+        "reviewerSummary",
+        "changeDetails"
+      ],
+      "properties": {
+        "reviewPairKey": { "type": "string", "minLength": 1 },
+        "targetId": { "type": "string", "minLength": 1 },
+        "targetPath": { "type": "string", "minLength": 1 },
+        "comparison": { "$ref": "#/$defs/comparison" },
+        "sortKey": { "type": "string", "minLength": 1 },
+        "primaryReviewerDestination": { "$ref": "#/$defs/reviewerDestination" },
+        "debugDestinations": { "$ref": "#/$defs/debugDestinations" },
+        "surfaces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/reviewSurface" }
+        },
+        "reviewerSummary": {
+          "anyOf": [
+            { "$ref": "#/$defs/reviewerSummary" },
+            { "type": "null" }
+          ]
+        },
+        "changeDetails": {
+          "anyOf": [
+            { "$ref": "#/$defs/changeDetails" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targetId",
+        "targetPath",
+        "finalStatus",
+        "finalReason",
+        "rawPreviewPairCount",
+        "rawPreviewPairs",
+        "reviewPairCount"
+      ],
+      "properties": {
+        "targetId": { "type": "string", "minLength": 1 },
+        "targetPath": { "type": "string", "minLength": 1 },
+        "finalStatus": { "type": ["string", "null"] },
+        "finalReason": { "type": ["string", "null"] },
+        "rawPreviewPairCount": { "type": "integer", "minimum": 0 },
+        "rawPreviewPairs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/rawPreviewPair" }
+        },
+        "reviewPairCount": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/scripts/Invoke-CompareVIHistoryReviewBundleCompiler.ps1
+++ b/scripts/Invoke-CompareVIHistoryReviewBundleCompiler.ps1
@@ -1,0 +1,90 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$TargetRunsManifestPath,
+  [Parameter(Mandatory = $true)]
+  [string]$ResultsDir,
+  [string]$OutputPath,
+  [string]$GitHubOutputPath,
+  [string]$StepSummaryPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionOutput {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Key,
+    [AllowNull()]
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    return
+  }
+
+  $safeValue = if ($null -eq $Value) { '' } else { [string]$Value }
+  "$Key=$safeValue" | Out-File -FilePath $GitHubOutputPath -Encoding utf8 -Append
+}
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+$basePath = (Get-Location).Path
+$manifestPathResolved = Resolve-AbsolutePath -Path $TargetRunsManifestPath -BasePath $basePath
+$resultsDirResolved = Resolve-AbsolutePath -Path $ResultsDir -BasePath $basePath
+$outputPathResolved = if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+  Join-Path $resultsDirResolved 'review-bundle.json'
+} else {
+  Resolve-AbsolutePath -Path $OutputPath -BasePath $basePath
+}
+
+if (-not (Test-Path -LiteralPath $manifestPathResolved -PathType Leaf)) {
+  throw "Target-runs manifest not found: $manifestPathResolved"
+}
+if (-not (Test-Path -LiteralPath $resultsDirResolved -PathType Container)) {
+  throw "Results directory not found: $resultsDirResolved"
+}
+
+$projectPathResolved = Resolve-AbsolutePath -Path '..\src\CompareVIHistory.ReviewCompiler\CompareVIHistory.ReviewCompiler.csproj' -BasePath $PSScriptRoot
+if (-not (Test-Path -LiteralPath $projectPathResolved -PathType Leaf)) {
+  throw "Review bundle compiler project not found: $projectPathResolved"
+}
+
+& dotnet run --project $projectPathResolved -- `
+  --target-runs-manifest-path $manifestPathResolved `
+  --results-dir $resultsDirResolved `
+  --output-path $outputPathResolved | Out-Null
+if ($LASTEXITCODE -ne 0) {
+  throw "Review bundle compiler failed with exit code $LASTEXITCODE."
+}
+
+if (-not (Test-Path -LiteralPath $outputPathResolved -PathType Leaf)) {
+  throw "Review bundle compiler did not emit expected output: $outputPathResolved"
+}
+
+Write-ActionOutput -Key 'review-bundle-path' -Value $outputPathResolved
+
+if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
+  @(
+    '## comparevi-history review bundle compiler'
+    ''
+    ('- Review bundle: `{0}`' -f $outputPathResolved)
+    ('- Target-runs manifest: `{0}`' -f $manifestPathResolved)
+    ('- Results directory: `{0}`' -f $resultsDirResolved)
+  ) | Out-File -FilePath $StepSummaryPath -Encoding utf8 -Append
+}
+
+Get-Content -LiteralPath $outputPathResolved -Raw

--- a/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -183,6 +183,21 @@ try {
     -GitHubOutputPath $outputPath
 
   $receipt = $receiptJson | ConvertFrom-Json -Depth 64
+  $outputValues = @{}
+  foreach ($line in Get-Content -LiteralPath $outputPath) {
+    if ($line -match '^(?<key>[^=]+)=(?<value>.*)$') {
+      $outputValues[$Matches['key']] = $Matches['value']
+    }
+  }
+
+  if (-not $outputValues.ContainsKey('review-bundle-path') -or -not (Test-Path -LiteralPath $outputValues['review-bundle-path'] -PathType Leaf)) {
+    throw 'Expected preview manifest generation to emit the compiled review bundle output path.'
+  }
+  $reviewBundle = Get-Content -LiteralPath $outputValues['review-bundle-path'] -Raw | ConvertFrom-Json -Depth 64
+  if ([string]$reviewBundle.schema -ne 'comparevi-history/review-bundle@v1') {
+    throw 'Expected preview manifest generation to source the compiler-generated review bundle.'
+  }
+
   if ($receipt.schema -ne 'comparevi-history/pr-preview-manifest@v1') {
     throw 'Preview manifest schema mismatch.'
   }

--- a/scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1
+++ b/scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1
@@ -1,0 +1,224 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'Invoke-CompareVIHistoryReviewBundleCompiler.ps1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('comparevi-history-review-bundle-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+function New-PreviewReportFixture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModeRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$ModeName,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex,
+    [Parameter(Mandatory = $true)]
+    [string]$BaseRef,
+    [Parameter(Mandatory = $true)]
+    [string]$HeadRef
+  )
+
+  $artifactDir = Join-Path $ModeRoot ('Demo.vi-{0:D3}-artifacts' -f $ComparisonIndex)
+  $reportFilesDir = Join-Path $artifactDir 'compare-report_files'
+  New-Item -ItemType Directory -Path $reportFilesDir -Force | Out-Null
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_1.png'), @(0xCA, 0xFE, 0xBA, 0xBE))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'fp_2.png'), @(0xBE, 0xBA, 0xFE, 0xCA))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_1.png'), @(0x0B, 0xD1, 0xA6, 0x01))
+  [System.IO.File]::WriteAllBytes((Join-Path $reportFilesDir 'bd_2.png'), @(0x10, 0x0C, 0xD1, 0xA6))
+
+  $reportHtmlPath = Join-Path $artifactDir 'compare-report.html'
+  $reportHtml = if ($ModeName -eq 'attributes') {
+@"
+<!DOCTYPE html>
+<html>
+<body>
+<div class="compared-VIs">
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
+<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
+</div>
+<div class="included-attributes">
+<ul class="inclusion-list">
+<li class="checked">Block Diagram Functional</li>
+<li class="checked">VI Attribute</li>
+</ul>
+</div>
+<h2 class="section-header">Detailed Information</h2>
+$(if ($ComparisonIndex -eq 1) {
+@'
+<details open>
+<summary class="difference-heading">1. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Property Node - moved : changed from "(-35,102)" to "(-55,77)"</li>
+<li class="diff-detail">Tunnel - moved : changed from "(141,124)" to "(141,124)"</li>
+<li class="diff-detail">Case Selector - moved : changed from "(141,143)" to "(141,143)"</li>
+</ol>
+</details>
+<details open>
+<summary class="difference-heading">2. Block Diagram objects</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">Case Structure - resized : changed from "702*298" to "702*370"</li>
+<li class="diff-detail"> - resized : changed from "690*23" to "690*25"</li>
+</ol>
+</details>
+'@
+} else {
+@'
+<details open>
+<summary class="difference-heading">1. VI Attribute - Miscellaneous</summary>
+<ol class="detailed-description-list" type="A">
+<li class="diff-detail">VI Version : changed from "21.0" to "20.0"</li>
+</ol>
+</details>
+'@
+})
+</body>
+</html>
+"@
+  } else {
+@'
+<!DOCTYPE html>
+<html>
+<body>
+<div class="compared-VIs">
+<details><summary class="difference-heading"><div class="dropdown-left">First VI: /compare/base/Base.vi</div><div class="dropdown-right">Second VI: /compare/head/Head.vi</div></summary>
+<table class="difference"><tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Front Panel Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/fp_2.png"/></td></tr>
+<tr class="compared-vi-image-captions"><td class="compared-vi-image-caption">Block Diagram Overview</td></tr>
+<tr class="compared-images"><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_1.png"/></td><td class="difference-divider"></td><td class="diff-image"><img class="difference-image" src="compare-report_files/bd_2.png"/></td></tr></table></details>
+</div>
+</body>
+</html>
+'@
+  }
+  $reportHtml | Set-Content -LiteralPath $reportHtmlPath -Encoding utf8
+
+  return [ordered]@{
+    index = $ComparisonIndex
+    base = [ordered]@{
+      ref = $BaseRef
+      short = ('base-{0:D2}' -f $ComparisonIndex)
+    }
+    head = [ordered]@{
+      ref = $HeadRef
+      short = ('head-{0:D2}' -f $ComparisonIndex)
+    }
+    result = [ordered]@{
+      reportHtml = $reportHtmlPath
+    }
+  }
+}
+
+try {
+  $resultsDir = Join-Path $tempRoot 'results'
+  $targetRoot = Join-Path $resultsDir 'targets/001-demo/history'
+  New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+  $modeManifests = New-Object System.Collections.Generic.List[object]
+  foreach ($modeName in @('front-panel', 'block-diagram', 'attributes')) {
+    $modeRoot = Join-Path $targetRoot $modeName
+    New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
+
+    $comparisons = @(
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 1 -BaseRef ('{0}-base-1' -f $modeName) -HeadRef ('{0}-head-1' -f $modeName)),
+      (New-PreviewReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 2 -BaseRef ('{0}-base-2' -f $modeName) -HeadRef ('{0}-head-2' -f $modeName))
+    )
+
+    $modeManifestPath = Join-Path $modeRoot 'manifest.json'
+    ([ordered]@{
+        schema = 'vi-compare/history@v1'
+        generatedAt = '2026-03-18T00:00:00Z'
+        mode = $modeName
+        comparisons = $comparisons
+      } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+
+    $modeManifests.Add([ordered]@{
+        name = $modeName
+        manifestPath = $modeManifestPath
+      }) | Out-Null
+  }
+
+  $suiteManifestPath = Join-Path $targetRoot 'manifest.json'
+  ([ordered]@{
+      schema = 'vi-compare/history-suite@v1'
+      generatedAt = '2026-03-18T00:00:00Z'
+      modes = @($modeManifests | ForEach-Object { $_ })
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $suiteManifestPath -Encoding utf8
+
+  $targetRunsManifestPath = Join-Path $resultsDir 'pr-target-runs-manifest.json'
+  ([ordered]@{
+      schema = 'comparevi-history/pr-target-runs-manifest@v2'
+      generatedAtUtc = '2026-03-18T00:00:00Z'
+      targets = @(
+        [ordered]@{
+          targetId = 'dynamic-demo-target'
+          targetPath = 'Tooling/demo/Demo.vi'
+          finalStatus = 'succeeded'
+          finalReason = 'completed'
+          manifestPath = $suiteManifestPath
+        }
+      )
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $targetRunsManifestPath -Encoding utf8
+
+  $outputPath = Join-Path $resultsDir 'review-bundle.json'
+  $receiptJson = & $scriptPath -TargetRunsManifestPath $targetRunsManifestPath -ResultsDir $resultsDir -OutputPath $outputPath
+  $receipt = $receiptJson | ConvertFrom-Json -Depth 64
+
+  if ($receipt.schema -ne 'comparevi-history/review-bundle@v1') {
+    throw 'Review bundle schema mismatch.'
+  }
+  if ($receipt.summary.targetCount -ne 1 -or
+    $receipt.summary.rawPreviewPairCount -ne 4 -or
+    $receipt.summary.reviewPairCount -ne 2 -or
+    $receipt.summary.primaryReviewerDestinationPolicy -ne 'pair-level@v1') {
+    throw 'Review bundle summary mismatch.'
+  }
+  if ($receipt.targets.Count -ne 1 -or
+    $receipt.targets[0].rawPreviewPairCount -ne 4 -or
+    $receipt.targets[0].reviewPairCount -ne 2) {
+    throw 'Review bundle target summary mismatch.'
+  }
+  if ($receipt.rawPreviewPairs.Count -ne 4) {
+    throw 'Expected four raw preview pairs in the review bundle.'
+  }
+  if ([string]$receipt.rawPreviewPairs[0].debugReportHtmlRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report.html') {
+    throw 'Expected the first raw preview pair to preserve the raw report destination.'
+  }
+  if (($receipt.reviewPairs | Measure-Object).Count -ne 2) {
+    throw 'Expected two compiled review pairs.'
+  }
+  if ([string]$receipt.reviewPairs[0].primaryReviewerDestination.kind -ne 'history-pair-review-page' -or
+    $null -ne $receipt.reviewPairs[0].primaryReviewerDestination.relativePath) {
+    throw 'Expected pair-level reviewer destinations from the compiled review bundle.'
+  }
+  $surfaceKinds = @($receipt.reviewPairs[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ','
+  if ($surfaceKinds -ne 'front-panel,block-diagram') {
+    throw "Expected front-panel and block-diagram surfaces on the first review pair. Actual: $surfaceKinds"
+  }
+  if ([string]$receipt.reviewPairs[0].debugDestinations.frontPanelReportHtmlRelativePath -ne 'targets/001-demo/history/front-panel/Demo.vi-001-artifacts/compare-report.html' -or
+    [string]$receipt.reviewPairs[0].debugDestinations.blockDiagramReportHtmlRelativePath -ne 'targets/001-demo/history/block-diagram/Demo.vi-001-artifacts/compare-report.html' -or
+    [string]$receipt.reviewPairs[0].debugDestinations.changeDetailsReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.reviewer-anchors.html') {
+    throw 'Expected debug destinations to preserve the raw mode-scoped reports.'
+  }
+  if ([string]$receipt.reviewPairs[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
+    [string]$receipt.reviewPairs[1].reviewerSummary.headline -ne 'Material version or compatibility changes') {
+    throw 'Reviewer summary compilation mismatch.'
+  }
+  if ([string]$receipt.reviewPairs[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
+    [string]$receipt.reviewPairs[0].changeDetails.groups[1].heading -ne 'Block diagram resizing' -or
+    [string]$receipt.reviewPairs[1].changeDetails.groups[0].heading -ne 'VI version changes') {
+    throw 'Change-details compilation mismatch.'
+  }
+  if ([string]$receipt.reviewPairs[0].changeDetails.groups[0].sectionLinks[0].debugReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
+    [string]$receipt.reviewPairs[1].changeDetails.groups[0].primaryDebugReportHtmlRelativePath -ne 'targets/001-demo/history/attributes/Demo.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous') {
+    throw 'Expected anchored attribute debug links in the compiled review bundle.'
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $tempRoot) {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+  }
+}

--- a/scripts/Test-CompareVIHistoryTemplateContracts.ps1
+++ b/scripts/Test-CompareVIHistoryTemplateContracts.ps1
@@ -343,6 +343,7 @@ Assert-Match -Content $readme -Pattern 'comparevi-history/pr-run@v1' -Message 'R
 Assert-Match -Content $readme -Pattern 'comparevi-history/changed-vi-discovery@v2' -Message 'README must document the dynamic changed-VI discovery contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-policy@v2' -Message 'README must document the dynamic PR policy contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-run@v2' -Message 'README must document the dynamic aggregate pull-request run contract.'
+Assert-Match -Content $readme -Pattern 'comparevi-history/review-bundle@v1' -Message 'README must document the compiled review bundle contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/pr-comment-publication@v1' -Message 'README must document the PR comment publication contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/agent-canary-policy@v1' -Message 'README must document the agent-canary policy contract.'
 Assert-Match -Content $readme -Pattern 'comparevi-history/agent-canary-evaluation@v1' -Message 'README must document the agent-canary evaluation contract.'

--- a/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
+++ b/scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1
@@ -1326,6 +1326,304 @@ function New-ReviewerPreviewCards {
   return @($cards | ForEach-Object { $_ })
 }
 
+function Invoke-CompareVIHistoryReviewBundleCompiler {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetRunsManifestPath,
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsDir,
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+  )
+
+  $wrapperPath = Resolve-AbsolutePath -Path 'Invoke-CompareVIHistoryReviewBundleCompiler.ps1' -BasePath $PSScriptRoot
+  if (-not (Test-Path -LiteralPath $wrapperPath -PathType Leaf)) {
+    throw "Review bundle compiler wrapper not found: $wrapperPath"
+  }
+
+  & $wrapperPath -TargetRunsManifestPath $TargetRunsManifestPath -ResultsDir $ResultsDir -OutputPath $OutputPath | Out-Null
+
+  if (-not (Test-Path -LiteralPath $OutputPath -PathType Leaf)) {
+    throw "Review bundle compiler did not emit expected output: $OutputPath"
+  }
+
+  return $OutputPath
+}
+
+function Get-ReviewPairKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetId,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex
+  )
+
+  return '{0}|{1}' -f $TargetId, $ComparisonIndex
+}
+
+function Convert-ReviewBundleRawPreviewPair {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewPair
+  )
+
+  return [ordered]@{
+    targetId = [string]$PreviewPair.targetId
+    targetPath = [string]$PreviewPair.targetPath
+    mode = Get-OptionalString -Value $PreviewPair.mode
+    comparison = Get-NestedValue -Object $PreviewPair -Path @('comparison')
+    sectionKind = Get-OptionalString -Value $PreviewPair.sectionKind
+    sectionOrdinal = [int](Get-NestedValue -Object $PreviewPair -Path @('sectionOrdinal') -Default 0)
+    label = [string]$PreviewPair.label
+    reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $PreviewPair -Path @('debugReportHtmlRelativePath'))
+    baseImageRelativePath = [string]$PreviewPair.baseImageRelativePath
+    headImageRelativePath = [string]$PreviewPair.headImageRelativePath
+    baseByteLength = [int64](Get-NestedValue -Object $PreviewPair -Path @('baseByteLength') -Default 0)
+    headByteLength = [int64](Get-NestedValue -Object $PreviewPair -Path @('headByteLength') -Default 0)
+    baseImageSha256 = Get-OptionalString -Value $PreviewPair.baseImageSha256
+    headImageSha256 = Get-OptionalString -Value $PreviewPair.headImageSha256
+    sortKey = Get-OptionalString -Value $PreviewPair.sortKey
+  }
+}
+
+function Convert-ReviewBundleChangeDetailSectionLink {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$SectionLink
+  )
+
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('reviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    sectionOrdinal = [int](Get-NestedValue -Object $SectionLink -Path @('sectionOrdinal') -Default 0)
+    label = [string](Get-NestedValue -Object $SectionLink -Path @('label') -Default '')
+    reportHtmlRelativePath = $reportHtmlRelativePath
+  }
+}
+
+function Convert-ReviewBundleChangeDetailGroup {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Group
+  )
+
+  $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Group -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Group -Path @('primaryDebugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    heading = [string](Get-NestedValue -Object $Group -Path @('heading') -Default '')
+    sectionCount = [int](Get-NestedValue -Object $Group -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-NestedValue -Object $Group -Path @('detailCount') -Default 0)
+    sampleDetails = @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $Group -Path @('sampleDetails') -Default @()))
+    omittedDetailCount = [int](Get-NestedValue -Object $Group -Path @('omittedDetailCount') -Default 0)
+    primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+    sectionLinks = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $Group -Path @('sectionLinks') -Default @()) |
+        ForEach-Object { Convert-ReviewBundleChangeDetailSectionLink -SectionLink $_ }
+    )
+  }
+}
+
+function Convert-ReviewBundleChangeDetails {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return $null
+  }
+
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    label = [string](Get-NestedValue -Object $ChangeDetails -Path @('label') -Default 'Change details')
+    sourceMode = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('sourceMode'))
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    includedCategories = @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()))
+    groupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('groupCount') -Default 0)
+    omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+    sectionCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('detailCount') -Default 0)
+    groups = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()) |
+        ForEach-Object { Convert-ReviewBundleChangeDetailGroup -Group $_ }
+    )
+  }
+}
+
+function Convert-ReviewBundleReviewerSignal {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Signal
+  )
+
+  $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Signal -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Signal -Path @('primaryDebugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    signalKey = Get-OptionalString -Value (Get-NestedValue -Object $Signal -Path @('signalKey'))
+    label = [string](Get-NestedValue -Object $Signal -Path @('label') -Default '')
+    severity = Get-OptionalString -Value (Get-NestedValue -Object $Signal -Path @('severity'))
+    detailCount = [int](Get-NestedValue -Object $Signal -Path @('detailCount') -Default 0)
+    sectionCount = [int](Get-NestedValue -Object $Signal -Path @('sectionCount') -Default 0)
+    summary = [string](Get-NestedValue -Object $Signal -Path @('summary') -Default '')
+    primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+    sectionLinks = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $Signal -Path @('sectionLinks') -Default @()) |
+        ForEach-Object { Convert-ReviewBundleChangeDetailSectionLink -SectionLink $_ }
+    )
+  }
+}
+
+function Convert-ReviewBundleReviewerSummary {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return $null
+  }
+
+  return [ordered]@{
+    label = [string](Get-NestedValue -Object $ReviewerSummary -Path @('label') -Default 'Reviewer summary')
+    overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+    headline = [string](Get-NestedValue -Object $ReviewerSummary -Path @('headline') -Default '')
+    signalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('signalCount') -Default 0)
+    omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+    signals = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()) |
+        ForEach-Object { Convert-ReviewBundleReviewerSignal -Signal $_ }
+    )
+  }
+}
+
+function Convert-ReviewBundleSurface {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Surface
+  )
+
+  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    surfaceKind = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('surfaceKind'))
+    surfaceLabel = [string](Get-NestedValue -Object $Surface -Path @('surfaceLabel') -Default '')
+    mode = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('mode'))
+    label = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('label'))
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    baseImageRelativePath = [string](Get-NestedValue -Object $Surface -Path @('baseImageRelativePath') -Default '')
+    headImageRelativePath = [string](Get-NestedValue -Object $Surface -Path @('headImageRelativePath') -Default '')
+    baseByteLength = [int64](Get-NestedValue -Object $Surface -Path @('baseByteLength') -Default 0)
+    headByteLength = [int64](Get-NestedValue -Object $Surface -Path @('headByteLength') -Default 0)
+    baseImageSha256 = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('baseImageSha256'))
+    headImageSha256 = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('headImageSha256'))
+    sortKey = Get-OptionalString -Value (Get-NestedValue -Object $Surface -Path @('sortKey'))
+  }
+}
+
+function Convert-ReviewBundleReviewPairCard {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$ReviewPair
+  )
+
+  return [ordered]@{
+    targetId = [string]$ReviewPair.targetId
+    targetPath = [string]$ReviewPair.targetPath
+    comparison = Get-NestedValue -Object $ReviewPair -Path @('comparison')
+    sortKey = Get-OptionalString -Value (Get-NestedValue -Object $ReviewPair -Path @('sortKey'))
+    surfaces = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewPair -Path @('surfaces') -Default @()) |
+        ForEach-Object { Convert-ReviewBundleSurface -Surface $_ }
+    )
+    reviewerSummary = Convert-ReviewBundleReviewerSummary -ReviewerSummary (Get-NestedValue -Object $ReviewPair -Path @('reviewerSummary'))
+    changeDetails = Convert-ReviewBundleChangeDetails -ChangeDetails (Get-NestedValue -Object $ReviewPair -Path @('changeDetails'))
+  }
+}
+
+function ConvertTo-ReviewCardArray {
+  param(
+    [AllowNull()]
+    $Value
+  )
+
+  return @(
+    ConvertTo-ObjectArray -Value $Value |
+      Sort-Object {
+        $sortKey = Get-OptionalString -Value $_.sortKey
+        if ([string]::IsNullOrWhiteSpace($sortKey)) {
+          '{0}|{1:D4}' -f [string]$_.targetPath, [int](Get-NestedValue -Object $_ -Path @('comparison', 'index') -Default 0)
+        } else {
+          $sortKey
+        }
+      }
+  )
+}
+
+function Convert-ReviewBundleTargetReceipt {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Target
+  )
+
+  $rawPreviewPairs = @(
+    ConvertTo-ObjectArray -Value (Get-NestedValue -Object $Target -Path @('rawPreviewPairs') -Default @()) |
+      ForEach-Object { Convert-ReviewBundleRawPreviewPair -PreviewPair $_ }
+  )
+
+  return [ordered]@{
+    targetId = [string]$Target.targetId
+    targetPath = [string]$Target.targetPath
+    finalStatus = [string](Get-NestedValue -Object $Target -Path @('finalStatus') -Default '')
+    finalReason = [string](Get-NestedValue -Object $Target -Path @('finalReason') -Default '')
+    previewPairCount = [int](Get-NestedValue -Object $Target -Path @('rawPreviewPairCount') -Default $rawPreviewPairs.Count)
+    previewPairs = @(ConvertTo-PreviewPairArray -Value $rawPreviewPairs)
+    reviewPairCount = [int](Get-NestedValue -Object $Target -Path @('reviewPairCount') -Default 0)
+  }
+}
+
+function Select-RepresentativePreviewPairsForCards {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object[]]$Cards,
+    [Parameter(Mandatory = $true)]
+    [object[]]$AllPreviewPairs
+  )
+
+  $firstPairByKey = @{}
+  foreach ($previewPair in @(ConvertTo-PreviewPairArray -Value $AllPreviewPairs)) {
+    $pairKey = Get-ReviewPairKey -TargetId ([string]$previewPair.targetId) -ComparisonIndex ([int](Get-NestedValue -Object $previewPair -Path @('comparison', 'index') -Default 0))
+    if (-not $firstPairByKey.ContainsKey($pairKey)) {
+      $firstPairByKey[$pairKey] = $previewPair
+    }
+  }
+
+  $selectedPairs = New-Object System.Collections.Generic.List[object]
+  foreach ($card in @(ConvertTo-ReviewCardArray -Value $Cards)) {
+    $pairKey = Get-ReviewPairKey -TargetId ([string]$card.targetId) -ComparisonIndex ([int](Get-NestedValue -Object $card -Path @('comparison', 'index') -Default 0))
+    if ($firstPairByKey.ContainsKey($pairKey)) {
+      $selectedPairs.Add($firstPairByKey[$pairKey]) | Out-Null
+    }
+  }
+
+  return @($selectedPairs | ForEach-Object { $_ })
+}
+
 function Get-ReportPreviewPairs {
   param(
     [Parameter(Mandatory = $true)]
@@ -1432,67 +1730,35 @@ if ([string]$targetRunsManifest.schema -ne 'comparevi-history/pr-target-runs-man
   throw "Unsupported target-runs manifest schema in '$manifestPathResolved': $($targetRunsManifest.schema)"
 }
 
-$allPreviewPairs = New-Object System.Collections.Generic.List[object]
-$allChangeDetails = New-Object System.Collections.Generic.List[object]
-$targetReceipts = New-Object System.Collections.Generic.List[object]
-
-foreach ($target in @(ConvertTo-ObjectArray -Value $targetRunsManifest.targets)) {
-  $targetPreviewPairs = New-Object System.Collections.Generic.List[object]
-  $targetRepositoryRoot = Resolve-TargetRepositoryRoot -Target $target -BasePath $basePath
-  $suiteManifestPath = Resolve-ExistingPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $target -Path @('manifestPath'))) -BasePath $basePath -PathType Leaf
-  if ($null -ne $suiteManifestPath) {
-    $suiteManifest = Read-JsonFile -Path $suiteManifestPath
-    foreach ($modeEntry in @(ConvertTo-ObjectArray -Value $suiteManifest.modes)) {
-      $modeName = Get-OptionalString -Value $modeEntry.name
-      $modeManifestPath = Resolve-ExistingPath -Path (Get-OptionalString -Value $modeEntry.manifestPath) -BasePath $basePath -PathType Leaf
-      if ($null -eq $modeManifestPath) {
-        continue
-      }
-
-      $modeManifest = Read-JsonFile -Path $modeManifestPath
-      foreach ($comparison in @(ConvertTo-ObjectArray -Value $modeManifest.comparisons)) {
-        $reportHtmlPath = Resolve-ExistingPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $comparison -Path @('result', 'reportHtml'))) -BasePath $basePath -PathType Leaf
-        if ($null -eq $reportHtmlPath) {
-          $reportHtmlPath = Resolve-ExistingPath -Path (Get-OptionalString -Value (Get-NestedValue -Object $comparison -Path @('result', 'reportPath'))) -BasePath $basePath -PathType Leaf
-        }
-        if ($null -eq $reportHtmlPath) {
-          continue
-        }
-
-        if ($modeName -eq 'attributes') {
-          $changeDetailsRecord = Get-ReviewerChangeDetailsFromReport -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Comparison $comparison -RepositoryRoot $targetRepositoryRoot
-          if ($null -ne $changeDetailsRecord) {
-            $allChangeDetails.Add($changeDetailsRecord) | Out-Null
-          }
-        }
-
-        foreach ($previewPair in @(Get-ReportPreviewPairs -ReportHtmlPath $reportHtmlPath -ResultsRoot $resultsDirResolved -TargetId ([string]$target.targetId) -TargetPath ([string]$target.targetPath) -Mode $modeName -Comparison $comparison -RepositoryRoot $targetRepositoryRoot)) {
-          $targetPreviewPairs.Add($previewPair) | Out-Null
-          $allPreviewPairs.Add($previewPair) | Out-Null
-        }
-      }
-    }
-  }
-
-  $targetReceipts.Add([ordered]@{
-      targetId = [string]$target.targetId
-      targetPath = [string]$target.targetPath
-      finalStatus = [string]$target.finalStatus
-      finalReason = [string]$target.finalReason
-      previewPairCount = $targetPreviewPairs.Count
-      previewPairs = @(ConvertTo-PreviewPairArray -Value $targetPreviewPairs)
-    }) | Out-Null
+$reviewBundlePathResolved = Join-Path $resultsDirResolved 'review-bundle.json'
+$reviewBundlePathResolved = Invoke-CompareVIHistoryReviewBundleCompiler `
+  -TargetRunsManifestPath $manifestPathResolved `
+  -ResultsDir $resultsDirResolved `
+  -OutputPath $reviewBundlePathResolved
+$reviewBundle = Read-JsonFile -Path $reviewBundlePathResolved
+if ([string]$reviewBundle.schema -ne 'comparevi-history/review-bundle@v1') {
+  throw "Unsupported review bundle schema in '$reviewBundlePathResolved': $($reviewBundle.schema)"
 }
 
-$orderedPreviewPairs = @(ConvertTo-PreviewPairArray -Value $allPreviewPairs)
-$reviewerPreviewPairs = @(Get-ReviewerPreviewPairArray -Value $orderedPreviewPairs)
-$commentPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $CommentPreviewPairCap)
-$indexPreviewPairs = @(Select-PreviewPairs -PreviewPairs $orderedPreviewPairs -Limit $IndexPreviewPairCap)
-$allChangeDetailRecords = @($allChangeDetails | ForEach-Object { $_ })
-$reviewerPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $reviewerPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
-$commentPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $commentPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
-$indexPreviewCards = @(New-ReviewerPreviewCards -SelectedPreviewPairs $indexPreviewPairs -AllPreviewPairs $orderedPreviewPairs -AllChangeDetails $allChangeDetailRecords)
-$targetReceiptArray = @($targetReceipts | ForEach-Object { $_ })
+$targetReceiptArray = @(
+  ConvertTo-ObjectArray -Value $reviewBundle.targets |
+    ForEach-Object { Convert-ReviewBundleTargetReceipt -Target $_ }
+)
+$orderedPreviewPairs = @(
+  ConvertTo-ObjectArray -Value $reviewBundle.rawPreviewPairs |
+    ForEach-Object { Convert-ReviewBundleRawPreviewPair -PreviewPair $_ }
+)
+$reviewerPreviewCards = @(
+  ConvertTo-ReviewCardArray -Value @(
+    ConvertTo-ObjectArray -Value $reviewBundle.reviewPairs |
+      ForEach-Object { Convert-ReviewBundleReviewPairCard -ReviewPair $_ }
+  )
+)
+$commentPreviewCards = @($reviewerPreviewCards | Select-Object -First $CommentPreviewPairCap)
+$indexPreviewCards = @($reviewerPreviewCards | Select-Object -First $IndexPreviewPairCap)
+$reviewerPreviewPairs = @(Select-RepresentativePreviewPairsForCards -Cards $reviewerPreviewCards -AllPreviewPairs $orderedPreviewPairs)
+$commentPreviewPairs = @(Select-RepresentativePreviewPairsForCards -Cards $commentPreviewCards -AllPreviewPairs $orderedPreviewPairs)
+$indexPreviewPairs = @(Select-RepresentativePreviewPairsForCards -Cards $indexPreviewCards -AllPreviewPairs $orderedPreviewPairs)
 $orderedPreviewPairArray = @($orderedPreviewPairs | ForEach-Object { $_ })
 $commentPreviewPairArray = @($commentPreviewPairs | ForEach-Object { $_ })
 $indexPreviewPairArray = @($indexPreviewPairs | ForEach-Object { $_ })
@@ -1542,6 +1808,7 @@ $receipt = [ordered]@{
 $receipt | ConvertTo-Json -Depth 64 | Set-Content -LiteralPath $outputPathResolved -Encoding utf8
 
 Write-ActionOutput -Key 'preview-manifest-path' -Value $outputPathResolved
+Write-ActionOutput -Key 'review-bundle-path' -Value $reviewBundlePathResolved
 Write-ActionOutput -Key 'preview-pair-count' -Value ([string]$reviewerPreviewPairs.Count)
 Write-ActionOutput -Key 'raw-preview-pair-count' -Value ([string]$orderedPreviewPairs.Count)
 Write-ActionOutput -Key 'reviewer-preview-pair-count' -Value ([string]$reviewerPreviewPairs.Count)
@@ -1561,6 +1828,7 @@ if (-not [string]::IsNullOrWhiteSpace($StepSummaryPath)) {
     '## comparevi-history PR preview manifest'
     ''
     ('- Preview manifest: `{0}`' -f $outputPathResolved)
+    ('- Review bundle: `{0}`' -f $reviewBundlePathResolved)
     ('- Raw preview pairs: `{0}`' -f $orderedPreviewPairs.Count)
     ('- Reviewer preview cards: `{0}` across `{1}` visual surfaces' -f $reviewerPreviewCards.Count, $reviewerPreviewSurfaceCount)
     ('- Comment preview pairs: `{0}` shown, `{1}` omitted, cap `{2}`' -f $commentPreviewPairs.Count, [Math]::Max($reviewerPreviewPairs.Count - $commentPreviewPairs.Count, 0), [int]$CommentPreviewPairCap)

--- a/src/CompareVIHistory.ReviewCompiler/CompareVIHistory.ReviewCompiler.csproj
+++ b/src/CompareVIHistory.ReviewCompiler/CompareVIHistory.ReviewCompiler.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/CompareVIHistory.ReviewCompiler/CompilerOptions.cs
+++ b/src/CompareVIHistory.ReviewCompiler/CompilerOptions.cs
@@ -1,0 +1,45 @@
+namespace CompareVIHistory.ReviewCompiler;
+
+internal sealed record CompilerOptions(string TargetRunsManifestPath, string ResultsDir, string OutputPath)
+{
+    public static CompilerOptions Parse(string[] args)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < args.Length; index += 1)
+        {
+            var key = args[index];
+            if (!key.StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Unexpected argument '{key}'.");
+            }
+
+            if (index + 1 >= args.Length)
+            {
+                throw new InvalidOperationException($"Missing value for argument '{key}'.");
+            }
+
+            values[key[2..]] = args[index + 1];
+            index += 1;
+        }
+
+        if (!values.TryGetValue("target-runs-manifest-path", out var manifestPath) || string.IsNullOrWhiteSpace(manifestPath))
+        {
+            throw new InvalidOperationException("Missing required argument '--target-runs-manifest-path'.");
+        }
+
+        if (!values.TryGetValue("results-dir", out var resultsDir) || string.IsNullOrWhiteSpace(resultsDir))
+        {
+            throw new InvalidOperationException("Missing required argument '--results-dir'.");
+        }
+
+        values.TryGetValue("output-path", out var outputPath);
+        var basePath = Environment.CurrentDirectory;
+        var resolvedManifestPath = PathHelpers.ResolveAbsolutePath(manifestPath, basePath);
+        var resolvedResultsDir = PathHelpers.ResolveAbsolutePath(resultsDir, basePath);
+        var resolvedOutputPath = string.IsNullOrWhiteSpace(outputPath)
+            ? Path.Combine(resolvedResultsDir, "review-bundle.json")
+            : PathHelpers.ResolveAbsolutePath(outputPath, basePath);
+
+        return new CompilerOptions(resolvedManifestPath, resolvedResultsDir, resolvedOutputPath);
+    }
+}

--- a/src/CompareVIHistory.ReviewCompiler/HtmlReviewParser.cs
+++ b/src/CompareVIHistory.ReviewCompiler/HtmlReviewParser.cs
@@ -1,0 +1,604 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal static class HtmlReviewParser
+{
+    private const int ReviewerChangeDetailGroupCap = 3;
+    private const int ReviewerChangeDetailSampleCap = 3;
+    private const int ReviewerSummarySignalCap = 3;
+
+    public static ReviewChangeDetailsRecord? GetReviewerChangeDetailsFromReport(
+        string reportHtmlPath,
+        string resultsRoot,
+        string targetId,
+        string targetPath,
+        ComparisonManifest comparison,
+        string? repositoryRoot)
+    {
+        if (!File.Exists(reportHtmlPath))
+        {
+            return null;
+        }
+
+        var sectionReceipt = GetReviewerChangeDetailSectionsFromReport(reportHtmlPath, resultsRoot);
+        if (string.IsNullOrWhiteSpace(sectionReceipt.ReportHtml))
+        {
+            return null;
+        }
+
+        var effectiveDebugReportHtmlRelativePath = ReviewCompilerText.CleanString(sectionReceipt.DebugReportHtmlRelativePath)
+            ?? PathHelpers.ResolveRelativePath(reportHtmlPath, resultsRoot);
+        var includedCategories = GetReportIncludedCategories(sectionReceipt.ReportHtml);
+        var groupMap = new Dictionary<string, MutableChangeDetailGroup>(StringComparer.OrdinalIgnoreCase);
+        var groupOrder = new List<string>();
+
+        foreach (var section in sectionReceipt.Sections)
+        {
+            var sectionLinkRecord = new DebugChangeDetailSectionLink
+            {
+                SectionOrdinal = section.Ordinal,
+                Label = $"section {section.Ordinal}",
+                ReviewerRelativePath = null,
+                DebugReportHtmlRelativePath = section.DebugReportHtmlRelativePath
+            };
+            var sectionGroupKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var detailLine in section.DetailLines)
+            {
+                var semanticHeading = GetReviewerSemanticHeadingFromSection(section.Heading, detailLine);
+                if (!groupMap.TryGetValue(semanticHeading, out var groupRecord))
+                {
+                    groupRecord = new MutableChangeDetailGroup { Heading = semanticHeading };
+                    groupMap[semanticHeading] = groupRecord;
+                    groupOrder.Add(semanticHeading);
+                }
+
+                if (sectionGroupKeys.Add(semanticHeading))
+                {
+                    groupRecord.SectionCount += 1;
+                    groupRecord.SectionLinks.Add(sectionLinkRecord);
+                }
+
+                groupRecord.DetailCount += 1;
+                if (groupRecord.SampleDetails.Count < ReviewerChangeDetailSampleCap)
+                {
+                    groupRecord.SampleDetails.Add(detailLine);
+                }
+            }
+        }
+
+        if (groupOrder.Count == 0 && includedCategories.Count == 0)
+        {
+            return null;
+        }
+
+        var groupItems = new List<ReviewChangeDetailGroup>();
+        var sectionCount = 0;
+        var detailCount = 0;
+        foreach (var heading in groupOrder.Take(ReviewerChangeDetailGroupCap))
+        {
+            var groupRecord = groupMap[heading];
+            sectionCount += groupRecord.SectionCount;
+            detailCount += groupRecord.DetailCount;
+            groupItems.Add(new ReviewChangeDetailGroup
+            {
+                Heading = groupRecord.Heading,
+                SectionCount = groupRecord.SectionCount,
+                DetailCount = groupRecord.DetailCount,
+                SampleDetails = groupRecord.SampleDetails.ToArray(),
+                OmittedDetailCount = Math.Max(groupRecord.DetailCount - groupRecord.SampleDetails.Count, 0),
+                PrimaryReviewerRelativePath = null,
+                PrimaryDebugReportHtmlRelativePath = groupRecord.SectionLinks.FirstOrDefault()?.DebugReportHtmlRelativePath,
+                SectionLinks = groupRecord.SectionLinks.ToArray()
+            });
+        }
+
+        foreach (var heading in groupOrder.Skip(ReviewerChangeDetailGroupCap))
+        {
+            var groupRecord = groupMap[heading];
+            sectionCount += groupRecord.SectionCount;
+            detailCount += groupRecord.DetailCount;
+        }
+
+        var comparisonReceipt = ReviewBundleCompiler.BuildComparisonReceipt(comparison, repositoryRoot);
+        return new ReviewChangeDetailsRecord
+        {
+            TargetId = targetId,
+            TargetPath = targetPath,
+            Comparison = comparisonReceipt,
+            SortKey = $"{targetPath}|{comparisonReceipt.Index:D4}|change-details",
+            ChangeDetails = new ReviewChangeDetails
+            {
+                Label = "Change details",
+                SourceMode = "attributes",
+                PrimaryReviewerRelativePath = null,
+                DebugReportHtmlRelativePath = effectiveDebugReportHtmlRelativePath,
+                IncludedCategories = includedCategories.ToArray(),
+                GroupCount = groupOrder.Count,
+                OmittedGroupCount = Math.Max(groupOrder.Count - groupItems.Count, 0),
+                SectionCount = sectionCount,
+                DetailCount = detailCount,
+                Groups = groupItems.ToArray()
+            }
+        };
+    }
+
+    public static RawPreviewPair[] GetReportPreviewPairs(
+        string reportHtmlPath,
+        string resultsRoot,
+        string targetId,
+        string targetPath,
+        string mode,
+        ComparisonManifest comparison,
+        string? repositoryRoot,
+        int modeSortOrder,
+        Func<string?, int> getSectionKindSortOrder)
+    {
+        if (!File.Exists(reportHtmlPath))
+        {
+            return [];
+        }
+
+        var reportHtml = File.ReadAllText(reportHtmlPath);
+        if (string.IsNullOrWhiteSpace(reportHtml))
+        {
+            return [];
+        }
+
+        var reportDirectory = Path.GetDirectoryName(reportHtmlPath)!;
+        var reportHtmlRelativePath = PathHelpers.ResolveRelativePath(reportHtmlPath, resultsRoot);
+        var pairs = new List<RawPreviewPair>();
+        var sectionOrdinal = 0;
+        foreach (Match match in PreviewTableRegex.Matches(reportHtml))
+        {
+            var summaryAttributes = match.Groups["summaryAttrs"].Value;
+            var summaryText = ReviewCompilerText.ConvertFromHtmlText(match.Groups["summary"].Value);
+            var tableHtml = match.Groups["table"].Value;
+            var surfaceCandidates = GetReportPreviewSurfaceCandidates(tableHtml, reportDirectory);
+            var selectedSurface = SelectPreviewSurfaceCandidateForMode(surfaceCandidates, mode);
+            if (selectedSurface is null)
+            {
+                continue;
+            }
+
+            var sectionKind = summaryAttributes.Contains("difference-heading", StringComparison.OrdinalIgnoreCase) ? "overview" : "detail";
+            var label = !string.IsNullOrWhiteSpace(selectedSurface.Label)
+                ? selectedSurface.Label
+                : !string.IsNullOrWhiteSpace(summaryText)
+                    ? summaryText
+                    : "Preview";
+            var comparisonReceipt = ReviewBundleCompiler.BuildComparisonReceipt(comparison, repositoryRoot);
+            var sortKey = $"{targetPath}|{modeSortOrder:D2}|{comparisonReceipt.Index:D4}|{getSectionKindSortOrder(sectionKind):D2}|{sectionOrdinal:D4}|{ReviewCompilerText.ConvertToSlug(label, "preview")}";
+
+            pairs.Add(new RawPreviewPair
+            {
+                TargetId = targetId,
+                TargetPath = targetPath,
+                Mode = mode,
+                Comparison = comparisonReceipt,
+                SectionKind = sectionKind,
+                SectionOrdinal = sectionOrdinal,
+                Label = label,
+                DebugReportHtmlRelativePath = reportHtmlRelativePath,
+                BaseImageRelativePath = PathHelpers.ResolveRelativePath(selectedSurface.BaseImagePath, resultsRoot),
+                HeadImageRelativePath = PathHelpers.ResolveRelativePath(selectedSurface.HeadImagePath, resultsRoot),
+                BaseByteLength = new FileInfo(selectedSurface.BaseImagePath).Length,
+                HeadByteLength = new FileInfo(selectedSurface.HeadImagePath).Length,
+                BaseImageSha256 = PathHelpers.GetFileSha256Hex(selectedSurface.BaseImagePath),
+                HeadImageSha256 = PathHelpers.GetFileSha256Hex(selectedSurface.HeadImagePath),
+                SortKey = sortKey
+            });
+            sectionOrdinal += 1;
+        }
+
+        return pairs.ToArray();
+    }
+
+    public static ReviewerSummary? NewReviewerSummaryFromChangeDetails(ReviewChangeDetails? changeDetails)
+    {
+        if (changeDetails is null)
+        {
+            return null;
+        }
+
+        var signalMap = new Dictionary<string, MutableReviewerSignal>(StringComparer.OrdinalIgnoreCase);
+        foreach (var group in changeDetails.Groups ?? [])
+        {
+            var descriptor = GetReviewerSignalDescriptor(group.Heading, group.DetailCount, group.SectionCount);
+            if (!signalMap.TryGetValue(descriptor.SignalKey, out var signalRecord))
+            {
+                signalRecord = new MutableReviewerSignal
+                {
+                    SignalKey = descriptor.SignalKey,
+                    Label = descriptor.Label,
+                    HeadlineLabel = descriptor.HeadlineLabel,
+                    Severity = descriptor.Severity,
+                    SortOrder = descriptor.SortOrder
+                };
+                signalMap[descriptor.SignalKey] = signalRecord;
+            }
+
+            if (GetReviewerSeverityRank(descriptor.Severity) > GetReviewerSeverityRank(signalRecord.Severity))
+            {
+                signalRecord.Severity = descriptor.Severity;
+            }
+
+            signalRecord.DetailCount += group.DetailCount;
+            signalRecord.SectionCount += group.SectionCount;
+            signalRecord.PrimaryDebugReportHtmlRelativePath ??= group.PrimaryDebugReportHtmlRelativePath;
+            foreach (var sectionLink in group.SectionLinks ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(sectionLink.DebugReportHtmlRelativePath) || string.IsNullOrWhiteSpace(sectionLink.Label))
+                {
+                    continue;
+                }
+
+                if (signalRecord.SectionLinkKeys.Add(sectionLink.DebugReportHtmlRelativePath))
+                {
+                    signalRecord.SectionLinks.Add(new DebugChangeDetailSectionLink
+                    {
+                        SectionOrdinal = sectionLink.SectionOrdinal,
+                        Label = sectionLink.Label,
+                        ReviewerRelativePath = null,
+                        DebugReportHtmlRelativePath = sectionLink.DebugReportHtmlRelativePath
+                    });
+                }
+            }
+        }
+
+        var orderedSignals = signalMap.Values
+            .OrderByDescending(signal => GetReviewerSeverityRank(signal.Severity))
+            .ThenBy(signal => signal.SortOrder)
+            .ThenBy(signal => signal.Label, StringComparer.Ordinal)
+            .ToArray();
+        if (orderedSignals.Length == 0)
+        {
+            return null;
+        }
+
+        var signalItems = orderedSignals
+            .Take(ReviewerSummarySignalCap)
+            .Select(signalRecord => new ReviewerSignal
+            {
+                SignalKey = signalRecord.SignalKey,
+                Label = signalRecord.Label,
+                Severity = signalRecord.Severity,
+                DetailCount = signalRecord.DetailCount,
+                SectionCount = signalRecord.SectionCount,
+                Summary = $"{signalRecord.DetailCount} details across {signalRecord.SectionCount} sections",
+                PrimaryReviewerRelativePath = null,
+                PrimaryDebugReportHtmlRelativePath = signalRecord.PrimaryDebugReportHtmlRelativePath,
+                SectionLinks = signalRecord.SectionLinks.ToArray()
+            })
+            .ToArray();
+
+        var overallSeverity = orderedSignals[0].Severity;
+        var headlineLabels = orderedSignals.Take(2).Select(signal => signal.HeadlineLabel).ToArray();
+        var headlineBody = headlineLabels.Length switch
+        {
+            0 => string.Empty,
+            1 => headlineLabels[0],
+            2 => $"{headlineLabels[0]} and {headlineLabels[1]}",
+            _ => $"{headlineLabels[0]}, {headlineLabels[1]}, and more"
+        };
+        var headlinePrefix = overallSeverity switch
+        {
+            "high" => "High-change",
+            "medium" => "Material",
+            "low" => "Scoped",
+            _ => "Observed"
+        };
+
+        return new ReviewerSummary
+        {
+            Label = "Reviewer summary",
+            OverallSeverity = overallSeverity,
+            Headline = string.IsNullOrWhiteSpace(headlineBody) ? headlinePrefix : $"{headlinePrefix} {headlineBody}",
+            SignalCount = orderedSignals.Length,
+            OmittedSignalCount = Math.Max(orderedSignals.Length - signalItems.Length, 0),
+            Signals = signalItems
+        };
+    }
+
+    private static ChangeDetailSectionReceipt GetReviewerChangeDetailSectionsFromReport(string reportHtmlPath, string resultsRoot)
+    {
+        var reportHtml = File.ReadAllText(reportHtmlPath);
+        if (string.IsNullOrWhiteSpace(reportHtml))
+        {
+            return new ChangeDetailSectionReceipt { ReportHtml = reportHtml };
+        }
+
+        var sections = new List<ParsedChangeDetailSection>();
+        var matches = DetailBlockRegex.Matches(reportHtml);
+        if (matches.Count == 0)
+        {
+            return new ChangeDetailSectionReceipt { ReportHtml = reportHtml };
+        }
+
+        var builder = new StringBuilder();
+        var cursor = 0;
+        var sectionIndex = 0;
+        var htmlChanged = false;
+
+        foreach (Match match in matches)
+        {
+            builder.Append(reportHtml.AsSpan(cursor, match.Index - cursor));
+            var blockHtml = match.Value;
+            var bodyHtml = match.Groups["body"].Value;
+            if (bodyHtml.Contains("detailed-description-list", StringComparison.OrdinalIgnoreCase))
+            {
+                sectionIndex += 1;
+                var summaryText = ReviewCompilerText.ConvertFromHtmlText(match.Groups["summary"].Value);
+                var heading = ReviewCompilerText.NormalizeReviewerChangeDetailHeading(summaryText) ?? "Change details";
+                var sectionOrdinal = ReviewCompilerText.GetReviewerChangeDetailSectionOrdinal(summaryText) ?? sectionIndex;
+                var anchorIdMatch = Regex.Match(match.Groups["detailsAttributes"].Value, "\\bid=\"(?<id>[^\"]+)\"");
+                var anchorId = ReviewCompilerText.GetOptionalString(anchorIdMatch.Groups["id"].Value);
+                if (string.IsNullOrWhiteSpace(anchorId))
+                {
+                    anchorId = $"comparevi-change-{sectionOrdinal:D3}-{ReviewCompilerText.ConvertToSlug(heading, "change-detail")}";
+                    var openTag = match.Groups["open"].Value;
+                    var updatedOpenTag = Regex.IsMatch(openTag, "\\bid=\"[^\"]+\"")
+                        ? openTag
+                        : openTag.Insert(openTag.Length - 1, $" id=\"{anchorId}\"");
+                    blockHtml = updatedOpenTag + blockHtml[openTag.Length..];
+                    htmlChanged = true;
+                }
+
+                var detailLines = DiffDetailRegex.Matches(bodyHtml)
+                    .Select(detailMatch => ReviewCompilerText.ConvertFromHtmlText(detailMatch.Groups["detail"].Value))
+                    .Where(detailLine => !string.IsNullOrWhiteSpace(detailLine))
+                    .ToArray();
+                if (detailLines.Length > 0)
+                {
+                    sections.Add(new ParsedChangeDetailSection
+                    {
+                        Index = sectionIndex,
+                        Ordinal = sectionOrdinal,
+                        Heading = heading,
+                        AnchorId = anchorId!,
+                        DetailLines = detailLines
+                    });
+                }
+            }
+
+            builder.Append(blockHtml);
+            cursor = match.Index + match.Length;
+        }
+
+        if (cursor < reportHtml.Length)
+        {
+            builder.Append(reportHtml[cursor..]);
+        }
+
+        var updatedReportHtml = builder.ToString();
+        var effectiveReportHtmlPath = reportHtmlPath;
+        if (htmlChanged && !string.Equals(updatedReportHtml, reportHtml, StringComparison.Ordinal))
+        {
+            effectiveReportHtmlPath = GetReviewerAnchoredReportPath(reportHtmlPath);
+            File.WriteAllText(effectiveReportHtmlPath, updatedReportHtml, Encoding.UTF8);
+        }
+
+        var effectiveDebugReportHtmlRelativePath = PathHelpers.ResolveRelativePath(effectiveReportHtmlPath, resultsRoot);
+        foreach (var section in sections)
+        {
+            section.DebugReportHtmlRelativePath = $"{effectiveDebugReportHtmlRelativePath}#{section.AnchorId}";
+        }
+
+        return new ChangeDetailSectionReceipt
+        {
+            ReportHtml = updatedReportHtml,
+            DebugReportHtmlRelativePath = effectiveDebugReportHtmlRelativePath,
+            Sections = sections.ToArray()
+        };
+    }
+
+    private static string GetReviewerAnchoredReportPath(string reportHtmlPath)
+    {
+        var directory = Path.GetDirectoryName(reportHtmlPath)!;
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(reportHtmlPath);
+        var extension = Path.GetExtension(reportHtmlPath);
+        return Path.Combine(directory, $"{fileNameWithoutExtension}.reviewer-anchors{extension}");
+    }
+
+    private static List<string> GetReportIncludedCategories(string reportHtml)
+    {
+        var includedCategories = new List<string>();
+        var includedBlockMatch = IncludedAttributesRegex.Match(reportHtml);
+        if (!includedBlockMatch.Success)
+        {
+            return includedCategories;
+        }
+
+        foreach (Match itemMatch in CheckedAttributeRegex.Matches(includedBlockMatch.Groups["list"].Value))
+        {
+            var itemText = ReviewCompilerText.ConvertFromHtmlText(itemMatch.Groups["item"].Value);
+            if (!string.IsNullOrWhiteSpace(itemText))
+            {
+                includedCategories.Add(itemText);
+            }
+        }
+
+        return includedCategories;
+    }
+
+    private static PreviewSurfaceCandidate[] GetReportPreviewSurfaceCandidates(string tableHtml, string reportDirectory)
+    {
+        var candidates = new List<PreviewSurfaceCandidate>();
+        foreach (Match surfaceMatch in PreviewSurfaceRegex.Matches(tableHtml))
+        {
+            var caption = ReviewCompilerText.ConvertFromHtmlText(surfaceMatch.Groups["caption"].Value);
+            var imageSources = ImageSourceRegex.Matches(surfaceMatch.Groups["images"].Value)
+                .Select(match => ReviewCompilerText.GetOptionalString(match.Groups["src"].Value))
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Cast<string>()
+                .ToArray();
+            if (imageSources.Length < 2)
+            {
+                continue;
+            }
+
+            var baseImagePath = PathHelpers.ResolveExistingFilePath(imageSources[0], reportDirectory);
+            var headImagePath = PathHelpers.ResolveExistingFilePath(imageSources[1], reportDirectory);
+            if (string.IsNullOrWhiteSpace(baseImagePath) || string.IsNullOrWhiteSpace(headImagePath))
+            {
+                continue;
+            }
+
+            candidates.Add(new PreviewSurfaceCandidate(caption, baseImagePath!, headImagePath!));
+        }
+
+        return candidates.ToArray();
+    }
+
+    private static PreviewSurfaceCandidate? SelectPreviewSurfaceCandidateForMode(PreviewSurfaceCandidate[] candidates, string mode)
+    {
+        if (candidates.Length == 0)
+        {
+            return null;
+        }
+
+        var matchingCandidate = candidates.FirstOrDefault(candidate => PreviewSurfaceMatchesMode(candidate, mode));
+        if (matchingCandidate is not null)
+        {
+            return matchingCandidate;
+        }
+
+        return string.Equals(mode, "front-panel", StringComparison.OrdinalIgnoreCase) ? candidates[0] : null;
+    }
+
+    private static bool PreviewSurfaceMatchesMode(PreviewSurfaceCandidate candidate, string mode)
+    {
+        var label = candidate.Label.ToLowerInvariant();
+        var baseName = Path.GetFileName(candidate.BaseImagePath).ToLowerInvariant();
+        var headName = Path.GetFileName(candidate.HeadImagePath).ToLowerInvariant();
+        return mode switch
+        {
+            "front-panel" => label.Contains("front panel", StringComparison.Ordinal) || baseName.StartsWith("fp_", StringComparison.Ordinal) || headName.StartsWith("fp_", StringComparison.Ordinal),
+            "block-diagram" => label.Contains("block diagram", StringComparison.Ordinal) || baseName.StartsWith("bd_", StringComparison.Ordinal) || headName.StartsWith("bd_", StringComparison.Ordinal),
+            "attributes" => label.Contains("attribute", StringComparison.Ordinal),
+            _ => false
+        };
+    }
+
+    private static string GetReviewerSemanticHeadingFromSection(string sectionHeading, string? detailLine)
+    {
+        var normalizedHeading = ReviewCompilerText.NormalizeReviewerChangeDetailHeading(sectionHeading);
+        if (string.IsNullOrWhiteSpace(normalizedHeading))
+        {
+            return "Change details";
+        }
+
+        var (subject, action) = ReviewCompilerText.GetReviewerChangeDetailLineParts(detailLine);
+        action = ReviewCompilerText.CleanString(action)?.ToLowerInvariant();
+        return normalizedHeading switch
+        {
+            "Block Diagram objects" => action switch
+            {
+                "moved" => "Block diagram moves",
+                "resized" => "Block diagram resizing",
+                "deleted" => "Removed block diagram objects",
+                "added" => "Added block diagram objects",
+                _ => "Block diagram object changes"
+            },
+            "Front Panel objects" => action switch
+            {
+                "moved" => "Front panel layout moves",
+                "resized" => "Front panel resizing",
+                "deleted" => "Removed front panel objects",
+                "added" => "Added front panel objects",
+                _ => "Front panel object changes"
+            },
+            var value when value.StartsWith("VI Attribute", StringComparison.Ordinal) => subject switch
+            {
+                not null when subject.StartsWith("VI Version", StringComparison.Ordinal) => "VI version changes",
+                not null when subject.StartsWith("Execution", StringComparison.Ordinal) => "Execution changes",
+                not null when subject.StartsWith("Icon", StringComparison.Ordinal) => "Icon changes",
+                _ => "VI attribute changes"
+            },
+            _ => normalizedHeading
+        };
+    }
+
+    private static ReviewerSignalDescriptor GetReviewerSignalDescriptor(string? heading, int detailCount, int sectionCount)
+    {
+        var normalizedHeading = ReviewCompilerText.NormalizeReviewerChangeDetailHeading(heading);
+        if (string.IsNullOrWhiteSpace(normalizedHeading))
+        {
+            return new ReviewerSignalDescriptor("diagnostic-change", "Additional diagnostic changes", "additional diagnostic changes", "low", 90);
+        }
+
+        return normalizedHeading switch
+        {
+            "Block diagram moves" => new ReviewerSignalDescriptor("logic-movement", "Logic-affecting movement", "logic-affecting movement", detailCount >= 10 || sectionCount >= 3 ? "high" : "medium", 10),
+            "Block diagram resizing" => new ReviewerSignalDescriptor("structure-resizing", "Structure resizing", "structure resizing", detailCount >= 5 || sectionCount >= 2 ? "medium" : "low", 20),
+            "Added block diagram objects" or "Removed block diagram objects" => new ReviewerSignalDescriptor("object-topology", "Object additions or removals", "object additions or removals", "high", 5),
+            "Front panel layout moves" or "Front panel resizing" or "Front panel object changes" or "Added front panel objects" or "Removed front panel objects" => new ReviewerSignalDescriptor("layout-changes", "Layout changes", "layout changes", detailCount >= 8 || sectionCount >= 3 ? "medium" : "low", 40),
+            "Execution changes" => new ReviewerSignalDescriptor("execution-behavior", "Execution behavior changes", "execution behavior changes", "high", 15),
+            "VI version changes" => new ReviewerSignalDescriptor("version-compatibility", "Version or compatibility changes", "version or compatibility changes", "medium", 30),
+            "Icon changes" => new ReviewerSignalDescriptor("visual-presentation", "Visual presentation changes", "visual presentation changes", "low", 60),
+            "VI attribute changes" => new ReviewerSignalDescriptor("metadata", "Metadata changes", "metadata changes", "low", 50),
+            _ => new ReviewerSignalDescriptor("diagnostic-change", "Additional diagnostic changes", "additional diagnostic changes", "low", 90)
+        };
+    }
+
+    private static int GetReviewerSeverityRank(string? severity) => severity switch
+    {
+        "high" => 3,
+        "medium" => 2,
+        "low" => 1,
+        _ => 0
+    };
+
+    private sealed class MutableChangeDetailGroup
+    {
+        public string Heading { get; init; } = string.Empty;
+        public int SectionCount { get; set; }
+        public int DetailCount { get; set; }
+        public List<string> SampleDetails { get; } = [];
+        public List<DebugChangeDetailSectionLink> SectionLinks { get; } = [];
+    }
+
+    private sealed class MutableReviewerSignal
+    {
+        public string SignalKey { get; init; } = string.Empty;
+        public string Label { get; init; } = string.Empty;
+        public string HeadlineLabel { get; init; } = string.Empty;
+        public string Severity { get; set; } = "low";
+        public int SortOrder { get; init; }
+        public int DetailCount { get; set; }
+        public int SectionCount { get; set; }
+        public string? PrimaryDebugReportHtmlRelativePath { get; set; }
+        public HashSet<string> SectionLinkKeys { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public List<DebugChangeDetailSectionLink> SectionLinks { get; } = [];
+    }
+
+    private sealed record PreviewSurfaceCandidate(string Label, string BaseImagePath, string HeadImagePath);
+    private sealed record ReviewerSignalDescriptor(string SignalKey, string Label, string HeadlineLabel, string Severity, int SortOrder);
+
+    private sealed class ChangeDetailSectionReceipt
+    {
+        public string? ReportHtml { get; init; }
+        public string? DebugReportHtmlRelativePath { get; init; }
+        public ParsedChangeDetailSection[] Sections { get; init; } = [];
+    }
+
+    private sealed class ParsedChangeDetailSection
+    {
+        public int Index { get; init; }
+        public int Ordinal { get; init; }
+        public string Heading { get; init; } = string.Empty;
+        public string AnchorId { get; init; } = string.Empty;
+        public string[] DetailLines { get; init; } = [];
+        public string? DebugReportHtmlRelativePath { get; set; }
+    }
+
+    private static readonly Regex DetailBlockRegex = new("(?is)(?<open><details(?<detailsAttributes>[^>]*)>)\\s*<summary(?<summaryAttributes>[^>]*)>(?<summary>.*?)</summary>(?<body>.*?)</details>", RegexOptions.Compiled);
+    private static readonly Regex DiffDetailRegex = new("(?is)<li class=\"[^\"]*diff-detail[^\"]*\">(?<detail>.*?)</li>", RegexOptions.Compiled);
+    private static readonly Regex IncludedAttributesRegex = new("(?is)<div class=\"included-attributes\".*?<ul[^>]*>(?<list>.*?)</ul>", RegexOptions.Compiled);
+    private static readonly Regex CheckedAttributeRegex = new("(?is)<li class=\"checked\">(?<item>.*?)</li>", RegexOptions.Compiled);
+    private static readonly Regex PreviewTableRegex = new("(?is)<details(?<detailsAttrs>[^>]*)>\\s*<summary(?<summaryAttrs>[^>]*)>(?<summary>.*?)</summary>\\s*<table class=\"difference\">(?<table>.*?)</table>\\s*</details>", RegexOptions.Compiled);
+    private static readonly Regex PreviewSurfaceRegex = new("(?is)<tr class=\"compared-vi-image-captions\">.*?<td class=\"compared-vi-image-caption\">(?<caption>.*?)</td>.*?</tr>\\s*<tr class=\"compared-images\">(?<images>.*?)</tr>", RegexOptions.Compiled);
+    private static readonly Regex ImageSourceRegex = new("(?is)<img[^>]+src=\"(?<src>[^\"]+)\"", RegexOptions.Compiled);
+}

--- a/src/CompareVIHistory.ReviewCompiler/InputModels.cs
+++ b/src/CompareVIHistory.ReviewCompiler/InputModels.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Serialization;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal sealed class TargetRunsManifest
+{
+    [JsonPropertyName("schema")]
+    public string? Schema { get; set; }
+
+    [JsonPropertyName("targets")]
+    public TargetRun[]? Targets { get; set; }
+}
+
+internal sealed class TargetRun
+{
+    [JsonPropertyName("targetId")]
+    public string? TargetId { get; set; }
+
+    [JsonPropertyName("targetPath")]
+    public string? TargetPath { get; set; }
+
+    [JsonPropertyName("finalStatus")]
+    public string? FinalStatus { get; set; }
+
+    [JsonPropertyName("finalReason")]
+    public string? FinalReason { get; set; }
+
+    [JsonPropertyName("manifestPath")]
+    public string? ManifestPath { get; set; }
+
+    [JsonPropertyName("publicRunPath")]
+    public string? PublicRunPath { get; set; }
+}
+
+internal sealed class HistorySuiteManifest
+{
+    [JsonPropertyName("modes")]
+    public HistoryModeEntry[]? Modes { get; set; }
+}
+
+internal sealed class HistoryModeEntry
+{
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("manifestPath")]
+    public string? ManifestPath { get; set; }
+}
+
+internal sealed class HistoryModeManifest
+{
+    [JsonPropertyName("comparisons")]
+    public ComparisonManifest[]? Comparisons { get; set; }
+}
+
+internal sealed class ComparisonManifest
+{
+    [JsonPropertyName("index")]
+    public int Index { get; set; }
+
+    [JsonPropertyName("base")]
+    public ComparisonRef? Base { get; set; }
+
+    [JsonPropertyName("head")]
+    public ComparisonRef? Head { get; set; }
+
+    [JsonPropertyName("result")]
+    public ComparisonResult? Result { get; set; }
+}
+
+internal sealed class ComparisonRef
+{
+    [JsonPropertyName("ref")]
+    public string? Ref { get; set; }
+
+    [JsonPropertyName("short")]
+    public string? Short { get; set; }
+}
+
+internal sealed class ComparisonResult
+{
+    [JsonPropertyName("reportHtml")]
+    public string? ReportHtml { get; set; }
+
+    [JsonPropertyName("reportPath")]
+    public string? ReportPath { get; set; }
+}
+
+internal sealed class PublicRunReceipt
+{
+    [JsonPropertyName("request")]
+    public PublicRunRequest? Request { get; set; }
+}
+
+internal sealed class PublicRunRequest
+{
+    [JsonPropertyName("consumer")]
+    public PublicRunConsumer? Consumer { get; set; }
+}
+
+internal sealed class PublicRunConsumer
+{
+    [JsonPropertyName("repositoryRoot")]
+    public string? RepositoryRoot { get; set; }
+}

--- a/src/CompareVIHistory.ReviewCompiler/PathHelpers.cs
+++ b/src/CompareVIHistory.ReviewCompiler/PathHelpers.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal static class PathHelpers
+{
+    public static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    private static readonly ConcurrentDictionary<string, string?> GitCommitSubjectCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public static string ResolveAbsolutePath(string path, string basePath)
+    {
+        return Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(Path.Combine(basePath, path));
+    }
+
+    public static string? ResolveExistingFilePath(string? path, string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var resolvedPath = ResolveAbsolutePath(path, basePath);
+        return File.Exists(resolvedPath) ? resolvedPath : null;
+    }
+
+    public static string? ResolveExistingDirectoryPath(string? path, string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var resolvedPath = ResolveAbsolutePath(path, basePath);
+        return Directory.Exists(resolvedPath) ? resolvedPath : null;
+    }
+
+    public static string ResolveRelativePath(string path, string resultsRoot)
+    {
+        var resolvedPath = ResolveAbsolutePath(path, resultsRoot);
+        return Path.GetRelativePath(resultsRoot, resolvedPath).Replace('\\', '/');
+    }
+
+    public static string GetFileSha256Hex(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var sha256 = SHA256.Create();
+        return Convert.ToHexString(sha256.ComputeHash(stream)).ToLowerInvariant();
+    }
+
+    public static T ReadJsonFile<T>(string path)
+    {
+        var raw = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new InvalidOperationException($"JSON file was empty: {path}");
+        }
+
+        return JsonSerializer.Deserialize<T>(raw, JsonOptions)
+            ?? throw new InvalidOperationException($"Failed to deserialize JSON file: {path}");
+    }
+
+    public static string? GetGitCommitSubject(string? repositoryRoot, string? @ref)
+    {
+        repositoryRoot = ReviewCompilerText.CleanString(repositoryRoot);
+        @ref = ReviewCompilerText.CleanString(@ref);
+        if (string.IsNullOrWhiteSpace(repositoryRoot) || string.IsNullOrWhiteSpace(@ref))
+        {
+            return null;
+        }
+
+        var cacheKey = $"{repositoryRoot}|{@ref}";
+        if (GitCommitSubjectCache.TryGetValue(cacheKey, out var cachedSubject))
+        {
+            return cachedSubject;
+        }
+
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = repositoryRoot
+        };
+        processStartInfo.ArgumentList.Add("show");
+        processStartInfo.ArgumentList.Add("-s");
+        processStartInfo.ArgumentList.Add("--format=%s");
+        processStartInfo.ArgumentList.Add(@ref);
+
+        try
+        {
+            using var process = Process.Start(processStartInfo);
+            if (process is null)
+            {
+                GitCommitSubjectCache[cacheKey] = null;
+                return null;
+            }
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+            var subject = process.ExitCode == 0 ? ReviewCompilerText.CleanString(stdout) : null;
+            GitCommitSubjectCache[cacheKey] = subject;
+            return subject;
+        }
+        catch
+        {
+            GitCommitSubjectCache[cacheKey] = null;
+            return null;
+        }
+    }
+}

--- a/src/CompareVIHistory.ReviewCompiler/Program.cs
+++ b/src/CompareVIHistory.ReviewCompiler/Program.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using System.Text.Json;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal static class Program
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static int Main(string[] args)
+    {
+        try
+        {
+            var options = CompilerOptions.Parse(args);
+            var bundle = ReviewBundleCompiler.Build(options);
+            Directory.CreateDirectory(Path.GetDirectoryName(options.OutputPath)!);
+            var json = JsonSerializer.Serialize(bundle, JsonOptions);
+            File.WriteAllText(options.OutputPath, json, Encoding.UTF8);
+            Console.WriteLine(json);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+}

--- a/src/CompareVIHistory.ReviewCompiler/ReviewBundleCompiler.cs
+++ b/src/CompareVIHistory.ReviewCompiler/ReviewBundleCompiler.cs
@@ -1,0 +1,297 @@
+using System.Globalization;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal static class ReviewBundleCompiler
+{
+    private static readonly IReadOnlyDictionary<string, int> ModeOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["front-panel"] = 0,
+        ["block-diagram"] = 1,
+        ["attributes"] = 2
+    };
+
+    private static readonly IReadOnlyDictionary<string, int> SectionKindOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["overview"] = 0,
+        ["detail"] = 1
+    };
+
+    public static ReviewBundle Build(CompilerOptions options)
+    {
+        if (!File.Exists(options.TargetRunsManifestPath))
+        {
+            throw new InvalidOperationException($"Target-runs manifest not found: {options.TargetRunsManifestPath}");
+        }
+
+        if (!Directory.Exists(options.ResultsDir))
+        {
+            throw new InvalidOperationException($"Results directory not found: {options.ResultsDir}");
+        }
+
+        var targetRunsManifest = PathHelpers.ReadJsonFile<TargetRunsManifest>(options.TargetRunsManifestPath);
+        if (!string.Equals(targetRunsManifest.Schema, "comparevi-history/pr-target-runs-manifest@v2", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Unsupported target-runs manifest schema in '{options.TargetRunsManifestPath}': {targetRunsManifest.Schema}");
+        }
+
+        var basePath = Environment.CurrentDirectory;
+        var allRawPreviewPairs = new List<RawPreviewPair>();
+        var allChangeDetails = new List<ReviewChangeDetailsRecord>();
+        var targetContexts = new List<TargetContext>();
+
+        foreach (var target in targetRunsManifest.Targets ?? [])
+        {
+            var targetId = ReviewCompilerText.CleanString(target.TargetId) ?? string.Empty;
+            var targetPath = ReviewCompilerText.CleanString(target.TargetPath) ?? string.Empty;
+            var targetRepositoryRoot = ResolveTargetRepositoryRoot(target, basePath);
+            var suiteManifestPath = PathHelpers.ResolveExistingFilePath(ReviewCompilerText.CleanString(target.ManifestPath), basePath);
+            var targetRawPreviewPairs = new List<RawPreviewPair>();
+
+            if (!string.IsNullOrWhiteSpace(suiteManifestPath))
+            {
+                var suiteManifest = PathHelpers.ReadJsonFile<HistorySuiteManifest>(suiteManifestPath!);
+                foreach (var modeEntry in suiteManifest.Modes ?? [])
+                {
+                    var modeName = ReviewCompilerText.CleanString(modeEntry.Name);
+                    if (string.IsNullOrWhiteSpace(modeName))
+                    {
+                        continue;
+                    }
+
+                    var modeManifestPath = PathHelpers.ResolveExistingFilePath(ReviewCompilerText.CleanString(modeEntry.ManifestPath), basePath);
+                    if (string.IsNullOrWhiteSpace(modeManifestPath))
+                    {
+                        continue;
+                    }
+
+                    var modeManifest = PathHelpers.ReadJsonFile<HistoryModeManifest>(modeManifestPath!);
+                    foreach (var comparison in modeManifest.Comparisons ?? [])
+                    {
+                        var reportHtmlPath = PathHelpers.ResolveExistingFilePath(ReviewCompilerText.CleanString(comparison.Result?.ReportHtml), basePath)
+                            ?? PathHelpers.ResolveExistingFilePath(ReviewCompilerText.CleanString(comparison.Result?.ReportPath), basePath);
+                        if (string.IsNullOrWhiteSpace(reportHtmlPath))
+                        {
+                            continue;
+                        }
+
+                        if (string.Equals(modeName, "attributes", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var changeDetails = HtmlReviewParser.GetReviewerChangeDetailsFromReport(
+                                reportHtmlPath!,
+                                options.ResultsDir,
+                                targetId,
+                                targetPath,
+                                comparison,
+                                targetRepositoryRoot);
+                            if (changeDetails is not null)
+                            {
+                                allChangeDetails.Add(changeDetails);
+                            }
+                        }
+
+                        foreach (var rawPreviewPair in HtmlReviewParser.GetReportPreviewPairs(
+                                     reportHtmlPath!,
+                                     options.ResultsDir,
+                                     targetId,
+                                     targetPath,
+                                     modeName!,
+                                     comparison,
+                                     targetRepositoryRoot,
+                                     GetModeSortOrder(modeName),
+                                     GetSectionKindSortOrder))
+                        {
+                            targetRawPreviewPairs.Add(rawPreviewPair);
+                            allRawPreviewPairs.Add(rawPreviewPair);
+                        }
+                    }
+                }
+            }
+
+            targetContexts.Add(new TargetContext(target, targetRawPreviewPairs));
+        }
+
+        var orderedRawPreviewPairs = allRawPreviewPairs.OrderBy(static pair => pair.SortKey, StringComparer.Ordinal).ToArray();
+        var reviewPairs = BuildReviewPairs(orderedRawPreviewPairs, allChangeDetails);
+        var reviewPairsByTargetId = reviewPairs
+            .GroupBy(static pair => pair.TargetId, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(static group => group.Key, static group => group.ToArray(), StringComparer.OrdinalIgnoreCase);
+
+        var targets = targetContexts.Select(context =>
+        {
+            reviewPairsByTargetId.TryGetValue(ReviewCompilerText.CleanString(context.Target.TargetId) ?? string.Empty, out var targetReviewPairs);
+            targetReviewPairs ??= [];
+            return new ReviewBundleTarget
+            {
+                TargetId = ReviewCompilerText.CleanString(context.Target.TargetId) ?? string.Empty,
+                TargetPath = ReviewCompilerText.CleanString(context.Target.TargetPath) ?? string.Empty,
+                FinalStatus = ReviewCompilerText.CleanString(context.Target.FinalStatus),
+                FinalReason = ReviewCompilerText.CleanString(context.Target.FinalReason),
+                RawPreviewPairCount = context.RawPreviewPairs.Count,
+                RawPreviewPairs = context.RawPreviewPairs.OrderBy(static pair => pair.SortKey, StringComparer.Ordinal).ToArray(),
+                ReviewPairCount = targetReviewPairs.Length
+            };
+        }).ToArray();
+
+        return new ReviewBundle
+        {
+            Schema = "comparevi-history/review-bundle@v1",
+            GeneratedAtUtc = DateTime.UtcNow,
+            TargetRunsManifestPath = options.TargetRunsManifestPath,
+            ResultsDir = options.ResultsDir,
+            Summary = new ReviewBundleSummary
+            {
+                TargetCount = targets.Length,
+                RawPreviewPairCount = orderedRawPreviewPairs.Length,
+                ReviewPairCount = reviewPairs.Length,
+                PrimaryReviewerDestinationPolicy = "pair-level@v1"
+            },
+            Targets = targets,
+            RawPreviewPairs = orderedRawPreviewPairs,
+            ReviewPairs = reviewPairs
+        };
+    }
+
+    private static ReviewPair[] BuildReviewPairs(IReadOnlyList<RawPreviewPair> orderedRawPreviewPairs, IReadOnlyList<ReviewChangeDetailsRecord> allChangeDetails)
+    {
+        var changeDetailsByCardKey = allChangeDetails.ToDictionary(
+            static record => GetReviewPairKey(record.TargetId, record.Comparison.Index),
+            static record => record.ChangeDetails,
+            StringComparer.OrdinalIgnoreCase);
+
+        var reviewPairs = new List<ReviewPair>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var selectedPreviewPair in orderedRawPreviewPairs)
+        {
+            var reviewPairKey = GetReviewPairKey(selectedPreviewPair.TargetId, selectedPreviewPair.Comparison.Index);
+            if (!seen.Add(reviewPairKey))
+            {
+                continue;
+            }
+
+            var matchingPairs = orderedRawPreviewPairs
+                .Where(pair => string.Equals(GetReviewPairKey(pair.TargetId, pair.Comparison.Index), reviewPairKey, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+
+            var surfaces = new List<ReviewSurface>();
+            var seenSurfaceKinds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var matchingPair in matchingPairs)
+            {
+                var surfaceKind = matchingPair.Mode switch
+                {
+                    "front-panel" => "front-panel",
+                    "block-diagram" => "block-diagram",
+                    _ => string.Empty
+                };
+                if (string.IsNullOrWhiteSpace(surfaceKind) || !seenSurfaceKinds.Add(surfaceKind))
+                {
+                    continue;
+                }
+
+                surfaces.Add(new ReviewSurface
+                {
+                    SurfaceKind = surfaceKind,
+                    SurfaceLabel = surfaceKind == "front-panel" ? "Front panel" : "Block diagram",
+                    Mode = ReviewCompilerText.CleanString(matchingPair.Mode),
+                    Label = matchingPair.Label,
+                    PrimaryReviewerRelativePath = null,
+                    DebugReportHtmlRelativePath = matchingPair.DebugReportHtmlRelativePath,
+                    BaseImageRelativePath = matchingPair.BaseImageRelativePath,
+                    HeadImageRelativePath = matchingPair.HeadImageRelativePath,
+                    BaseByteLength = matchingPair.BaseByteLength,
+                    HeadByteLength = matchingPair.HeadByteLength,
+                    BaseImageSha256 = matchingPair.BaseImageSha256,
+                    HeadImageSha256 = matchingPair.HeadImageSha256,
+                    SortKey = matchingPair.SortKey
+                });
+            }
+
+            changeDetailsByCardKey.TryGetValue(reviewPairKey, out var changeDetails);
+            reviewPairs.Add(new ReviewPair
+            {
+                ReviewPairKey = reviewPairKey,
+                TargetId = selectedPreviewPair.TargetId,
+                TargetPath = selectedPreviewPair.TargetPath,
+                Comparison = selectedPreviewPair.Comparison,
+                SortKey = selectedPreviewPair.SortKey,
+                PrimaryReviewerDestination = new ReviewerDestination
+                {
+                    Kind = "history-pair-review-page",
+                    RelativePath = null
+                },
+                DebugDestinations = new DebugDestinations
+                {
+                    FrontPanelReportHtmlRelativePath = matchingPairs.FirstOrDefault(pair => string.Equals(pair.Mode, "front-panel", StringComparison.OrdinalIgnoreCase))?.DebugReportHtmlRelativePath,
+                    BlockDiagramReportHtmlRelativePath = matchingPairs.FirstOrDefault(pair => string.Equals(pair.Mode, "block-diagram", StringComparison.OrdinalIgnoreCase))?.DebugReportHtmlRelativePath,
+                    ChangeDetailsReportHtmlRelativePath = changeDetails?.DebugReportHtmlRelativePath
+                },
+                Surfaces = surfaces.ToArray(),
+                ReviewerSummary = HtmlReviewParser.NewReviewerSummaryFromChangeDetails(changeDetails),
+                ChangeDetails = changeDetails
+            });
+        }
+
+        return reviewPairs.ToArray();
+    }
+
+    private static string GetReviewPairKey(string targetId, int comparisonIndex) => $"{targetId}|{comparisonIndex}";
+
+    private static string? ResolveTargetRepositoryRoot(TargetRun target, string basePath)
+    {
+        var publicRunPath = PathHelpers.ResolveExistingFilePath(ReviewCompilerText.CleanString(target.PublicRunPath), basePath);
+        if (string.IsNullOrWhiteSpace(publicRunPath))
+        {
+            return null;
+        }
+
+        PublicRunReceipt? publicRun;
+        try
+        {
+            publicRun = PathHelpers.ReadJsonFile<PublicRunReceipt>(publicRunPath!);
+        }
+        catch
+        {
+            return null;
+        }
+
+        var repositoryRoot = ReviewCompilerText.CleanString(publicRun.Request?.Consumer?.RepositoryRoot);
+        if (string.IsNullOrWhiteSpace(repositoryRoot))
+        {
+            return null;
+        }
+
+        var resolvedRepositoryRoot = PathHelpers.ResolveExistingDirectoryPath(repositoryRoot, basePath);
+        if (string.IsNullOrWhiteSpace(resolvedRepositoryRoot))
+        {
+            return null;
+        }
+
+        var gitPath = Path.Combine(resolvedRepositoryRoot!, ".git");
+        return File.Exists(gitPath) || Directory.Exists(gitPath) ? resolvedRepositoryRoot : null;
+    }
+
+    internal static ComparisonReceipt BuildComparisonReceipt(ComparisonManifest comparison, string? repositoryRoot)
+    {
+        var baseRef = ReviewCompilerText.CleanString(comparison.Base?.Ref);
+        var headRef = ReviewCompilerText.CleanString(comparison.Head?.Ref);
+        return new ComparisonReceipt
+        {
+            Index = comparison.Index,
+            BaseRef = baseRef,
+            HeadRef = headRef,
+            BaseShortRef = ReviewCompilerText.CleanString(comparison.Base?.Short) ?? ReviewCompilerText.ConvertToShortRef(baseRef),
+            HeadShortRef = ReviewCompilerText.CleanString(comparison.Head?.Short) ?? ReviewCompilerText.ConvertToShortRef(headRef),
+            BaseSubject = PathHelpers.GetGitCommitSubject(repositoryRoot, baseRef),
+            HeadSubject = PathHelpers.GetGitCommitSubject(repositoryRoot, headRef)
+        };
+    }
+
+    private static int GetModeSortOrder(string? mode) => mode is not null && ModeOrder.TryGetValue(mode, out var order) ? order : 99;
+    private static int GetSectionKindSortOrder(string? sectionKind) => sectionKind is not null && SectionKindOrder.TryGetValue(sectionKind, out var order) ? order : 99;
+
+    private sealed class TargetContext(TargetRun target, List<RawPreviewPair> rawPreviewPairs)
+    {
+        public TargetRun Target { get; } = target;
+        public List<RawPreviewPair> RawPreviewPairs { get; } = rawPreviewPairs;
+    }
+}

--- a/src/CompareVIHistory.ReviewCompiler/ReviewBundleModels.cs
+++ b/src/CompareVIHistory.ReviewCompiler/ReviewBundleModels.cs
@@ -1,0 +1,195 @@
+using System.Text.Json.Serialization;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal sealed class ReviewBundle
+{
+    [JsonPropertyName("schema")]
+    public string Schema { get; set; } = string.Empty;
+
+    [JsonPropertyName("generatedAtUtc")]
+    public DateTime GeneratedAtUtc { get; set; }
+
+    [JsonPropertyName("targetRunsManifestPath")]
+    public string TargetRunsManifestPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("resultsDir")]
+    public string ResultsDir { get; set; } = string.Empty;
+
+    [JsonPropertyName("summary")]
+    public ReviewBundleSummary Summary { get; set; } = new();
+
+    [JsonPropertyName("targets")]
+    public ReviewBundleTarget[] Targets { get; set; } = [];
+
+    [JsonPropertyName("rawPreviewPairs")]
+    public RawPreviewPair[] RawPreviewPairs { get; set; } = [];
+
+    [JsonPropertyName("reviewPairs")]
+    public ReviewPair[] ReviewPairs { get; set; } = [];
+}
+
+internal sealed class ReviewBundleSummary
+{
+    [JsonPropertyName("targetCount")]
+    public int TargetCount { get; set; }
+
+    [JsonPropertyName("rawPreviewPairCount")]
+    public int RawPreviewPairCount { get; set; }
+
+    [JsonPropertyName("reviewPairCount")]
+    public int ReviewPairCount { get; set; }
+
+    [JsonPropertyName("primaryReviewerDestinationPolicy")]
+    public string PrimaryReviewerDestinationPolicy { get; set; } = string.Empty;
+}
+
+internal sealed class ReviewBundleTarget
+{
+    [JsonPropertyName("targetId")]
+    public string TargetId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetPath")]
+    public string TargetPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("finalStatus")]
+    public string? FinalStatus { get; set; }
+
+    [JsonPropertyName("finalReason")]
+    public string? FinalReason { get; set; }
+
+    [JsonPropertyName("rawPreviewPairCount")]
+    public int RawPreviewPairCount { get; set; }
+
+    [JsonPropertyName("rawPreviewPairs")]
+    public RawPreviewPair[] RawPreviewPairs { get; set; } = [];
+
+    [JsonPropertyName("reviewPairCount")]
+    public int ReviewPairCount { get; set; }
+}
+
+internal sealed class RawPreviewPair
+{
+    [JsonPropertyName("targetId")]
+    public string TargetId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetPath")]
+    public string TargetPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("mode")]
+    public string Mode { get; set; } = string.Empty;
+
+    [JsonPropertyName("comparison")]
+    public ComparisonReceipt Comparison { get; set; } = new();
+
+    [JsonPropertyName("sectionKind")]
+    public string SectionKind { get; set; } = string.Empty;
+
+    [JsonPropertyName("sectionOrdinal")]
+    public int SectionOrdinal { get; set; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("debugReportHtmlRelativePath")]
+    public string? DebugReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("baseImageRelativePath")]
+    public string BaseImageRelativePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("headImageRelativePath")]
+    public string HeadImageRelativePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("baseByteLength")]
+    public long BaseByteLength { get; set; }
+
+    [JsonPropertyName("headByteLength")]
+    public long HeadByteLength { get; set; }
+
+    [JsonPropertyName("baseImageSha256")]
+    public string BaseImageSha256 { get; set; } = string.Empty;
+
+    [JsonPropertyName("headImageSha256")]
+    public string HeadImageSha256 { get; set; } = string.Empty;
+
+    [JsonPropertyName("sortKey")]
+    public string SortKey { get; set; } = string.Empty;
+}
+
+internal sealed class ComparisonReceipt
+{
+    [JsonPropertyName("index")]
+    public int Index { get; set; }
+
+    [JsonPropertyName("baseRef")]
+    public string? BaseRef { get; set; }
+
+    [JsonPropertyName("headRef")]
+    public string? HeadRef { get; set; }
+
+    [JsonPropertyName("baseShortRef")]
+    public string? BaseShortRef { get; set; }
+
+    [JsonPropertyName("headShortRef")]
+    public string? HeadShortRef { get; set; }
+
+    [JsonPropertyName("baseSubject")]
+    public string? BaseSubject { get; set; }
+
+    [JsonPropertyName("headSubject")]
+    public string? HeadSubject { get; set; }
+}
+
+internal sealed class ReviewPair
+{
+    [JsonPropertyName("reviewPairKey")]
+    public string ReviewPairKey { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetId")]
+    public string TargetId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetPath")]
+    public string TargetPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("comparison")]
+    public ComparisonReceipt Comparison { get; set; } = new();
+
+    [JsonPropertyName("sortKey")]
+    public string SortKey { get; set; } = string.Empty;
+
+    [JsonPropertyName("primaryReviewerDestination")]
+    public ReviewerDestination PrimaryReviewerDestination { get; set; } = new();
+
+    [JsonPropertyName("debugDestinations")]
+    public DebugDestinations DebugDestinations { get; set; } = new();
+
+    [JsonPropertyName("surfaces")]
+    public ReviewSurface[] Surfaces { get; set; } = [];
+
+    [JsonPropertyName("reviewerSummary")]
+    public ReviewerSummary? ReviewerSummary { get; set; }
+
+    [JsonPropertyName("changeDetails")]
+    public ReviewChangeDetails? ChangeDetails { get; set; }
+}
+
+internal sealed class ReviewerDestination
+{
+    [JsonPropertyName("kind")]
+    public string Kind { get; set; } = string.Empty;
+
+    [JsonPropertyName("relativePath")]
+    public string? RelativePath { get; set; }
+}
+
+internal sealed class DebugDestinations
+{
+    [JsonPropertyName("frontPanelReportHtmlRelativePath")]
+    public string? FrontPanelReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("blockDiagramReportHtmlRelativePath")]
+    public string? BlockDiagramReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("changeDetailsReportHtmlRelativePath")]
+    public string? ChangeDetailsReportHtmlRelativePath { get; set; }
+}

--- a/src/CompareVIHistory.ReviewCompiler/ReviewCompilerText.cs
+++ b/src/CompareVIHistory.ReviewCompiler/ReviewCompilerText.cs
@@ -1,0 +1,116 @@
+using System.Globalization;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal static class ReviewCompilerText
+{
+    public static string? GetOptionalString(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+
+    public static string? CleanString(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+
+    public static string ConvertFromHtmlText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var decoded = WebUtility.HtmlDecode(value);
+        var withoutTags = Regex.Replace(decoded, "<[^>]+>", " ");
+        return Regex.Replace(withoutTags, "\\s+", " ").Trim();
+    }
+
+    public static string ConvertToSlug(string? value, string fallback)
+    {
+        var normalized = CleanString(value);
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return fallback;
+        }
+
+        var slug = Regex.Replace(normalized.ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
+        return string.IsNullOrWhiteSpace(slug) ? fallback : slug;
+    }
+
+    public static string? ConvertToShortRef(string? @ref)
+    {
+        var refValue = CleanString(@ref);
+        if (string.IsNullOrWhiteSpace(refValue))
+        {
+            return null;
+        }
+
+        return refValue.Length <= 12 ? refValue : refValue[..12];
+    }
+
+    public static string? NormalizeReviewerChangeDetailHeading(string? heading)
+    {
+        var normalizedHeading = CleanString(heading);
+        return string.IsNullOrWhiteSpace(normalizedHeading)
+            ? null
+            : Regex.Replace(normalizedHeading, "^\\d+\\.\\s*", string.Empty).Trim();
+    }
+
+    public static int? GetReviewerChangeDetailSectionOrdinal(string? heading)
+    {
+        var normalizedHeading = CleanString(heading);
+        if (string.IsNullOrWhiteSpace(normalizedHeading))
+        {
+            return null;
+        }
+
+        var ordinalMatch = Regex.Match(normalizedHeading, "^\\s*(?<ordinal>\\d+)\\.");
+        return ordinalMatch.Success ? int.Parse(ordinalMatch.Groups["ordinal"].Value, CultureInfo.InvariantCulture) : null;
+    }
+
+    public static (string? Subject, string? Action) GetReviewerChangeDetailLineParts(string? detailLine)
+    {
+        var normalizedDetailLine = CleanString(detailLine);
+        if (string.IsNullOrWhiteSpace(normalizedDetailLine))
+        {
+            return (null, null);
+        }
+
+        var prefix = normalizedDetailLine;
+        var colonIndex = prefix.IndexOf(':');
+        if (colonIndex >= 0)
+        {
+            prefix = prefix[..colonIndex];
+        }
+
+        prefix = Regex.Replace(prefix, "\\s+", " ").Trim();
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return (null, null);
+        }
+
+        var subject = prefix;
+        string? action = null;
+        var actionMatch = Regex.Match(prefix, "^(?<subject>.*?)\\s*-\\s*(?<action>[^-].+?)$");
+        if (actionMatch.Success)
+        {
+            subject = Regex.Replace(actionMatch.Groups["subject"].Value, "\\s+", " ").Trim();
+            action = Regex.Replace(actionMatch.Groups["action"].Value, "\\s+", " ").Trim();
+        }
+
+        return (CleanString(subject), CleanString(action));
+    }
+}

--- a/src/CompareVIHistory.ReviewCompiler/ReviewDetailsModels.cs
+++ b/src/CompareVIHistory.ReviewCompiler/ReviewDetailsModels.cs
@@ -1,0 +1,189 @@
+using System.Text.Json.Serialization;
+
+namespace CompareVIHistory.ReviewCompiler;
+
+internal sealed class ReviewSurface
+{
+    [JsonPropertyName("surfaceKind")]
+    public string SurfaceKind { get; set; } = string.Empty;
+
+    [JsonPropertyName("surfaceLabel")]
+    public string SurfaceLabel { get; set; } = string.Empty;
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    [JsonPropertyName("primaryReviewerRelativePath")]
+    public string? PrimaryReviewerRelativePath { get; set; }
+
+    [JsonPropertyName("debugReportHtmlRelativePath")]
+    public string? DebugReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("baseImageRelativePath")]
+    public string BaseImageRelativePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("headImageRelativePath")]
+    public string HeadImageRelativePath { get; set; } = string.Empty;
+
+    [JsonPropertyName("baseByteLength")]
+    public long BaseByteLength { get; set; }
+
+    [JsonPropertyName("headByteLength")]
+    public long HeadByteLength { get; set; }
+
+    [JsonPropertyName("baseImageSha256")]
+    public string? BaseImageSha256 { get; set; }
+
+    [JsonPropertyName("headImageSha256")]
+    public string? HeadImageSha256 { get; set; }
+
+    [JsonPropertyName("sortKey")]
+    public string? SortKey { get; set; }
+}
+
+internal sealed class ReviewChangeDetailsRecord
+{
+    [JsonPropertyName("targetId")]
+    public string TargetId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetPath")]
+    public string TargetPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("comparison")]
+    public ComparisonReceipt Comparison { get; set; } = new();
+
+    [JsonPropertyName("sortKey")]
+    public string SortKey { get; set; } = string.Empty;
+
+    [JsonPropertyName("changeDetails")]
+    public ReviewChangeDetails ChangeDetails { get; set; } = new();
+}
+
+internal sealed class ReviewChangeDetails
+{
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceMode")]
+    public string SourceMode { get; set; } = string.Empty;
+
+    [JsonPropertyName("primaryReviewerRelativePath")]
+    public string? PrimaryReviewerRelativePath { get; set; }
+
+    [JsonPropertyName("debugReportHtmlRelativePath")]
+    public string? DebugReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("includedCategories")]
+    public string[] IncludedCategories { get; set; } = [];
+
+    [JsonPropertyName("groupCount")]
+    public int GroupCount { get; set; }
+
+    [JsonPropertyName("omittedGroupCount")]
+    public int OmittedGroupCount { get; set; }
+
+    [JsonPropertyName("sectionCount")]
+    public int SectionCount { get; set; }
+
+    [JsonPropertyName("detailCount")]
+    public int DetailCount { get; set; }
+
+    [JsonPropertyName("groups")]
+    public ReviewChangeDetailGroup[] Groups { get; set; } = [];
+}
+
+internal sealed class ReviewChangeDetailGroup
+{
+    [JsonPropertyName("heading")]
+    public string Heading { get; set; } = string.Empty;
+
+    [JsonPropertyName("sectionCount")]
+    public int SectionCount { get; set; }
+
+    [JsonPropertyName("detailCount")]
+    public int DetailCount { get; set; }
+
+    [JsonPropertyName("sampleDetails")]
+    public string[] SampleDetails { get; set; } = [];
+
+    [JsonPropertyName("omittedDetailCount")]
+    public int OmittedDetailCount { get; set; }
+
+    [JsonPropertyName("primaryReviewerRelativePath")]
+    public string? PrimaryReviewerRelativePath { get; set; }
+
+    [JsonPropertyName("primaryDebugReportHtmlRelativePath")]
+    public string? PrimaryDebugReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("sectionLinks")]
+    public DebugChangeDetailSectionLink[] SectionLinks { get; set; } = [];
+}
+
+internal sealed class DebugChangeDetailSectionLink
+{
+    [JsonPropertyName("sectionOrdinal")]
+    public int SectionOrdinal { get; set; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("reviewerRelativePath")]
+    public string? ReviewerRelativePath { get; set; }
+
+    [JsonPropertyName("debugReportHtmlRelativePath")]
+    public string? DebugReportHtmlRelativePath { get; set; }
+}
+
+internal sealed class ReviewerSummary
+{
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("overallSeverity")]
+    public string OverallSeverity { get; set; } = string.Empty;
+
+    [JsonPropertyName("headline")]
+    public string Headline { get; set; } = string.Empty;
+
+    [JsonPropertyName("signalCount")]
+    public int SignalCount { get; set; }
+
+    [JsonPropertyName("omittedSignalCount")]
+    public int OmittedSignalCount { get; set; }
+
+    [JsonPropertyName("signals")]
+    public ReviewerSignal[] Signals { get; set; } = [];
+}
+
+internal sealed class ReviewerSignal
+{
+    [JsonPropertyName("signalKey")]
+    public string SignalKey { get; set; } = string.Empty;
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = string.Empty;
+
+    [JsonPropertyName("severity")]
+    public string Severity { get; set; } = string.Empty;
+
+    [JsonPropertyName("detailCount")]
+    public int DetailCount { get; set; }
+
+    [JsonPropertyName("sectionCount")]
+    public int SectionCount { get; set; }
+
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+
+    [JsonPropertyName("primaryReviewerRelativePath")]
+    public string? PrimaryReviewerRelativePath { get; set; }
+
+    [JsonPropertyName("primaryDebugReportHtmlRelativePath")]
+    public string? PrimaryDebugReportHtmlRelativePath { get; set; }
+
+    [JsonPropertyName("sectionLinks")]
+    public DebugChangeDetailSectionLink[] SectionLinks { get; set; } = [];
+}


### PR DESCRIPTION
## Summary
- add the first compiled `comparevi-history/review-bundle@v1` .NET review compiler
- switch PR preview-manifest generation to consume the compiled bundle as its primary input
- add direct compiler coverage, CI wiring, and schema/docs updates for `#160`

## Testing
- `dotnet build src/CompareVIHistory.ReviewCompiler/CompareVIHistory.ReviewCompiler.csproj`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #160.
