### PR TITLE
#161 Render unified history-pair review pages

### DIFF
--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -786,7 +786,9 @@ function Add-AnchorToUrl {
 function New-CommentChangeDetailsEvidenceMarkdown {
   param(
     [Parameter(Mandatory = $true)]
-    [object]$PreviewCard
+    [object]$PreviewCard,
+    [AllowNull()]
+    [string]$PairReviewUrl
   )
 
   $lines = New-Object System.Collections.Generic.List[string]
@@ -865,6 +867,11 @@ function New-CommentChangeDetailsEvidenceMarkdown {
     }
   }
 
+  if (-not [string]::IsNullOrWhiteSpace($PairReviewUrl)) {
+    $lines.Add('') | Out-Null
+    $lines.Add(('[Unified pair review]({0})' -f $PairReviewUrl)) | Out-Null
+  }
+
   return ($lines -join "`n").TrimEnd() + "`n"
 }
 
@@ -875,7 +882,9 @@ function New-CommentSurfaceEvidenceMarkdown {
     [Parameter(Mandatory = $true)]
     [object]$Surface,
     [AllowNull()]
-    [string]$ChangeDetailsEvidenceUrl
+    [string]$ChangeDetailsEvidenceUrl,
+    [AllowNull()]
+    [string]$PairReviewUrl
   )
 
   $lines = New-Object System.Collections.Generic.List[string]
@@ -910,6 +919,10 @@ function New-CommentSurfaceEvidenceMarkdown {
     $lines.Add('') | Out-Null
     $lines.Add(('[Change details evidence]({0})' -f $ChangeDetailsEvidenceUrl)) | Out-Null
   }
+  if (-not [string]::IsNullOrWhiteSpace($PairReviewUrl)) {
+    $lines.Add('') | Out-Null
+    $lines.Add(('[Unified pair review]({0})' -f $PairReviewUrl)) | Out-Null
+  }
 
   return ($lines -join "`n").TrimEnd() + "`n"
 }
@@ -919,15 +932,22 @@ function ConvertTo-PublishedSectionLink {
     [Parameter(Mandatory = $true)]
     [object]$SectionLink,
     [AllowNull()]
-    [string]$EvidenceUrl
+    [string]$EvidencePath,
+    [AllowNull()]
+    [string]$EvidenceUrl,
+    [AllowNull()]
+    [string]$DebugEvidenceUrl
   )
 
-  $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('reportHtmlRelativePath'))
+  $rawReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('reportHtmlRelativePath'))
+  $anchorId = Get-ReportAnchorId -Path $rawReportHtmlRelativePath
   return [ordered]@{
     sectionOrdinal = [int](Get-NestedValue -Object $SectionLink -Path @('sectionOrdinal') -Default 0)
     label = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('label'))
-    reportHtmlRelativePath = $reportHtmlRelativePath
-    reportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $reportHtmlRelativePath)
+    reportHtmlRelativePath = Add-AnchorToUrl -Url $EvidencePath -AnchorId $anchorId
+    debugReportHtmlRelativePath = $rawReportHtmlRelativePath
+    reportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId $anchorId
+    debugReportUrl = Add-AnchorToUrl -Url $DebugEvidenceUrl -AnchorId $anchorId
   }
 }
 
@@ -936,7 +956,11 @@ function ConvertTo-PublishedChangeDetails {
     [AllowNull()]
     [object]$ChangeDetails,
     [AllowNull()]
-    [string]$EvidenceUrl
+    [string]$EvidencePath,
+    [AllowNull()]
+    [string]$EvidenceUrl,
+    [AllowNull()]
+    [string]$DebugEvidenceUrl
   )
 
   if ($null -eq $ChangeDetails) {
@@ -945,7 +969,8 @@ function ConvertTo-PublishedChangeDetails {
 
   $groups = New-Object System.Collections.Generic.List[object]
   foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
-    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $rawPrimaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $primaryAnchorId = Get-ReportAnchorId -Path $rawPrimaryReportHtmlRelativePath
     $groups.Add([ordered]@{
         heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
         sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
@@ -955,20 +980,26 @@ function ConvertTo-PublishedChangeDetails {
             ForEach-Object { [string]$_ }
         )
         omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
-        primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
-        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $primaryReportHtmlRelativePath)
+        primaryReportHtmlRelativePath = Add-AnchorToUrl -Url $EvidencePath -AnchorId $primaryAnchorId
+        debugPrimaryReportHtmlRelativePath = $rawPrimaryReportHtmlRelativePath
+        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId $primaryAnchorId
+        debugPrimaryReportUrl = Add-AnchorToUrl -Url $DebugEvidenceUrl -AnchorId $primaryAnchorId
         sectionLinks = @(
           ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
-            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidenceUrl $EvidenceUrl }
+            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidencePath $EvidencePath -EvidenceUrl $EvidenceUrl -DebugEvidenceUrl $DebugEvidenceUrl }
         )
       }) | Out-Null
   }
 
+  $rawReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+
   return [ordered]@{
     label = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('label'))
     sourceMode = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('sourceMode'))
-    reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
-    reportUrl = $EvidenceUrl
+    reportHtmlRelativePath = Add-AnchorToUrl -Url $EvidencePath -AnchorId 'change-details'
+    debugReportHtmlRelativePath = $rawReportHtmlRelativePath
+    reportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId 'change-details'
+    debugReportUrl = $DebugEvidenceUrl
     includedCategories = @(
       ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
         ForEach-Object { [string]$_ }
@@ -986,7 +1017,11 @@ function ConvertTo-PublishedReviewerSummary {
     [AllowNull()]
     [object]$ReviewerSummary,
     [AllowNull()]
-    [string]$EvidenceUrl
+    [string]$EvidencePath,
+    [AllowNull()]
+    [string]$EvidenceUrl,
+    [AllowNull()]
+    [string]$DebugEvidenceUrl
   )
 
   if ($null -eq $ReviewerSummary) {
@@ -995,7 +1030,8 @@ function ConvertTo-PublishedReviewerSummary {
 
   $signals = New-Object System.Collections.Generic.List[object]
   foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
-    $primaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $rawPrimaryReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $primaryAnchorId = Get-ReportAnchorId -Path $rawPrimaryReportHtmlRelativePath
     $signals.Add([ordered]@{
         signalKey = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('signalKey'))
         label = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
@@ -1003,11 +1039,13 @@ function ConvertTo-PublishedReviewerSummary {
         detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
         sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
         summary = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('summary'))
-        primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
-        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId (Get-ReportAnchorId -Path $primaryReportHtmlRelativePath)
+        primaryReportHtmlRelativePath = Add-AnchorToUrl -Url $EvidencePath -AnchorId $primaryAnchorId
+        debugPrimaryReportHtmlRelativePath = $rawPrimaryReportHtmlRelativePath
+        primaryReportUrl = Add-AnchorToUrl -Url $EvidenceUrl -AnchorId $primaryAnchorId
+        debugPrimaryReportUrl = Add-AnchorToUrl -Url $DebugEvidenceUrl -AnchorId $primaryAnchorId
         sectionLinks = @(
           ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()) |
-            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidenceUrl $EvidenceUrl }
+            ForEach-Object { ConvertTo-PublishedSectionLink -SectionLink $_ -EvidencePath $EvidencePath -EvidenceUrl $EvidenceUrl -DebugEvidenceUrl $DebugEvidenceUrl }
         )
       }) | Out-Null
   }
@@ -1020,6 +1058,140 @@ function ConvertTo-PublishedReviewerSummary {
     omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
     signals = @($signals | ForEach-Object { $_ })
   }
+}
+
+function New-CommentPairReviewMarkdown {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [string]$PairReviewUrl
+  )
+
+  $lines = New-Object System.Collections.Generic.List[string]
+  $title = Get-ReviewerPreviewTitle -PreviewPair $PreviewCard
+  $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $PreviewCard
+  $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $PreviewCard
+  $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $PreviewCard)
+  $changeDetails = Get-NestedValue -Object $PreviewCard -Path @('changeDetails')
+  $reviewerSummary = Get-NestedValue -Object $PreviewCard -Path @('reviewerSummary')
+
+  $lines.Add(('# `{0}`' -f $title)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('## {0}' -f $subtitle)) | Out-Null
+  $lines.Add('') | Out-Null
+  if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+    $lines.Add(('`{0}`' -f $revisionContext)) | Out-Null
+    $lines.Add('') | Out-Null
+  }
+  foreach ($detailLine in $detailLines) {
+    $lines.Add(('- {0}' -f $detailLine)) | Out-Null
+  }
+  if ($detailLines.Count -gt 0) {
+    $lines.Add('') | Out-Null
+  }
+
+  foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $PreviewCard -Path @('surfaces') -Default @()))) {
+    $surfaceKind = Get-OptionalString -Value $surface.surfaceKind
+    $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+    $debugEvidenceUrl = Get-OptionalString -Value (Get-NestedValue -Object $surface -Path @('debugEvidenceUrl'))
+    $lines.Add(('<a id="{0}"></a>' -f (ConvertTo-HtmlText $surfaceKind))) | Out-Null
+    $lines.Add(('## {0}' -f $surfaceLabel)) | Out-Null
+    $lines.Add('') | Out-Null
+    $baseMarkdown = ('![{0}]({1})' -f ('{0} base' -f $surfaceLabel), [string]$surface.baseImageUrl)
+    if (-not [string]::IsNullOrWhiteSpace($debugEvidenceUrl)) {
+      $baseMarkdown = '[{0}]({1})' -f $baseMarkdown, $debugEvidenceUrl
+    }
+    $headMarkdown = ('![{0}]({1})' -f ('{0} head' -f $surfaceLabel), [string]$surface.headImageUrl)
+    if (-not [string]::IsNullOrWhiteSpace($debugEvidenceUrl)) {
+      $headMarkdown = '[{0}]({1})' -f $headMarkdown, $debugEvidenceUrl
+    }
+    $lines.Add('**Base**') | Out-Null
+    $lines.Add($baseMarkdown) | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('**Head**') | Out-Null
+    $lines.Add($headMarkdown) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($debugEvidenceUrl)) {
+      $lines.Add('') | Out-Null
+      $lines.Add(('[Debug surface page]({0})' -f $debugEvidenceUrl)) | Out-Null
+    }
+    $lines.Add('') | Out-Null
+  }
+
+  $lines.Add('<a id="reviewer-summary"></a>') | Out-Null
+  $reviewerSummaryMarkdown = New-CommentReviewerSummaryMarkdown -ReviewerSummary $reviewerSummary
+  if (-not [string]::IsNullOrWhiteSpace($reviewerSummaryMarkdown)) {
+    $lines.Add($reviewerSummaryMarkdown) | Out-Null
+    $lines.Add('') | Out-Null
+  }
+
+  if ($null -ne $changeDetails) {
+    $lines.Add('<a id="change-details"></a>') | Out-Null
+    $lines.Add('<p><strong>Change details</strong></p>') | Out-Null
+    $lines.Add('<ul>') | Out-Null
+    $includedCategories = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('includedCategories') -Default @()) |
+        ForEach-Object { Get-OptionalString -Value $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($includedCategories.Count -gt 0) {
+      $lines.Add(('<li><strong>Included categories:</strong> {0}</li>' -f (ConvertTo-HtmlText ($includedCategories -join ', ')))) | Out-Null
+    }
+    foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('groups') -Default @()))) {
+      $anchorId = Get-ReportAnchorId -Path (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportUrl')))
+      if (-not [string]::IsNullOrWhiteSpace($anchorId)) {
+        $lines.Add(('<a id="{0}"></a>' -f (ConvertTo-HtmlText $anchorId))) | Out-Null
+      }
+      $headingText = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+      $primaryReportUrl = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportUrl'))
+      $headingMarkup = if ([string]::IsNullOrWhiteSpace($primaryReportUrl)) {
+        ConvertTo-HtmlText $headingText
+      } else {
+        '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $primaryReportUrl), (ConvertTo-HtmlText $headingText)
+      }
+      $lines.Add(('<li><strong>{0}:</strong> {1} details across {2} sections' -f `
+            $headingMarkup, `
+            [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0), `
+            [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0))) | Out-Null
+      $lines.Add('<ul>') | Out-Null
+      foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+        $lines.Add(('<li>{0}</li>' -f (ConvertTo-HtmlText ([string]$sampleDetail)))) | Out-Null
+      }
+      $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+      if ($omittedDetailCount -gt 0) {
+        $lines.Add(('<li>+{0} more details in report</li>' -f $omittedDetailCount)) | Out-Null
+      }
+      $sectionLinks = @(
+        ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
+          ForEach-Object {
+            $label = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('label'))
+            $path = Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('reportUrl'))
+            if ([string]::IsNullOrWhiteSpace($label) -or [string]::IsNullOrWhiteSpace($path)) {
+              return $null
+            }
+
+            '<a href="{0}">{1}</a>' -f (ConvertTo-HtmlText $path), (ConvertTo-HtmlText $label)
+          } |
+          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+      )
+      if ($sectionLinks.Count -gt 0) {
+        $lines.Add(('<li><strong>Exact sections:</strong> {0}</li>' -f ($sectionLinks -join ', '))) | Out-Null
+      }
+      $debugPrimaryReportUrl = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('debugPrimaryReportUrl'))
+      if (-not [string]::IsNullOrWhiteSpace($debugPrimaryReportUrl)) {
+        $lines.Add(('<li><strong>Debug section page:</strong> <a href="{0}">open debug evidence</a></li>' -f (ConvertTo-HtmlText $debugPrimaryReportUrl))) | Out-Null
+      }
+      $lines.Add('</ul>') | Out-Null
+      $lines.Add('</li>') | Out-Null
+    }
+    $debugChangeDetailsUrl = Get-OptionalString -Value (Get-NestedValue -Object $changeDetails -Path @('debugReportUrl'))
+    if (-not [string]::IsNullOrWhiteSpace($debugChangeDetailsUrl)) {
+      $lines.Add(('<li><a href="{0}">open debug change-details page</a></li>' -f (ConvertTo-HtmlText $debugChangeDetailsUrl))) | Out-Null
+    }
+    $lines.Add('</ul>') | Out-Null
+  }
+
+  return ($lines -join "`n").TrimEnd() + "`n"
 }
 
 function New-CommentPreviewMarkdown {
@@ -1153,9 +1325,12 @@ function Publish-CommentPreviewSurface {
   $publishedPreviewPairs = New-Object System.Collections.Generic.List[object]
   $publishedImageCount = 0
   $publishedSurfaceCount = 0
+  $publishedPairPageCount = 0
   $cardOrdinal = 1
   foreach ($previewCard in $previewCards) {
     $cardRoot = '{0}/{1}-{2}' -f $runRoot, ('{0:D3}' -f $cardOrdinal), ('history-pair-' + ('{0:D2}' -f (Get-ReviewerPreviewComparisonIndex -PreviewPair $previewCard)))
+    $pairReviewPath = '{0}/index.md' -f $cardRoot
+    $pairReviewUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $pairReviewPath
     $changeDetailsEvidencePath = '{0}/change-details.md' -f $cardRoot
     $changeDetailsEvidenceUrl = $null
     if ($null -ne (Get-NestedValue -Object $previewCard -Path @('changeDetails')) -or
@@ -1194,36 +1369,45 @@ function Publish-CommentPreviewSurface {
       $publishedSurface = [ordered]@{
         surfaceKind = Get-OptionalString -Value $surface.surfaceKind
         surfaceLabel = $surfaceLabel
-        reportHtmlRelativePath = Get-OptionalString -Value $surface.reportHtmlRelativePath
+        reportHtmlRelativePath = Add-AnchorToUrl -Url $pairReviewPath -AnchorId (Get-OptionalString -Value $surface.surfaceKind)
+        debugReportHtmlRelativePath = Get-OptionalString -Value $surface.reportHtmlRelativePath
+        reportUrl = Add-AnchorToUrl -Url $pairReviewUrl -AnchorId (Get-OptionalString -Value $surface.surfaceKind)
         baseImagePath = $basePublishPath
         baseImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $basePublishPath
         headImagePath = $headPublishPath
         headImageUrl = ConvertTo-RawGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $headPublishPath
-        evidencePath = $surfaceEvidencePath
-        evidenceUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $surfaceEvidencePath
+        evidencePath = Add-AnchorToUrl -Url $pairReviewPath -AnchorId (Get-OptionalString -Value $surface.surfaceKind)
+        evidenceUrl = Add-AnchorToUrl -Url $pairReviewUrl -AnchorId (Get-OptionalString -Value $surface.surfaceKind)
+        debugEvidencePath = $surfaceEvidencePath
+        debugEvidenceUrl = ConvertTo-BlobGitHubUrl -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $surfaceEvidencePath
       }
-      $surfaceEvidenceMarkdown = New-CommentSurfaceEvidenceMarkdown -PreviewCard $previewCard -Surface $publishedSurface -ChangeDetailsEvidenceUrl $changeDetailsEvidenceUrl
+      $surfaceEvidenceMarkdown = New-CommentSurfaceEvidenceMarkdown -PreviewCard $previewCard -Surface $publishedSurface -ChangeDetailsEvidenceUrl $changeDetailsEvidenceUrl -PairReviewUrl $pairReviewUrl
       Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $surfaceEvidencePath -Bytes ([System.Text.Encoding]::UTF8.GetBytes($surfaceEvidenceMarkdown)) -Message ('comparevi-history: publish PR preview evidence for run {0}' -f $ExecutionRunId) | Out-Null
       $publishedSurfaces.Add($publishedSurface) | Out-Null
       $surfaceOrdinal += 1
     }
 
     if (-not [string]::IsNullOrWhiteSpace($changeDetailsEvidenceUrl)) {
-      $changeDetailsEvidenceMarkdown = New-CommentChangeDetailsEvidenceMarkdown -PreviewCard $previewCard
+      $changeDetailsEvidenceMarkdown = New-CommentChangeDetailsEvidenceMarkdown -PreviewCard $previewCard -PairReviewUrl $pairReviewUrl
       Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $changeDetailsEvidencePath -Bytes ([System.Text.Encoding]::UTF8.GetBytes($changeDetailsEvidenceMarkdown)) -Message ('comparevi-history: publish PR preview evidence for run {0}' -f $ExecutionRunId) | Out-Null
     }
 
-    $publishedReviewerSummary = ConvertTo-PublishedReviewerSummary -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary')) -EvidenceUrl $changeDetailsEvidenceUrl
-    $publishedChangeDetails = ConvertTo-PublishedChangeDetails -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails')) -EvidenceUrl $changeDetailsEvidenceUrl
+    $publishedReviewerSummary = ConvertTo-PublishedReviewerSummary -ReviewerSummary (Get-NestedValue -Object $previewCard -Path @('reviewerSummary')) -EvidencePath $pairReviewPath -EvidenceUrl $pairReviewUrl -DebugEvidenceUrl $changeDetailsEvidenceUrl
+    $publishedChangeDetails = ConvertTo-PublishedChangeDetails -ChangeDetails (Get-NestedValue -Object $previewCard -Path @('changeDetails')) -EvidencePath $pairReviewPath -EvidenceUrl $pairReviewUrl -DebugEvidenceUrl $changeDetailsEvidenceUrl
 
     $publishedCard = [ordered]@{
       targetId = [string]$previewCard.targetId
       targetPath = [string]$previewCard.targetPath
       comparison = $previewCard.comparison
+      pairReviewPath = $pairReviewPath
+      pairReviewUrl = $pairReviewUrl
       reviewerSummary = $publishedReviewerSummary
       changeDetails = $publishedChangeDetails
       surfaces = @($publishedSurfaces | ForEach-Object { $_ })
     }
+    $pairReviewMarkdown = New-CommentPairReviewMarkdown -PreviewCard $publishedCard -PairReviewUrl $pairReviewUrl
+    Set-RepositoryContent -RepositorySlug $RepositorySlug -BranchName $BranchName -Path $pairReviewPath -Bytes ([System.Text.Encoding]::UTF8.GetBytes($pairReviewMarkdown)) -Message ('comparevi-history: publish PR preview evidence for run {0}' -f $ExecutionRunId) | Out-Null
+    $publishedPairPageCount += 1
     $publishedPreviewCards.Add($publishedCard) | Out-Null
 
     $representativeSurface = @($publishedSurfaces | Select-Object -First 1)
@@ -1233,15 +1417,18 @@ function Publish-CommentPreviewSurface {
           targetPath = [string]$previewCard.targetPath
           mode = Get-OptionalString -Value $representativeSurface.surfaceKind
           label = Get-OptionalString -Value $representativeSurface.surfaceLabel
-          sectionKind = 'overview'
+          sectionKind = 'review-pair'
           comparison = $previewCard.comparison
           reportHtmlRelativePath = Get-OptionalString -Value $representativeSurface.reportHtmlRelativePath
+          reportUrl = Get-OptionalString -Value $representativeSurface.reportUrl
           baseImagePath = [string]$representativeSurface.baseImagePath
           baseImageUrl = [string]$representativeSurface.baseImageUrl
           headImagePath = [string]$representativeSurface.headImagePath
           headImageUrl = [string]$representativeSurface.headImageUrl
           evidencePath = Get-OptionalString -Value $representativeSurface.evidencePath
           evidenceUrl = Get-OptionalString -Value $representativeSurface.evidenceUrl
+          debugEvidencePath = Get-OptionalString -Value $representativeSurface.debugEvidencePath
+          debugEvidenceUrl = Get-OptionalString -Value $representativeSurface.debugEvidenceUrl
         }) | Out-Null
     }
 
@@ -1271,6 +1458,7 @@ function Publish-CommentPreviewSurface {
     previewPairCount = $publishedPreviewCards.Count
     publishedImageCount = $publishedImageCount
     publishedSurfaceCount = $publishedSurfaceCount
+    publishedPairPageCount = $publishedPairPageCount
     commentPreviewCards = @($publishedPreviewCards | ForEach-Object { $_ })
     commentPreviewPairs = @($publishedPreviewPairs | ForEach-Object { $_ })
   }

--- a/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -591,6 +591,16 @@ try {
   }
 
   $indexMarkdown = Get-Content -LiteralPath $receipt.outputs.indexMarkdownPath -Raw
+  $pair1Html = 'history-pairs/001-history-pair-01-tooling-deployment-vip-post-install-custom-action-vi/index.html'
+  $pair1Markdown = 'history-pairs/001-history-pair-01-tooling-deployment-vip-post-install-custom-action-vi/index.md'
+  $pair2Html = 'history-pairs/002-history-pair-02-tooling-deployment-vip-post-install-custom-action-vi/index.html'
+  $pair2Markdown = 'history-pairs/002-history-pair-02-tooling-deployment-vip-post-install-custom-action-vi/index.md'
+  foreach ($pairPageRelativePath in @($pair1Html, $pair1Markdown, $pair2Html, $pair2Markdown)) {
+    $pairPagePath = Join-Path $resultsDir ($pairPageRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    if (-not (Test-Path -LiteralPath $pairPagePath -PathType Leaf)) {
+      throw "Expected pair review page '$pairPageRelativePath'."
+    }
+  }
   foreach ($requiredText in @(
       '# comparevi-history PR diagnostics workspace',
       '## Workspace summary',
@@ -605,9 +615,9 @@ try {
       '<a id="history-pair-01-tooling-deployment-vip-post-install-custom-action-vi"></a>',
       '<a id="history-pair-02-tooling-deployment-vip-post-install-custom-action-vi"></a>',
       'Quick links: [card](#history-pair-01-tooling-deployment-vip-post-install-custom-action-vi)',
-      '[front panel](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)',
-      '[block diagram](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)',
-      '[change details](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html)',
+      ('[front panel]({0}#front-panel)' -f $pair1Html),
+      ('[block diagram]({0}#block-diagram)' -f $pair1Html),
+      ('[change details]({0}#change-details)' -f $pair1Html),
       '[changed-vi-discovery.json](changed-vi-discovery.json)',
       '[pr-run.json](pr-run.json)',
       '[pr-preview-manifest.json](pr-preview-manifest.json)',
@@ -640,26 +650,26 @@ try {
     [regex]::Matches($indexMarkdown, [regex]::Escape('#### Block diagram')).Count -ne 2) {
     throw 'Index markdown should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
-  if ($indexMarkdown -notmatch [regex]::Escape('[![Front panel base](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png)](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)') -or
-    $indexMarkdown -notmatch [regex]::Escape('[![Block diagram base](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png)](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html)') -or
-    $indexMarkdown -notmatch [regex]::Escape('[![Front panel head](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png)](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html)') -or
-    $indexMarkdown -notmatch [regex]::Escape('[![Block diagram head](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png)](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html)')) {
-    throw 'Index markdown should make preview images one-click links to exact visual report surfaces.'
+  if ($indexMarkdown -notmatch [regex]::Escape(('[![Front panel base](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png)]({0}#front-panel)' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('[![Block diagram base](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png)]({0}#block-diagram)' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('[![Front panel head](targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png)]({0}#front-panel)' -f $pair2Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('[![Block diagram head](targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png)]({0}#block-diagram)' -f $pair2Html))) {
+    throw 'Index markdown should route preview images to unified history-pair review pages first.'
   }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Reviewer summary')).Count -ne 2 -or
     $indexMarkdown -notmatch [regex]::Escape('- Headline: `Material logic-affecting movement and structure resizing`') -or
     $indexMarkdown -notmatch [regex]::Escape('- Overall severity: `medium`') -or
-    $indexMarkdown -notmatch [regex]::Escape('- [`Logic-affecting movement`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects): `medium` severity, `3` details across `1` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('- [`Structure resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects): `low` severity, `2` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape(('- [`Logic-affecting movement`]({0}#comparevi-change-001-block-diagram-objects): `medium` severity, `3` details across `1` sections' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('- [`Structure resizing`]({0}#comparevi-change-002-block-diagram-objects): `low` severity, `2` details across `1` sections' -f $pair1Html)) -or
     $indexMarkdown -notmatch [regex]::Escape('- Headline: `Material version or compatibility changes`') -or
-    $indexMarkdown -notmatch [regex]::Escape('- [`Version or compatibility changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous): `medium` severity, `1` details across `1` sections')) {
+    $indexMarkdown -notmatch [regex]::Escape(('- [`Version or compatibility changes`]({0}#comparevi-change-001-vi-attribute-miscellaneous): `medium` severity, `1` details across `1` sections' -f $pair2Html))) {
     throw 'Index markdown should render reviewer-summary headlines, severity, and exact linked signals.'
   }
   if ([regex]::Matches($indexMarkdown, [regex]::Escape('#### Change details')).Count -ne 2 -or
-    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram moves`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects): `3` details across `1` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('[`Block diagram resizing`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects): `2` details across `1` sections') -or
-    $indexMarkdown -notmatch [regex]::Escape('Exact sections: [section 1](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects)') -or
-    $indexMarkdown -notmatch [regex]::Escape('[`VI version changes`](targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous): `1` details across `1` sections') -or
+    $indexMarkdown -notmatch [regex]::Escape(('[`Block diagram moves`]({0}#comparevi-change-001-block-diagram-objects): `3` details across `1` sections' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('[`Block diagram resizing`]({0}#comparevi-change-002-block-diagram-objects): `2` details across `1` sections' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('Exact sections: [section 1]({0}#comparevi-change-001-block-diagram-objects)' -f $pair1Html)) -or
+    $indexMarkdown -notmatch [regex]::Escape(('[`VI version changes`]({0}#comparevi-change-001-vi-attribute-miscellaneous): `1` details across `1` sections' -f $pair2Html)) -or
     $indexMarkdown -notmatch [regex]::Escape('Included categories: `Block Diagram Functional`, `VI Attribute`')) {
     throw 'Index markdown should render bounded change-detail summaries from the attributes compare report.'
   }
@@ -718,27 +728,27 @@ try {
     [regex]::Matches($indexHtml, [regex]::Escape('<h4>Block diagram</h4>')).Count -ne 2) {
     throw 'Index HTML should render both front-panel and block-diagram surfaces for each reviewer card.'
   }
-  if ($indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html"><img alt="Front panel base" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png"></a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html"><img alt="Block diagram base" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png"></a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html"><img alt="Front panel head" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png"></a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.html"><img alt="Block diagram head" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png"></a>')) {
-    throw 'Index HTML should make preview images one-click links to exact visual report surfaces.'
+  if ($indexHtml -notmatch [regex]::Escape(('<a href="{0}#front-panel"><img alt="Front panel base" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/fp_1.png"></a>' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#block-diagram"><img alt="Block diagram base" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report_files/bd_1.png"></a>' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#front-panel"><img alt="Front panel head" src="targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/fp_2.png"></a>' -f $pair2Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#block-diagram"><img alt="Block diagram head" src="targets/001-post/history/block-diagram/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report_files/bd_2.png"></a>' -f $pair2Html))) {
+    throw 'Index HTML should route preview images to unified history-pair review pages first.'
   }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Reviewer summary</h4>')).Count -ne 2 -or
     $indexHtml -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or
     $indexHtml -notmatch [regex]::Escape('<strong>Overall severity:</strong> medium') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections' -f $pair1Html)) -or
     $indexHtml -notmatch [regex]::Escape('<strong>Headline:</strong> Material version or compatibility changes') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections' -f $pair2Html))) {
     throw 'Index HTML should render reviewer-summary headlines, severity, and exact linked signals.'
   }
   if ([regex]::Matches($indexHtml, [regex]::Escape('<h4>Change details</h4>')).Count -ne 2 -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects">section 1</a>') -or
-    $indexHtml -notmatch [regex]::Escape('<a href="targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
-    $indexHtml -notmatch [regex]::Escape('open change details report')) {
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-block-diagram-objects">Block diagram moves</a>' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<strong>Exact sections:</strong> <a href="{0}#comparevi-change-001-block-diagram-objects">section 1</a>' -f $pair1Html)) -or
+    $indexHtml -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>' -f $pair2Html)) -or
+    $indexHtml -notmatch [regex]::Escape('open change details review')) {
     throw 'Index HTML should render bounded change-detail summaries from the attributes compare report.'
   }
 
@@ -776,8 +786,9 @@ try {
     [string]$previewManifest.indexPreviewCards[1].reviewerSummary.signals[0].label -ne 'Version or compatibility changes') {
     throw 'Preview manifest should carry reviewer-summary headlines and signals into the aggregate PR run.'
   }
-  if ([string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$previewManifest.indexPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous') {
+  if ([string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne ($pair1Html + '#comparevi-change-001-block-diagram-objects') -or
+    [string]$previewManifest.indexPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne ($pair2Html + '#comparevi-change-001-vi-attribute-miscellaneous') -or
+    [string]$previewManifest.indexPreviewCards[0].reviewerSummary.signals[0].debugPrimaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects') {
     throw 'Preview manifest should carry exact reviewer-summary links into the aggregate PR run.'
   }
   if ([string]$previewManifest.indexPreviewCards[0].changeDetails.label -ne 'Change details' -or
@@ -786,12 +797,15 @@ try {
     [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview manifest should carry reviewer-facing change-detail summaries into the aggregate PR run.'
   }
-  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-002-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-vi-attribute-miscellaneous') {
+  if ([string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne ($pair1Html + '#comparevi-change-001-block-diagram-objects') -or
+    [string]$previewManifest.indexPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne ($pair2Html + '#comparevi-change-001-vi-attribute-miscellaneous') -or
+    [string]$previewManifest.indexPreviewCards[0].changeDetails.groups[0].sectionLinks[0].debugReportHtmlRelativePath -ne 'targets/001-post/history/attributes/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.reviewer-anchors.html#comparevi-change-001-block-diagram-objects') {
     throw 'Preview manifest should carry exact attribute-section links into the aggregate PR run.'
   }
   if ($previewManifest.indexPreviewCards.Count -ne 2 -or
-    (@($previewManifest.indexPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
+    (@($previewManifest.indexPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram' -or
+    [string]$previewManifest.indexPreviewCards[0].surfaces[0].reportHtmlRelativePath -ne ($pair1Html + '#front-panel') -or
+    [string]$previewManifest.indexPreviewCards[0].surfaces[0].debugReportHtmlRelativePath -ne 'targets/001-post/history/front-panel/VIP_Post-Install_Custom_Action.vi-001-artifacts/compare-report.html') {
     throw 'Preview manifest should expose reviewer cards with both front-panel and block-diagram surfaces.'
   }
 

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -531,6 +531,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<!-- comparevi-history:pull-request-diagnostics -->')) {
     throw 'Created PR comment body is missing the sticky marker.'
   }
+  $pair1Url = 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md'
+  $pair2Url = 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/index.md'
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<h4><code>Tooling/demo/Demo.vi</code></h4>')).Count -ne 2) {
     throw 'Created PR comment body should render two reviewer-canonical preview gallery sections.'
   }
@@ -550,25 +552,25 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Reviewer summary</strong></p>')).Count -ne 2 -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material logic-affecting movement and structure resizing') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Overall severity:</strong> medium') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-block-diagram-objects">Logic-affecting movement</a>:</strong> medium severity, 3 details across 1 sections' -f $pair1Url)) -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-002-block-diagram-objects">Structure resizing</a>:</strong> low severity, 2 details across 1 sections' -f $pair1Url)) -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Headline:</strong> Material version or compatibility changes') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections')) {
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-vi-attribute-miscellaneous">Version or compatibility changes</a>:</strong> medium severity, 1 details across 1 sections' -f $pair2Url))) {
     throw 'Created PR comment body should render reviewer-summary headlines, severity, and exact linked signals.'
   }
   if ([regex]::Matches($global:RecordedPosts[0].body, [regex]::Escape('<p><strong>Change details</strong></p>')).Count -ne 2 -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">Block diagram moves</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<strong>Exact sections:</strong> <a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects">section 1</a>') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>') -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-block-diagram-objects">Block diagram moves</a>' -f $pair1Url)) -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-002-block-diagram-objects">Block diagram resizing</a>' -f $pair1Url)) -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<strong>Exact sections:</strong> <a href="{0}#comparevi-change-001-block-diagram-objects">section 1</a>' -f $pair1Url)) -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<a href="{0}#comparevi-change-001-vi-attribute-miscellaneous">VI version changes</a>' -f $pair2Url)) -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('VI Version : changed from &quot;21.0&quot; to &quot;20.0&quot;') -or
     $global:RecordedPosts[0].body -notmatch [regex]::Escape('open change details report')) {
     throw 'Created PR comment body should render bounded change-detail summaries from the attributes compare report.'
   }
-  if ($global:RecordedPosts[0].body -notmatch [regex]::Escape('<td><a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md"><img alt="Front panel base"') -or
-    $global:RecordedPosts[0].body -notmatch [regex]::Escape('<td><a href="https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/evidence.md"><img alt="Block diagram head"') -or
+  if ($global:RecordedPosts[0].body -notmatch [regex]::Escape(('<td><a href="{0}#front-panel"><img alt="Front panel base"' -f $pair1Url)) -or
+    $global:RecordedPosts[0].body -notmatch [regex]::Escape(('<td><a href="{0}#block-diagram"><img alt="Block diagram head"' -f $pair1Url)) -or
     $global:RecordedPosts[0].body -match [regex]::Escape('<p><a href="https://github.com/example/repo/actions/runs/321">workflow run</a></p>')) {
-    throw 'Created PR comment body should link preview images to exact published evidence pages instead of the workflow run.'
+    throw 'Created PR comment body should link preview images to unified published pair pages instead of the workflow run.'
   }
   if ([regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/base\.png').Count -ne 4 -or
     [regex]::Matches($global:RecordedPosts[0].body, 'https://raw\.githubusercontent\.com/.+?/head\.png').Count -ne 4) {
@@ -583,8 +585,8 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
   if ($global:RecordedRefCreates.Count -ne 1) {
     throw 'Expected one preview branch creation request.'
   }
-  if ($global:RecordedContentWrites.Count -ne 15) {
-    throw 'Expected preview publication to write eight images, six evidence pages, and one manifest.'
+  if ($global:RecordedContentWrites.Count -ne 17) {
+    throw 'Expected preview publication to write eight images, six debug pages, two pair pages, and one manifest.'
   }
 
   $publishedPairOrder = @(
@@ -598,10 +600,11 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     (@($createReceipt.previewPublication.commentPreviewCards[0].surfaces | ForEach-Object { [string]$_.surfaceKind }) -join ',') -ne 'front-panel,block-diagram') {
     throw 'Preview publication should retain reviewer cards with both front-panel and block-diagram surfaces.'
   }
-  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].evidenceUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md' -or
-    [string]$createReceipt.previewPublication.commentPreviewPairs[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md') {
-    throw 'Preview publication should expose exact published evidence-page locations for visual surfaces.'
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].pairReviewPath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md#front-panel' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].debugEvidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/01-front-panel/evidence.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewPairs[0].evidencePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md#front-panel') {
+    throw 'Preview publication should expose unified pair-review locations first and keep per-surface pages as debug surfaces.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.label -ne 'Reviewer summary' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.headline -ne 'Material logic-affecting movement and structure resizing' -or
@@ -611,10 +614,10 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].label -ne 'Version or compatibility changes') {
     throw 'Preview publication should retain reviewer-summary headlines and signals.'
   }
-  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[1].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects') {
-    throw 'Preview publication should retain exact reviewer-summary links and publish stable evidence URLs.'
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportHtmlRelativePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].debugPrimaryReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportUrl -ne ($pair1Url + '#comparevi-change-001-block-diagram-objects')) {
+    throw 'Preview publication should route reviewer-summary links to the pair page and preserve debug evidence links.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or
@@ -622,11 +625,11 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].heading -ne 'VI version changes') {
     throw 'Preview publication should retain reviewer-facing change-detail summaries.'
   }
-  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.reportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-001-artifacts/compare-report.html#comparevi-change-001-block-diagram-objects' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects' -or
-    [string]$createReceipt.previewPublication.commentPreviewCards[1].changeDetails.groups[0].primaryReportHtmlRelativePath -ne 'targets/001/history/attributes/Demo.vi-002-artifacts/compare-report.html#comparevi-change-001-vi-attribute-miscellaneous') {
-    throw 'Preview publication should retain exact section links for reviewer change details and publish stable evidence URLs.'
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.reportUrl -ne ($pair1Url + '#change-details') -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.debugReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].reportHtmlRelativePath -ne '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md#comparevi-change-001-block-diagram-objects' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].sectionLinks[0].debugReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects') {
+    throw 'Preview publication should route change-detail links to the pair page and preserve debug section evidence.'
   }
 
   $writeOrder = @(
@@ -641,6 +644,7 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/head.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/02-block-diagram/evidence.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/index.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/base.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/head.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/01-front-panel/evidence.md',
@@ -648,6 +652,7 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/head.png',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/02-block-diagram/evidence.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/change-details.md',
+    '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/002-history-pair-02/index.md',
     '.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/preview-manifest.json'
   )
   foreach ($index in 0..($expectedWritePaths.Count - 1)) {

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -170,6 +170,73 @@ function Escape-Html {
   return [System.Net.WebUtility]::HtmlEncode($Value)
 }
 
+function Get-ReportAnchorId {
+  param(
+    [AllowNull()]
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $hashIndex = $Path.IndexOf('#', [System.StringComparison]::Ordinal)
+  if ($hashIndex -lt 0 -or $hashIndex -ge ($Path.Length - 1)) {
+    return $null
+  }
+
+  return $Path.Substring($hashIndex + 1)
+}
+
+function Add-AnchorToRelativePath {
+  param(
+    [AllowNull()]
+    [string]$Path,
+    [AllowNull()]
+    [string]$AnchorId
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($AnchorId)) {
+    return $Path
+  }
+
+  return '{0}#{1}' -f $Path, $AnchorId
+}
+
+function Resolve-RelativeLinkFromPage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PageRelativePath,
+    [AllowNull()]
+    [string]$TargetRelativePath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($TargetRelativePath)) {
+    return $null
+  }
+
+  $anchorId = Get-ReportAnchorId -Path $TargetRelativePath
+  $pathWithoutAnchor = $TargetRelativePath
+  $hashIndex = $TargetRelativePath.IndexOf('#', [System.StringComparison]::Ordinal)
+  if ($hashIndex -ge 0) {
+    $pathWithoutAnchor = $TargetRelativePath.Substring(0, $hashIndex)
+  }
+
+  $pageDirectory = [System.IO.Path]::GetDirectoryName(($PageRelativePath -replace '/', '\'))
+  $targetPath = $pathWithoutAnchor -replace '/', '\'
+  $relativePath = if ([string]::IsNullOrWhiteSpace($pageDirectory)) {
+    $targetPath
+  } else {
+    [System.IO.Path]::GetRelativePath($pageDirectory, $targetPath)
+  }
+
+  return Add-AnchorToRelativePath -Path ($relativePath.Replace('\', '/')) -AnchorId $anchorId
+}
+
 function ConvertTo-ShortRef {
   param([AllowNull()][string]$Ref)
 
@@ -332,6 +399,39 @@ function Get-WorkspaceCardAnchorId {
   $comparisonIndex = Get-ReviewerPreviewComparisonIndex -PreviewPair $PreviewCard
   $targetSlug = ConvertTo-Slug -Value (Get-OptionalString -Value $PreviewCard.targetPath) -Fallback (ConvertTo-Slug -Value (Get-OptionalString -Value $PreviewCard.targetId) -Fallback 'target')
   return 'history-pair-{0:D2}-{1}' -f $comparisonIndex, $targetSlug
+}
+
+function Get-WorkspacePairPageRootRelativePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [int]$Ordinal
+  )
+
+  return 'history-pairs/{0:D3}-{1}' -f $Ordinal, (Get-WorkspaceCardAnchorId -PreviewCard $PreviewCard)
+}
+
+function Get-WorkspacePairPageHtmlRelativePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [int]$Ordinal
+  )
+
+  return '{0}/index.html' -f (Get-WorkspacePairPageRootRelativePath -PreviewCard $PreviewCard -Ordinal $Ordinal)
+}
+
+function Get-WorkspacePairPageMarkdownRelativePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [int]$Ordinal
+  )
+
+  return '{0}/index.md' -f (Get-WorkspacePairPageRootRelativePath -PreviewCard $PreviewCard -Ordinal $Ordinal)
 }
 
 function Get-WorkspaceSurfaceReportLink {
@@ -756,7 +856,7 @@ function New-MarkdownChangeDetailsLines {
   }
   $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
   if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
-    $lines.Add(('- Report: [{0}]({0})' -f $reportHtmlRelativePath)) | Out-Null
+    $lines.Add(('- Review page: [{0}]({0})' -f $reportHtmlRelativePath)) | Out-Null
   }
   $lines.Add('') | Out-Null
   return @($lines | ForEach-Object { $_ })
@@ -858,7 +958,7 @@ function New-HtmlChangeDetailsBlock {
   }
   $reportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
   if (-not [string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
-    $items.Add('<li><a href="' + (Escape-Html $reportHtmlRelativePath) + '">open change details report</a></li>') | Out-Null
+    $items.Add('<li><a href="' + (Escape-Html $reportHtmlRelativePath) + '">open change details review</a></li>') | Out-Null
   }
 
   return '<section class="preview-change-details"><h4>Change details</h4><ul>' + ($items -join '') + '</ul></section>'
@@ -1016,6 +1116,507 @@ function New-ReviewerPreviewCards {
   return @($cards | ForEach-Object { $_ })
 }
 
+function ConvertTo-WorkspaceReviewerSectionLink {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$SectionLink,
+    [Parameter(Mandatory = $true)]
+    [string]$PairPageHtmlRelativePath,
+    [string]$FallbackAnchorId = 'change-details'
+  )
+
+  $rawReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('reportHtmlRelativePath'))
+  $anchorId = Get-ReportAnchorId -Path $rawReportHtmlRelativePath
+  if ([string]::IsNullOrWhiteSpace($anchorId)) {
+    $anchorId = ConvertTo-Slug -Value (Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('label'))) -Fallback $FallbackAnchorId
+  }
+
+  return [ordered]@{
+    sectionOrdinal = [int](Get-NestedValue -Object $SectionLink -Path @('sectionOrdinal') -Default 0)
+    label = Get-OptionalString -Value (Get-NestedValue -Object $SectionLink -Path @('label'))
+    reportHtmlRelativePath = Add-AnchorToRelativePath -Path $PairPageHtmlRelativePath -AnchorId $anchorId
+    debugReportHtmlRelativePath = $rawReportHtmlRelativePath
+  }
+}
+
+function ConvertTo-WorkspaceReviewerSummary {
+  param(
+    [AllowNull()]
+    [object]$ReviewerSummary,
+    [Parameter(Mandatory = $true)]
+    [string]$PairPageHtmlRelativePath
+  )
+
+  if ($null -eq $ReviewerSummary) {
+    return $null
+  }
+
+  $signals = New-Object System.Collections.Generic.List[object]
+  foreach ($signal in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ReviewerSummary -Path @('signals') -Default @()))) {
+    $rawPrimaryPath = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('primaryReportHtmlRelativePath'))
+    $primaryAnchorId = Get-ReportAnchorId -Path $rawPrimaryPath
+    if ([string]::IsNullOrWhiteSpace($primaryAnchorId)) {
+      $primaryAnchorId = ConvertTo-Slug -Value (Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))) -Fallback 'reviewer-signal'
+    }
+
+    $signals.Add([ordered]@{
+        signalKey = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('signalKey'))
+        label = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('label'))
+        severity = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('severity'))
+        detailCount = [int](Get-NestedValue -Object $signal -Path @('detailCount') -Default 0)
+        sectionCount = [int](Get-NestedValue -Object $signal -Path @('sectionCount') -Default 0)
+        summary = Get-OptionalString -Value (Get-NestedValue -Object $signal -Path @('summary'))
+        primaryReportHtmlRelativePath = Add-AnchorToRelativePath -Path $PairPageHtmlRelativePath -AnchorId $primaryAnchorId
+        debugPrimaryReportHtmlRelativePath = $rawPrimaryPath
+        sectionLinks = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $signal -Path @('sectionLinks') -Default @()) |
+            ForEach-Object { ConvertTo-WorkspaceReviewerSectionLink -SectionLink $_ -PairPageHtmlRelativePath $PairPageHtmlRelativePath -FallbackAnchorId $primaryAnchorId }
+        )
+      }) | Out-Null
+  }
+
+  return [ordered]@{
+    label = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('label'))
+    overallSeverity = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+    headline = Get-OptionalString -Value (Get-NestedValue -Object $ReviewerSummary -Path @('headline'))
+    signalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('signalCount') -Default 0)
+    omittedSignalCount = [int](Get-NestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+    signals = @($signals | ForEach-Object { $_ })
+  }
+}
+
+function ConvertTo-WorkspaceChangeDetails {
+  param(
+    [AllowNull()]
+    [object]$ChangeDetails,
+    [Parameter(Mandatory = $true)]
+    [string]$PairPageHtmlRelativePath
+  )
+
+  if ($null -eq $ChangeDetails) {
+    return $null
+  }
+
+  $groups = New-Object System.Collections.Generic.List[object]
+  foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('groups') -Default @()))) {
+    $rawPrimaryPath = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath'))
+    $primaryAnchorId = Get-ReportAnchorId -Path $rawPrimaryPath
+    if ([string]::IsNullOrWhiteSpace($primaryAnchorId)) {
+      $primaryAnchorId = ConvertTo-Slug -Value (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))) -Fallback 'change-group'
+    }
+
+    $groups.Add([ordered]@{
+        heading = Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading'))
+        sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+        detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+        sampleDetails = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()) |
+            ForEach-Object { [string]$_ }
+        )
+        omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+        primaryReportHtmlRelativePath = Add-AnchorToRelativePath -Path $PairPageHtmlRelativePath -AnchorId $primaryAnchorId
+        debugPrimaryReportHtmlRelativePath = $rawPrimaryPath
+        sectionLinks = @(
+          ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()) |
+            ForEach-Object { ConvertTo-WorkspaceReviewerSectionLink -SectionLink $_ -PairPageHtmlRelativePath $PairPageHtmlRelativePath -FallbackAnchorId $primaryAnchorId }
+        )
+      }) | Out-Null
+  }
+
+  return [ordered]@{
+    label = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('label'))
+    sourceMode = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('sourceMode'))
+    reportHtmlRelativePath = Add-AnchorToRelativePath -Path $PairPageHtmlRelativePath -AnchorId 'change-details'
+    debugReportHtmlRelativePath = Get-OptionalString -Value (Get-NestedValue -Object $ChangeDetails -Path @('reportHtmlRelativePath'))
+    includedCategories = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()) |
+        ForEach-Object { [string]$_ }
+    )
+    groupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('groupCount') -Default 0)
+    omittedGroupCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+    sectionCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-NestedValue -Object $ChangeDetails -Path @('detailCount') -Default 0)
+    groups = @($groups | ForEach-Object { $_ })
+  }
+}
+
+function ConvertTo-WorkspacePreviewCard {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [Parameter(Mandatory = $true)]
+    [int]$Ordinal
+  )
+
+  $pairPageHtmlRelativePath = Get-WorkspacePairPageHtmlRelativePath -PreviewCard $PreviewCard -Ordinal $Ordinal
+  $pairPageMarkdownRelativePath = Get-WorkspacePairPageMarkdownRelativePath -PreviewCard $PreviewCard -Ordinal $Ordinal
+
+  $surfaces = New-Object System.Collections.Generic.List[object]
+  foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $PreviewCard -Path @('surfaces') -Default @()))) {
+    $surfaceKind = Get-OptionalString -Value $surface.surfaceKind
+    $surfaceAnchorId = switch ($surfaceKind) {
+      'front-panel' { 'front-panel' }
+      'block-diagram' { 'block-diagram' }
+      default { ConvertTo-Slug -Value $surfaceKind -Fallback 'preview-surface' }
+    }
+
+    $surfaces.Add([ordered]@{
+        surfaceKind = $surfaceKind
+        surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+        reportHtmlRelativePath = Add-AnchorToRelativePath -Path $pairPageHtmlRelativePath -AnchorId $surfaceAnchorId
+        debugReportHtmlRelativePath = Get-OptionalString -Value $surface.reportHtmlRelativePath
+        baseImageRelativePath = Get-OptionalString -Value $surface.baseImageRelativePath
+        headImageRelativePath = Get-OptionalString -Value $surface.headImageRelativePath
+      }) | Out-Null
+  }
+
+  return [ordered]@{
+    targetId = [string]$PreviewCard.targetId
+    targetPath = [string]$PreviewCard.targetPath
+    comparison = $PreviewCard.comparison
+    pairPageHtmlRelativePath = $pairPageHtmlRelativePath
+    pairPageMarkdownRelativePath = $pairPageMarkdownRelativePath
+    reviewerSummary = ConvertTo-WorkspaceReviewerSummary -ReviewerSummary (Get-NestedValue -Object $PreviewCard -Path @('reviewerSummary')) -PairPageHtmlRelativePath $pairPageHtmlRelativePath
+    changeDetails = ConvertTo-WorkspaceChangeDetails -ChangeDetails (Get-NestedValue -Object $PreviewCard -Path @('changeDetails')) -PairPageHtmlRelativePath $pairPageHtmlRelativePath
+    surfaces = @($surfaces | ForEach-Object { $_ })
+  }
+}
+
+function New-WorkspacePrimaryPreviewCards {
+  param(
+    [AllowEmptyCollection()]
+    [object[]]$PreviewCards = @()
+  )
+
+  $convertedCards = New-Object System.Collections.Generic.List[object]
+  $ordinal = 1
+  foreach ($previewCard in @(ConvertTo-ObjectArray -Value $PreviewCards)) {
+    $convertedCards.Add((ConvertTo-WorkspacePreviewCard -PreviewCard $previewCard -Ordinal $ordinal)) | Out-Null
+    $ordinal += 1
+  }
+
+  return @($convertedCards | ForEach-Object { $_ })
+}
+
+function New-WorkspacePrimaryPreviewPairs {
+  param(
+    [AllowEmptyCollection()]
+    [object[]]$PreviewCards = @()
+  )
+
+  $previewPairs = New-Object System.Collections.Generic.List[object]
+  foreach ($previewCard in @(ConvertTo-ObjectArray -Value $PreviewCards)) {
+    $representativeSurface = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $previewCard -Path @('surfaces') -Default @()) |
+        Select-Object -First 1
+    )
+    if ($null -eq $representativeSurface) {
+      continue
+    }
+
+    $previewPairs.Add([ordered]@{
+        targetId = [string]$previewCard.targetId
+        targetPath = [string]$previewCard.targetPath
+        mode = Get-OptionalString -Value $representativeSurface.surfaceKind
+        label = Get-OptionalString -Value $representativeSurface.surfaceLabel
+        sectionKind = 'review-pair'
+        comparison = $previewCard.comparison
+        reportHtmlRelativePath = Get-OptionalString -Value $representativeSurface.reportHtmlRelativePath
+        debugReportHtmlRelativePath = Get-OptionalString -Value $representativeSurface.debugReportHtmlRelativePath
+        baseImageRelativePath = Get-OptionalString -Value $representativeSurface.baseImageRelativePath
+        headImageRelativePath = Get-OptionalString -Value $representativeSurface.headImageRelativePath
+      }) | Out-Null
+  }
+
+  return @($previewPairs | ForEach-Object { $_ })
+}
+
+function New-MarkdownWorkspacePairPage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [AllowEmptyCollection()]
+    [object[]]$Targets = @(),
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
+  )
+
+  $pageRelativePath = Get-OptionalString -Value $PreviewCard.pairPageMarkdownRelativePath
+  $workspaceHtmlLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Add-AnchorToRelativePath -Path 'index.html' -AnchorId (Get-WorkspaceCardAnchorId -PreviewCard $PreviewCard))
+  $workspaceMarkdownLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Add-AnchorToRelativePath -Path 'index.md' -AnchorId (Get-WorkspaceCardAnchorId -PreviewCard $PreviewCard))
+  $lines = New-Object System.Collections.Generic.List[string]
+  $title = Get-ReviewerPreviewTitle -PreviewPair $PreviewCard
+  $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $PreviewCard
+  $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $PreviewCard
+  $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $PreviewCard)
+
+  $lines.Add(('# `{0}`' -f $title)) | Out-Null
+  $lines.Add('') | Out-Null
+  $lines.Add(('## {0}' -f $subtitle)) | Out-Null
+  $lines.Add('') | Out-Null
+  if (-not [string]::IsNullOrWhiteSpace($revisionContext)) {
+    $lines.Add(('`{0}`' -f $revisionContext)) | Out-Null
+    $lines.Add('') | Out-Null
+  }
+  foreach ($detailLine in $detailLines) {
+    $lines.Add(('- {0}' -f $detailLine)) | Out-Null
+  }
+  if ($detailLines.Count -gt 0) {
+    $lines.Add('') | Out-Null
+  }
+  $lines.Add(('Back to workspace: [index.html]({0}), [index.md]({1})' -f $workspaceHtmlLink, $workspaceMarkdownLink)) | Out-Null
+  $lines.Add('') | Out-Null
+
+  foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $PreviewCard -Path @('surfaces') -Default @()))) {
+    $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind (Get-OptionalString -Value $surface.surfaceKind) -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+    $baseImageRelativePath = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.baseImageRelativePath)
+    $headImageRelativePath = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.headImageRelativePath)
+    $debugReportLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.debugReportHtmlRelativePath)
+
+    $lines.Add(('## {0}' -f $surfaceLabel)) | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('**Base**') | Out-Null
+    $lines.Add(('![{0}]({1})' -f ('{0} base' -f $surfaceLabel), $baseImageRelativePath)) | Out-Null
+    $lines.Add('') | Out-Null
+    $lines.Add('**Head**') | Out-Null
+    $lines.Add(('![{0}]({1})' -f ('{0} head' -f $surfaceLabel), $headImageRelativePath)) | Out-Null
+    if (-not [string]::IsNullOrWhiteSpace($debugReportLink)) {
+      $lines.Add('') | Out-Null
+      $lines.Add(('- Debug raw report: [{0}]({0})' -f $debugReportLink)) | Out-Null
+    }
+    $lines.Add('') | Out-Null
+  }
+
+  foreach ($reviewerSummaryLine in @(New-MarkdownReviewerSummaryLines -ReviewerSummary (Get-NestedValue -Object $PreviewCard -Path @('reviewerSummary')))) {
+    $lines.Add($reviewerSummaryLine) | Out-Null
+  }
+  foreach ($changeDetailLine in @(New-MarkdownChangeDetailsLines -ChangeDetails (Get-NestedValue -Object $PreviewCard -Path @('changeDetails')))) {
+    $lines.Add($changeDetailLine) | Out-Null
+  }
+
+  $targetLinks = Get-WorkspaceTargetLinks -PreviewCard $PreviewCard -Targets $Targets -ResultsRoot $ResultsRoot
+  $debugLinks = New-Object System.Collections.Generic.List[string]
+  foreach ($key in @('historyReport', 'sharedEvidence', 'publicRun', 'modeSummary', 'request')) {
+    $path = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value (Get-NestedValue -Object $targetLinks -Path @($key)))
+    if ([string]::IsNullOrWhiteSpace($path)) {
+      continue
+    }
+    $label = switch ($key) {
+      'historyReport' { 'history report' }
+      'sharedEvidence' { 'shared evidence' }
+      'publicRun' { 'public run' }
+      'modeSummary' { 'mode summary' }
+      'request' { 'request' }
+      default { $key }
+    }
+    $debugLinks.Add(('[{0}]({1})' -f $label, $path)) | Out-Null
+  }
+  if ($debugLinks.Count -gt 0) {
+    $lines.Add('## Debug evidence') | Out-Null
+    $lines.Add('') | Out-Null
+    foreach ($debugLink in $debugLinks) {
+      $lines.Add(('- {0}' -f $debugLink)) | Out-Null
+    }
+    $lines.Add('') | Out-Null
+  }
+
+  return ($lines -join "`n").TrimEnd() + "`n"
+}
+
+function New-HtmlWorkspacePairPage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard,
+    [AllowEmptyCollection()]
+    [object[]]$Targets = @(),
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
+  )
+
+  $pageRelativePath = Get-OptionalString -Value $PreviewCard.pairPageHtmlRelativePath
+  $workspaceHtmlLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Add-AnchorToRelativePath -Path 'index.html' -AnchorId (Get-WorkspaceCardAnchorId -PreviewCard $PreviewCard))
+  $workspaceMarkdownLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Add-AnchorToRelativePath -Path 'index.md' -AnchorId (Get-WorkspaceCardAnchorId -PreviewCard $PreviewCard))
+  $title = Get-ReviewerPreviewTitle -PreviewPair $PreviewCard
+  $subtitle = Get-ReviewerPreviewSubtitle -PreviewPair $PreviewCard
+  $revisionContext = Get-ReviewerPreviewRevisionContext -PreviewPair $PreviewCard
+  $detailLines = @(Get-ReviewerPreviewDetailLines -PreviewPair $PreviewCard)
+
+  $surfaceSections = New-Object System.Collections.Generic.List[string]
+  foreach ($surface in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $PreviewCard -Path @('surfaces') -Default @()))) {
+    $surfaceKind = Get-OptionalString -Value $surface.surfaceKind
+    $surfaceAnchorId = switch ($surfaceKind) {
+      'front-panel' { 'front-panel' }
+      'block-diagram' { 'block-diagram' }
+      default { ConvertTo-Slug -Value $surfaceKind -Fallback 'preview-surface' }
+    }
+    $surfaceLabel = Get-ReviewerPreviewSurfaceLabel -SurfaceKind $surfaceKind -FallbackLabel (Get-OptionalString -Value $surface.surfaceLabel)
+    $baseImageRelativePath = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.baseImageRelativePath)
+    $headImageRelativePath = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.headImageRelativePath)
+    $debugReportLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value $surface.debugReportHtmlRelativePath)
+
+    $surfaceSections.Add(@"
+  <section class="pair-surface" id="$(Escape-Html $surfaceAnchorId)">
+    <h2>$(Escape-Html $surfaceLabel)</h2>
+    <div class="pair-image-grid">
+      <figure>
+        <img alt="$(Escape-Html ($surfaceLabel + ' base'))" src="$(Escape-Html $baseImageRelativePath)">
+        <figcaption>Base</figcaption>
+      </figure>
+      <figure>
+        <img alt="$(Escape-Html ($surfaceLabel + ' head'))" src="$(Escape-Html $headImageRelativePath)">
+        <figcaption>Head</figcaption>
+      </figure>
+    </div>
+    $(if (-not [string]::IsNullOrWhiteSpace($debugReportLink)) { '<p class="pair-debug-links"><strong>Debug raw report:</strong> <a href="' + (Escape-Html $debugReportLink) + '">open raw report</a></p>' } else { '' })
+  </section>
+"@) | Out-Null
+  }
+
+  $reviewerSummaryHtml = New-HtmlReviewerSummaryBlock -ReviewerSummary (Get-NestedValue -Object $PreviewCard -Path @('reviewerSummary'))
+
+  $changeDetailItems = New-Object System.Collections.Generic.List[string]
+  $changeDetails = Get-NestedValue -Object $PreviewCard -Path @('changeDetails')
+  if ($null -ne $changeDetails) {
+    $includedCategories = @(
+      ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('includedCategories') -Default @()) |
+        ForEach-Object { Get-OptionalString -Value $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+    if ($includedCategories.Count -gt 0) {
+      $changeDetailItems.Add('<li><strong>Included categories:</strong> ' + (Escape-Html ($includedCategories -join ', ')) + '</li>') | Out-Null
+    }
+    foreach ($group in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $changeDetails -Path @('groups') -Default @()))) {
+      $groupAnchorId = Get-ReportAnchorId -Path (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('primaryReportHtmlRelativePath')))
+      $heading = Escape-Html (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('heading')))
+      $detailCount = [int](Get-NestedValue -Object $group -Path @('detailCount') -Default 0)
+      $sectionCount = [int](Get-NestedValue -Object $group -Path @('sectionCount') -Default 0)
+      $sampleItems = New-Object System.Collections.Generic.List[string]
+      foreach ($sampleDetail in @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sampleDetails') -Default @()))) {
+        $sampleItems.Add('<li>' + (Escape-Html ([string]$sampleDetail)) + '</li>') | Out-Null
+      }
+      $omittedDetailCount = [int](Get-NestedValue -Object $group -Path @('omittedDetailCount') -Default 0)
+      if ($omittedDetailCount -gt 0) {
+        $sampleItems.Add('<li>+' + $omittedDetailCount + ' more details in report</li>') | Out-Null
+      }
+      $sectionLinksHtml = New-HtmlChangeDetailSectionLinks -SectionLinks @(ConvertTo-ObjectArray -Value (Get-NestedValue -Object $group -Path @('sectionLinks') -Default @()))
+      if (-not [string]::IsNullOrWhiteSpace($sectionLinksHtml)) {
+        $sampleItems.Add($sectionLinksHtml) | Out-Null
+      }
+      $debugPrimaryPath = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value (Get-NestedValue -Object $group -Path @('debugPrimaryReportHtmlRelativePath')))
+      if (-not [string]::IsNullOrWhiteSpace($debugPrimaryPath)) {
+        $sampleItems.Add('<li><strong>Debug raw section:</strong> <a href="' + (Escape-Html $debugPrimaryPath) + '">open raw section</a></li>') | Out-Null
+      }
+      $changeDetailItems.Add(@"
+<li>
+  <a id="$(Escape-Html $groupAnchorId)"></a>
+  <strong>${heading}:</strong> $detailCount details across $sectionCount sections
+  <ul>$($sampleItems -join '')</ul>
+</li>
+"@) | Out-Null
+    }
+    $debugReportLink = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value (Get-NestedValue -Object $changeDetails -Path @('debugReportHtmlRelativePath')))
+    if (-not [string]::IsNullOrWhiteSpace($debugReportLink)) {
+      $changeDetailItems.Add('<li><a href="' + (Escape-Html $debugReportLink) + '">open raw attributes report</a></li>') | Out-Null
+    }
+  }
+
+  $targetLinks = Get-WorkspaceTargetLinks -PreviewCard $PreviewCard -Targets $Targets -ResultsRoot $ResultsRoot
+  $debugEvidenceItems = New-Object System.Collections.Generic.List[string]
+  foreach ($key in @('historyReport', 'sharedEvidence', 'publicRun', 'modeSummary', 'request')) {
+    $path = Resolve-RelativeLinkFromPage -PageRelativePath $pageRelativePath -TargetRelativePath (Get-OptionalString -Value (Get-NestedValue -Object $targetLinks -Path @($key)))
+    if ([string]::IsNullOrWhiteSpace($path)) {
+      continue
+    }
+    $label = switch ($key) {
+      'historyReport' { 'history report' }
+      'sharedEvidence' { 'shared evidence' }
+      'publicRun' { 'public run' }
+      'modeSummary' { 'mode summary' }
+      'request' { 'request' }
+      default { $key }
+    }
+    $debugEvidenceItems.Add('<li><a href="' + (Escape-Html $path) + '">' + (Escape-Html $label) + '</a></li>') | Out-Null
+  }
+
+  return @"
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>$(Escape-Html $title)</title>
+  <style>
+    body { font-family: Segoe UI, sans-serif; margin: 0; color: #1f2933; background: #f8fafc; }
+    .page-shell { max-width: 1200px; margin: 0 auto; padding: 2rem; }
+    code { background: #e2e8f0; padding: 0.1rem 0.3rem; border-radius: 4px; }
+    .pair-nav, .pair-meta, .pair-debug { background: #ffffff; border: 1px solid #cbd5e1; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+    .pair-image-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem; }
+    .pair-image-grid figure { margin: 0; }
+    .pair-image-grid img { max-width: 100%; height: auto; border: 1px solid #cbd5e1; background: #ffffff; }
+    .pair-surface, .pair-section { background: #ffffff; border: 1px solid #cbd5e1; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+    .pair-debug-links { color: #334155; }
+  </style>
+</head>
+<body>
+  <div class="page-shell">
+    <h1><code>$(Escape-Html $title)</code></h1>
+    <div class="pair-meta">
+      <p><strong>History pair:</strong> $(Escape-Html $subtitle)</p>
+      $(if (-not [string]::IsNullOrWhiteSpace($revisionContext)) { '<p><code>' + (Escape-Html $revisionContext) + '</code></p>' } else { '' })
+      $(if ($detailLines.Count -gt 0) { '<div>' + (($detailLines | ForEach-Object { '<p>' + (Escape-Html $_) + '</p>' }) -join '') + '</div>' } else { '' })
+    </div>
+    <div class="pair-nav">
+      <strong>Navigation:</strong>
+      <a href="$(Escape-Html $workspaceHtmlLink)">workspace html</a>,
+      <a href="$(Escape-Html $workspaceMarkdownLink)">workspace markdown</a>,
+      <a href="#front-panel">front panel</a>,
+      <a href="#block-diagram">block diagram</a>,
+      <a href="#reviewer-summary">reviewer summary</a>,
+      <a href="#change-details">change details</a>
+    </div>
+    $($surfaceSections -join "`n")
+    <section class="pair-section" id="reviewer-summary">
+      <h2>Reviewer summary</h2>
+      $reviewerSummaryHtml
+    </section>
+    <section class="pair-section" id="change-details">
+      <h2>Change details</h2>
+      <ul>$($changeDetailItems -join '')</ul>
+    </section>
+    $(if ($debugEvidenceItems.Count -gt 0) {
+      '<section class="pair-debug"><h2>Debug evidence</h2><ul>' + ($debugEvidenceItems -join '') + '</ul></section>'
+    } else { '' })
+  </div>
+</body>
+</html>
+"@
+}
+
+function Write-WorkspacePairPages {
+  param(
+    [AllowEmptyCollection()]
+    [object[]]$PreviewCards = @(),
+    [AllowEmptyCollection()]
+    [object[]]$Targets = @(),
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot
+  )
+
+  foreach ($previewCard in @(ConvertTo-ObjectArray -Value $PreviewCards)) {
+    $markdownRelativePath = Get-OptionalString -Value $previewCard.pairPageMarkdownRelativePath
+    $htmlRelativePath = Get-OptionalString -Value $previewCard.pairPageHtmlRelativePath
+    if ([string]::IsNullOrWhiteSpace($markdownRelativePath) -or [string]::IsNullOrWhiteSpace($htmlRelativePath)) {
+      continue
+    }
+
+    $markdownPath = Join-Path $ResultsRoot ($markdownRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    $htmlPath = Join-Path $ResultsRoot ($htmlRelativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+    New-Item -ItemType Directory -Path (Split-Path -Parent $markdownPath) -Force | Out-Null
+    New-Item -ItemType Directory -Path (Split-Path -Parent $htmlPath) -Force | Out-Null
+    (New-MarkdownWorkspacePairPage -PreviewCard $previewCard -Targets $Targets -ResultsRoot $ResultsRoot) | Set-Content -LiteralPath $markdownPath -Encoding utf8
+    (New-HtmlWorkspacePairPage -PreviewCard $previewCard -Targets $Targets -ResultsRoot $ResultsRoot) | Set-Content -LiteralPath $htmlPath -Encoding utf8
+  }
+}
+
 function New-MarkdownPreviewGallery {
   param(
     [AllowEmptyCollection()]
@@ -1093,7 +1694,7 @@ function New-MarkdownPreviewGallery {
       }
       $lines.Add($headImageMarkdown) | Out-Null
       if (-not [string]::IsNullOrWhiteSpace($surfaceReportPath)) {
-        $lines.Add(('- Report: [{0}]({0})' -f $surfaceReportPath)) | Out-Null
+        $lines.Add(('- Review page: [{0}]({0})' -f $surfaceReportPath)) | Out-Null
       }
       $lines.Add('') | Out-Null
     }
@@ -1138,7 +1739,7 @@ function New-HtmlPreviewGallery {
       $reportLink = if ([string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
         ''
       } else {
-        '<p><a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">open ' + (Escape-Html $surfaceLabel.ToLowerInvariant()) + ' report</a></p>'
+        '<p><a href="' + (Escape-Html ([string]$surface.reportHtmlRelativePath)) + '">open ' + (Escape-Html $surfaceLabel.ToLowerInvariant()) + ' review</a></p>'
       }
       $baseImageHtml = '<img alt="' + (Escape-Html ($surfaceLabel + ' base')) + '" src="' + (Escape-Html ([string]$surface.baseImageRelativePath)) + '">'
       if (-not [string]::IsNullOrWhiteSpace([string]$surface.reportHtmlRelativePath)) {
@@ -1257,6 +1858,7 @@ $indexPreviewCardCount = 0
 $commentPreviewPairCap = 0
 $indexPreviewPairCap = 0
 $indexPreviewCards = @()
+$commentPreviewCards = @()
 $previewTargetPairCountById = @{}
 if ($null -ne $targetManifest) {
   $targets = @($targetManifest.targets | ForEach-Object { $_ })
@@ -1294,6 +1896,20 @@ if ($null -ne $targetManifest) {
       -SelectedPreviewPairs @($previewManifest.indexPreviewPairs | ForEach-Object { $_ }) `
       -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
       -ExistingCards @($previewManifest.indexPreviewCards | ForEach-Object { $_ }))
+  $commentPreviewCards = @(New-ReviewerPreviewCards `
+      -SelectedPreviewPairs @($previewManifest.commentPreviewPairs | ForEach-Object { $_ }) `
+      -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
+      -ExistingCards @($previewManifest.commentPreviewCards | ForEach-Object { $_ }))
+  $indexPreviewCards = @(New-WorkspacePrimaryPreviewCards -PreviewCards $indexPreviewCards)
+  $commentPreviewCards = @(New-WorkspacePrimaryPreviewCards -PreviewCards $commentPreviewCards)
+  Write-WorkspacePairPages -PreviewCards $indexPreviewCards -Targets $targets -ResultsRoot $resultsDirResolved
+  $previewManifest.indexPreviewCards = @($indexPreviewCards | ForEach-Object { $_ })
+  $previewManifest.indexPreviewPairs = @(New-WorkspacePrimaryPreviewPairs -PreviewCards $indexPreviewCards)
+  $previewManifest.commentPreviewCards = @($commentPreviewCards | ForEach-Object { $_ })
+  $previewManifest.commentPreviewPairs = @(New-WorkspacePrimaryPreviewPairs -PreviewCards $commentPreviewCards)
+  $previewManifest.summary.indexPreviewCardCount = $indexPreviewCards.Count
+  $previewManifest.summary.commentPreviewCardCount = $commentPreviewCards.Count
+  ($previewManifest | ConvertTo-Json -Depth 100) | Set-Content -LiteralPath $previewManifestPathResolved -Encoding utf8
   foreach ($previewTarget in @($previewManifest.targets | ForEach-Object { $_ })) {
     $previewTargetPairCountById[[string]$previewTarget.targetId] = [int]$previewTarget.previewPairCount
   }


### PR DESCRIPTION
## Summary
- render unified history-pair review pages in the artifact workspace
- route reviewer-facing workspace and published comment links to those pair pages first
- keep raw mode reports and per-surface debug pages as secondary evidence only

## Validation
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check

Closes #161
