### PR TITLE
#162 Migrate reviewer renderers onto compiled review bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
             'scripts/Write-CompareVIHistoryPullRequestDiscovery.ps1',
             'scripts/Write-CompareVIHistoryAutomaticPullRequestDiscovery.ps1',
             'scripts/Invoke-CompareVIHistoryReviewBundleCompiler.ps1',
+            'scripts/CompareVIHistoryReviewBundleProjection.psm1',
             'scripts/Write-CompareVIHistoryPullRequestPreviewManifest.ps1',
             'scripts/Write-CompareVIHistoryRevisionCatalog.ps1',
             'scripts/Write-CompareVIHistoryChunkPlan.ps1',
@@ -150,6 +151,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
             'scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1',
             'scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1',
+            'scripts/Test-CompareVIHistoryReviewBundleProjection.ps1',
             'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryTemplateContracts.ps1'
@@ -210,6 +212,7 @@ jobs:
             'scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1',
             'scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1',
             'scripts/Test-CompareVIHistoryReviewBundleCompiler.ps1',
+            'scripts/Test-CompareVIHistoryReviewBundleProjection.ps1',
             'scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1',
             'scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1',
             'scripts/Test-CompareVIHistoryRequest.ps1',

--- a/scripts/CompareVIHistoryReviewBundleProjection.psm1
+++ b/scripts/CompareVIHistoryReviewBundleProjection.psm1
@@ -1,0 +1,316 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-ProjectionOptionalString {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+function Get-ProjectionNestedValue {
+  param(
+    [AllowNull()]
+    [object]$Object,
+    [Parameter(Mandatory = $true)]
+    [string[]]$Path,
+    [AllowNull()]
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function ConvertTo-ProjectionObjectArray {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return @()
+  }
+
+  if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable]) {
+    return @($Value)
+  }
+
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($item in ([System.Collections.IEnumerable]$Value)) {
+    $items.Add($item) | Out-Null
+  }
+
+  return @($items | ForEach-Object { $_ })
+}
+
+function Get-ReviewPairSelectionKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetId,
+    [Parameter(Mandatory = $true)]
+    [int]$ComparisonIndex
+  )
+
+  return '{0}|{1}' -f $TargetId, $ComparisonIndex
+}
+
+function Convert-ProjectionSectionLink {
+  param([Parameter(Mandatory = $true)][object]$SectionLink)
+
+  $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $SectionLink -Path @('reviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $SectionLink -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    sectionOrdinal = [int](Get-ProjectionNestedValue -Object $SectionLink -Path @('sectionOrdinal') -Default 0)
+    label = [string](Get-ProjectionNestedValue -Object $SectionLink -Path @('label') -Default '')
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    debugReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $SectionLink -Path @('debugReportHtmlRelativePath'))
+  }
+}
+
+function Convert-ProjectionChangeDetailGroup {
+  param([Parameter(Mandatory = $true)][object]$Group)
+
+  $primaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Group -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $primaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Group -Path @('primaryDebugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    heading = [string](Get-ProjectionNestedValue -Object $Group -Path @('heading') -Default '')
+    sectionCount = [int](Get-ProjectionNestedValue -Object $Group -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-ProjectionNestedValue -Object $Group -Path @('detailCount') -Default 0)
+    sampleDetails = @(ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $Group -Path @('sampleDetails') -Default @()))
+    omittedDetailCount = [int](Get-ProjectionNestedValue -Object $Group -Path @('omittedDetailCount') -Default 0)
+    primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+    debugPrimaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Group -Path @('primaryDebugReportHtmlRelativePath'))
+    sectionLinks = @(
+      ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $Group -Path @('sectionLinks') -Default @()) |
+        ForEach-Object { Convert-ProjectionSectionLink -SectionLink $_ }
+    )
+  }
+}
+
+function Convert-ProjectionChangeDetails {
+  param([AllowNull()][object]$ChangeDetails)
+
+  if ($null -eq $ChangeDetails) {
+    return $null
+  }
+
+  $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    label = [string](Get-ProjectionNestedValue -Object $ChangeDetails -Path @('label') -Default 'Change details')
+    sourceMode = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('sourceMode'))
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    debugReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('debugReportHtmlRelativePath'))
+    includedCategories = @(ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('includedCategories') -Default @()))
+    groupCount = [int](Get-ProjectionNestedValue -Object $ChangeDetails -Path @('groupCount') -Default 0)
+    omittedGroupCount = [int](Get-ProjectionNestedValue -Object $ChangeDetails -Path @('omittedGroupCount') -Default 0)
+    sectionCount = [int](Get-ProjectionNestedValue -Object $ChangeDetails -Path @('sectionCount') -Default 0)
+    detailCount = [int](Get-ProjectionNestedValue -Object $ChangeDetails -Path @('detailCount') -Default 0)
+    groups = @(
+      ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $ChangeDetails -Path @('groups') -Default @()) |
+        ForEach-Object { Convert-ProjectionChangeDetailGroup -Group $_ }
+    )
+  }
+}
+
+function Convert-ProjectionReviewerSignal {
+  param([Parameter(Mandatory = $true)][object]$Signal)
+
+  $primaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Signal -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($primaryReportHtmlRelativePath)) {
+    $primaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Signal -Path @('primaryDebugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    signalKey = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Signal -Path @('signalKey'))
+    label = [string](Get-ProjectionNestedValue -Object $Signal -Path @('label') -Default '')
+    severity = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Signal -Path @('severity'))
+    detailCount = [int](Get-ProjectionNestedValue -Object $Signal -Path @('detailCount') -Default 0)
+    sectionCount = [int](Get-ProjectionNestedValue -Object $Signal -Path @('sectionCount') -Default 0)
+    summary = [string](Get-ProjectionNestedValue -Object $Signal -Path @('summary') -Default '')
+    primaryReportHtmlRelativePath = $primaryReportHtmlRelativePath
+    debugPrimaryReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Signal -Path @('primaryDebugReportHtmlRelativePath'))
+    sectionLinks = @(
+      ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $Signal -Path @('sectionLinks') -Default @()) |
+        ForEach-Object { Convert-ProjectionSectionLink -SectionLink $_ }
+    )
+  }
+}
+
+function Convert-ProjectionReviewerSummary {
+  param([AllowNull()][object]$ReviewerSummary)
+
+  if ($null -eq $ReviewerSummary) {
+    return $null
+  }
+
+  return [ordered]@{
+    label = [string](Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('label') -Default 'Reviewer summary')
+    overallSeverity = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('overallSeverity'))
+    headline = [string](Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('headline') -Default '')
+    signalCount = [int](Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('signalCount') -Default 0)
+    omittedSignalCount = [int](Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('omittedSignalCount') -Default 0)
+    signals = @(
+      ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $ReviewerSummary -Path @('signals') -Default @()) |
+        ForEach-Object { Convert-ProjectionReviewerSignal -Signal $_ }
+    )
+  }
+}
+
+function Convert-ProjectionSurface {
+  param([Parameter(Mandatory = $true)][object]$Surface)
+
+  $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('primaryReviewerRelativePath'))
+  if ([string]::IsNullOrWhiteSpace($reportHtmlRelativePath)) {
+    $reportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('debugReportHtmlRelativePath'))
+  }
+
+  return [ordered]@{
+    surfaceKind = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('surfaceKind'))
+    surfaceLabel = [string](Get-ProjectionNestedValue -Object $Surface -Path @('surfaceLabel') -Default '')
+    mode = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('mode'))
+    label = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('label'))
+    reportHtmlRelativePath = $reportHtmlRelativePath
+    debugReportHtmlRelativePath = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('debugReportHtmlRelativePath'))
+    baseImageRelativePath = [string](Get-ProjectionNestedValue -Object $Surface -Path @('baseImageRelativePath') -Default '')
+    headImageRelativePath = [string](Get-ProjectionNestedValue -Object $Surface -Path @('headImageRelativePath') -Default '')
+    baseByteLength = [int64](Get-ProjectionNestedValue -Object $Surface -Path @('baseByteLength') -Default 0)
+    headByteLength = [int64](Get-ProjectionNestedValue -Object $Surface -Path @('headByteLength') -Default 0)
+    baseImageSha256 = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('baseImageSha256'))
+    headImageSha256 = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('headImageSha256'))
+    sortKey = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $Surface -Path @('sortKey'))
+  }
+}
+
+function Convert-ProjectionReviewPairCard {
+  param([Parameter(Mandatory = $true)][object]$ReviewPair)
+
+  return [ordered]@{
+    targetId = [string]$ReviewPair.targetId
+    targetPath = [string]$ReviewPair.targetPath
+    comparison = Get-ProjectionNestedValue -Object $ReviewPair -Path @('comparison')
+    sortKey = Get-ProjectionOptionalString -Value (Get-ProjectionNestedValue -Object $ReviewPair -Path @('sortKey'))
+    surfaces = @(
+      ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $ReviewPair -Path @('surfaces') -Default @()) |
+        ForEach-Object { Convert-ProjectionSurface -Surface $_ }
+    )
+    reviewerSummary = Convert-ProjectionReviewerSummary -ReviewerSummary (Get-ProjectionNestedValue -Object $ReviewPair -Path @('reviewerSummary'))
+    changeDetails = Convert-ProjectionChangeDetails -ChangeDetails (Get-ProjectionNestedValue -Object $ReviewPair -Path @('changeDetails'))
+  }
+}
+
+function Sort-ProjectionCards {
+  param([AllowNull()]$Cards)
+
+  return @(
+    ConvertTo-ProjectionObjectArray -Value $Cards |
+      Sort-Object {
+        $sortKey = Get-ProjectionOptionalString -Value $_.sortKey
+        if ([string]::IsNullOrWhiteSpace($sortKey)) {
+          '{0}|{1:D4}' -f [string]$_.targetPath, [int](Get-ProjectionNestedValue -Object $_ -Path @('comparison', 'index') -Default 0)
+        } else {
+          $sortKey
+        }
+      }
+  )
+}
+
+function Get-CompareVIHistoryReviewBundleCards {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$ReviewBundle,
+    [AllowEmptyCollection()]
+    [object[]]$SelectedPreviewPairs = @(),
+    [switch]$UseSelectedPreviewPairs
+  )
+
+  $allCards = Sort-ProjectionCards -Cards @(
+    ConvertTo-ProjectionObjectArray -Value (Get-ProjectionNestedValue -Object $ReviewBundle -Path @('reviewPairs') -Default @()) |
+      ForEach-Object { Convert-ProjectionReviewPairCard -ReviewPair $_ }
+  )
+
+  if (-not $UseSelectedPreviewPairs.IsPresent) {
+    return $allCards
+  }
+
+  if ($SelectedPreviewPairs.Count -eq 0) {
+    return @()
+  }
+
+  $cardsByKey = @{}
+  foreach ($card in $allCards) {
+    $pairKey = Get-ReviewPairSelectionKey `
+      -TargetId ([string]$card.targetId) `
+      -ComparisonIndex ([int](Get-ProjectionNestedValue -Object $card -Path @('comparison', 'index') -Default 0))
+    $cardsByKey[$pairKey] = $card
+  }
+
+  $selectedCards = New-Object System.Collections.Generic.List[object]
+  $seenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $missingKeys = New-Object System.Collections.Generic.List[string]
+  foreach ($selectedPreviewPair in @(ConvertTo-ProjectionObjectArray -Value $SelectedPreviewPairs)) {
+    $pairKey = Get-ReviewPairSelectionKey `
+      -TargetId ([string]$selectedPreviewPair.targetId) `
+      -ComparisonIndex ([int](Get-ProjectionNestedValue -Object $selectedPreviewPair -Path @('comparison', 'index') -Default 0))
+    if (-not $seenKeys.Add($pairKey)) {
+      continue
+    }
+
+    if (-not $cardsByKey.ContainsKey($pairKey)) {
+      $missingKeys.Add($pairKey) | Out-Null
+      continue
+    }
+
+    $selectedCards.Add($cardsByKey[$pairKey]) | Out-Null
+  }
+
+  if ($missingKeys.Count -gt 0) {
+    throw ('review-bundle selection was missing review pairs for: {0}' -f ($missingKeys -join ', '))
+  }
+
+  return @($selectedCards | ForEach-Object { $_ })
+}
+
+Export-ModuleMember -Function Get-CompareVIHistoryReviewBundleCards

--- a/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
+++ b/scripts/Publish-CompareVIHistoryPullRequestComment.ps1
@@ -17,6 +17,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot 'CompareVIHistoryReviewBundleProjection.psm1') -Force
+
 function Write-ActionOutput {
   param(
     [Parameter(Mandatory = $true)]
@@ -1294,16 +1296,15 @@ function Publish-CommentPreviewSurface {
     [Parameter(Mandatory = $true)]
     [string]$ArtifactRoot,
     [Parameter(Mandatory = $true)]
-    [object]$PreviewManifest
+    [object]$PreviewManifest,
+    [AllowEmptyCollection()]
+    [object[]]$ReviewCards = @()
   )
 
   Ensure-PreviewBranch -RepositorySlug $RepositorySlug -BranchName $BranchName | Out-Null
 
   $prNumber = [int](Get-OptionalString -Value (Get-NestedValue -Object $PreviewManifest -Path @('pullRequest', 'number') -Default 0))
-  $previewCards = @(New-ReviewerPreviewCards `
-      -SelectedPreviewPairs @($PreviewManifest.commentPreviewPairs | ForEach-Object { $_ }) `
-      -AllPreviewPairs @($PreviewManifest.previewPairs | ForEach-Object { $_ }) `
-      -ExistingCards @($PreviewManifest.commentPreviewCards | ForEach-Object { $_ }))
+  $previewCards = @($ReviewCards | ForEach-Object { $_ })
   if ($previewCards.Count -eq 0) {
     return [ordered]@{
       status = 'not-required'
@@ -1580,7 +1581,27 @@ try {
 
       $previewManifest | Add-Member -NotePropertyName pullRequest -NotePropertyValue $prRun.pullRequest -Force
       if ([int](Get-NestedValue -Object $previewManifest -Path @('summary', 'commentPreviewPairCount') -Default 0) -gt 0) {
-        $previewPublication = Publish-CommentPreviewSurface -RepositorySlug $Repository -BranchName $PreviewBranch -RootPath $PreviewRoot -ExecutionRunId $WorkflowRunId -ArtifactRoot $artifactRoot -PreviewManifest $previewManifest
+        $reviewBundleFile = Get-ChildItem -LiteralPath $artifactRoot -Recurse -Filter 'review-bundle.json' | Select-Object -First 1
+        if (-not $reviewBundleFile) {
+          throw 'Downloaded artifact did not contain review-bundle.json.'
+        }
+        $reviewBundle = Read-JsonFile -Path $reviewBundleFile.FullName
+        if ([string]$reviewBundle.schema -ne 'comparevi-history/review-bundle@v1') {
+          throw "Unsupported review bundle schema in '$($reviewBundleFile.FullName)': $($reviewBundle.schema)"
+        }
+
+        $commentPreviewCards = @(Get-CompareVIHistoryReviewBundleCards `
+            -ReviewBundle $reviewBundle `
+            -SelectedPreviewPairs @($previewManifest.commentPreviewPairs | ForEach-Object { $_ }) `
+            -UseSelectedPreviewPairs)
+        $previewPublication = Publish-CommentPreviewSurface `
+          -RepositorySlug $Repository `
+          -BranchName $PreviewBranch `
+          -RootPath $PreviewRoot `
+          -ExecutionRunId $WorkflowRunId `
+          -ArtifactRoot $artifactRoot `
+          -PreviewManifest $previewManifest `
+          -ReviewCards $commentPreviewCards
         $previewMarkdown = New-CommentPreviewMarkdown -PreviewCards @($previewPublication.commentPreviewCards | ForEach-Object { $_ }) -RunUrl $workflowRunUrl
         $commentBody = Insert-PreviewGallery -CommentBody $commentBody -PreviewMarkdown $previewMarkdown
         $commentBody | Set-Content -LiteralPath $commentBodyPath -Encoding utf8

--- a/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
+++ b/scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
@@ -185,6 +185,131 @@ function New-PreviewCard {
   }
 }
 
+function Convert-PreviewCardToReviewPair {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$PreviewCard
+  )
+
+  $surfaces = @(
+    $PreviewCard.surfaces |
+      ForEach-Object {
+        [ordered]@{
+          surfaceKind = [string]$_.surfaceKind
+          surfaceLabel = [string]$_.surfaceLabel
+          mode = [string]$_.surfaceKind
+          label = [string]$_.surfaceLabel
+          primaryReviewerRelativePath = [string]$_.reportHtmlRelativePath
+          debugReportHtmlRelativePath = ('debug/' + ([string]$_.surfaceKind) + '.html')
+          baseImageRelativePath = [string]$_.baseImageRelativePath
+          headImageRelativePath = [string]$_.headImageRelativePath
+          baseByteLength = 4
+          headByteLength = 4
+          baseImageSha256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          headImageSha256 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+          sortKey = ('Tooling/demo/Demo.vi|{0}|{1}' -f [int]$PreviewCard.comparison.index, [string]$_.surfaceKind)
+        }
+      }
+  )
+
+  $reviewerSummary = $null
+  if ($null -ne $PreviewCard.reviewerSummary) {
+    $reviewerSummary = [ordered]@{
+      label = [string]$PreviewCard.reviewerSummary.label
+      overallSeverity = [string]$PreviewCard.reviewerSummary.overallSeverity
+      headline = [string]$PreviewCard.reviewerSummary.headline
+      signalCount = [int]$PreviewCard.reviewerSummary.signalCount
+      omittedSignalCount = [int]$PreviewCard.reviewerSummary.omittedSignalCount
+      signals = @(
+        $PreviewCard.reviewerSummary.signals |
+          ForEach-Object {
+            [ordered]@{
+              signalKey = [string]$_.signalKey
+              label = [string]$_.label
+              severity = [string]$_.severity
+              detailCount = [int]$_.detailCount
+              sectionCount = [int]$_.sectionCount
+              summary = [string]$_.summary
+              primaryReviewerRelativePath = [string]$_.primaryReportHtmlRelativePath
+              primaryDebugReportHtmlRelativePath = ('debug/summary-' + [string]$_.signalKey + '.html')
+              sectionLinks = @(
+                $_.sectionLinks |
+                  ForEach-Object {
+                    [ordered]@{
+                      sectionOrdinal = [int]$_.sectionOrdinal
+                      label = [string]$_.label
+                      reviewerRelativePath = [string]$_.reportHtmlRelativePath
+                      debugReportHtmlRelativePath = ('debug/section-' + [int]$_.sectionOrdinal + '.html')
+                    }
+                  }
+              )
+            }
+          }
+      )
+    }
+  }
+
+  $changeDetails = $null
+  if ($null -ne $PreviewCard.changeDetails) {
+    $changeDetails = [ordered]@{
+      label = [string]$PreviewCard.changeDetails.label
+      sourceMode = [string]$PreviewCard.changeDetails.sourceMode
+      primaryReviewerRelativePath = [string]$PreviewCard.changeDetails.reportHtmlRelativePath
+      debugReportHtmlRelativePath = 'debug/change-details.html'
+      includedCategories = @($PreviewCard.changeDetails.includedCategories | ForEach-Object { [string]$_ })
+      groupCount = [int]$PreviewCard.changeDetails.groupCount
+      omittedGroupCount = [int]$PreviewCard.changeDetails.omittedGroupCount
+      sectionCount = [int]$PreviewCard.changeDetails.sectionCount
+      detailCount = [int]$PreviewCard.changeDetails.detailCount
+      groups = @(
+        $PreviewCard.changeDetails.groups |
+          ForEach-Object {
+            [ordered]@{
+              heading = [string]$_.heading
+              sectionCount = [int]$_.sectionCount
+              detailCount = [int]$_.detailCount
+              sampleDetails = @($_.sampleDetails | ForEach-Object { [string]$_ })
+              omittedDetailCount = [int]$_.omittedDetailCount
+              primaryReviewerRelativePath = [string]$_.primaryReportHtmlRelativePath
+              primaryDebugReportHtmlRelativePath = ('debug/group-' + ([string]$_.heading -replace '[^a-z0-9]+', '-').Trim('-') + '.html')
+              sectionLinks = @(
+                $_.sectionLinks |
+                  ForEach-Object {
+                    [ordered]@{
+                      sectionOrdinal = [int]$_.sectionOrdinal
+                      label = [string]$_.label
+                      reviewerRelativePath = [string]$_.reportHtmlRelativePath
+                      debugReportHtmlRelativePath = ('debug/section-' + [int]$_.sectionOrdinal + '.html')
+                    }
+                  }
+              )
+            }
+          }
+      )
+    }
+  }
+
+  return [ordered]@{
+    reviewPairKey = ('dynamic-demo-target|{0}' -f [int]$PreviewCard.comparison.index)
+    targetId = 'dynamic-demo-target'
+    targetPath = 'Tooling/demo/Demo.vi'
+    comparison = $PreviewCard.comparison
+    sortKey = ('Tooling/demo/Demo.vi|{0:D4}' -f [int]$PreviewCard.comparison.index)
+    primaryReviewerDestination = @{
+      kind = 'history-pair-review-page'
+      relativePath = $null
+    }
+    debugDestinations = @{
+      frontPanelReportHtmlRelativePath = 'debug/front-panel.html'
+      blockDiagramReportHtmlRelativePath = 'debug/block-diagram.html'
+      changeDetailsReportHtmlRelativePath = 'debug/change-details.html'
+    }
+    surfaces = $surfaces
+    reviewerSummary = $reviewerSummary
+    changeDetails = $changeDetails
+  }
+}
+
 function New-PublicationArtifactZip {
   param(
     [Parameter(Mandatory = $true)]
@@ -212,6 +337,19 @@ function New-PublicationArtifactZip {
     (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 1),
     (New-PreviewCard -PreviewPairs $previewPairs -ComparisonIndex 2)
   )
+  $reviewBundle = [ordered]@{
+    schema = 'comparevi-history/review-bundle@v1'
+    reviewPairs = @(
+      $commentPreviewCards |
+        ForEach-Object { Convert-PreviewCardToReviewPair -PreviewCard $_ }
+    )
+  }
+  $stalePreviewCards = @(
+    ($commentPreviewCards | ConvertTo-Json -Depth 64 | ConvertFrom-Json -Depth 64) |
+      ForEach-Object { $_ }
+  )
+  $stalePreviewCards[0].reviewerSummary.headline = 'STALE manifest headline'
+  $stalePreviewCards[0].surfaces[0].surfaceLabel = 'STALE manifest surface'
 
   ([ordered]@{
       schema = 'comparevi-history/pr-run@v2'
@@ -300,6 +438,7 @@ function New-PublicationArtifactZip {
       targets = @()
     } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-run.json') -Encoding utf8
   $CommentBody | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-comment.md') -Encoding utf8
+  ($reviewBundle | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'review-bundle.json') -Encoding utf8
 
   if ($IncludePreviewManifest.IsPresent) {
     foreach ($previewPair in $previewPairs) {
@@ -350,9 +489,9 @@ function New-PublicationArtifactZip {
         previewPairs = $previewPairs
         commentPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
         indexPreviewPairs = @($previewPairs | Where-Object { [int]$_.comparison.index -in @(1, 2) -and [string]$_.mode -eq 'front-panel' })
-        reviewerPreviewCards = $commentPreviewCards
-        commentPreviewCards = $commentPreviewCards
-        indexPreviewCards = $commentPreviewCards
+        reviewerPreviewCards = $stalePreviewCards
+        commentPreviewCards = $stalePreviewCards
+        indexPreviewCards = $stalePreviewCards
       } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath (Join-Path $artifactRoot 'pr-preview-manifest.json') -Encoding utf8
   }
 
@@ -618,6 +757,10 @@ The full unsuppressed history suite lives in the uploaded artifact bundle. Use t
     [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].debugPrimaryReportUrl -ne 'https://github.com/LabVIEW-Community-CI-CD/labview-icon-editor-demo/blob/comparevi-history-pr-previews/.comparevi-history/pr-diagnostics/previews/pull-request-00055/workflow-run-321/001-history-pair-01/change-details.md#comparevi-change-001-block-diagram-objects' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.signals[0].primaryReportUrl -ne ($pair1Url + '#comparevi-change-001-block-diagram-objects')) {
     throw 'Preview publication should route reviewer-summary links to the pair page and preserve debug evidence links.'
+  }
+  if ([string]$createReceipt.previewPublication.commentPreviewCards[0].reviewerSummary.headline -eq 'STALE manifest headline' -or
+    [string]$createReceipt.previewPublication.commentPreviewCards[0].surfaces[0].surfaceLabel -eq 'STALE manifest surface') {
+    throw 'Preview publication should rebuild comment cards from review-bundle.json instead of trusting stale manifest cards.'
   }
   if ([string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.label -ne 'Change details' -or
     [string]$createReceipt.previewPublication.commentPreviewCards[0].changeDetails.groups[0].heading -ne 'Block diagram moves' -or

--- a/scripts/Test-CompareVIHistoryReviewBundleProjection.ps1
+++ b/scripts/Test-CompareVIHistoryReviewBundleProjection.ps1
@@ -1,0 +1,143 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot 'CompareVIHistoryReviewBundleProjection.psm1') -Force
+
+$reviewBundle = [ordered]@{
+  schema = 'comparevi-history/review-bundle@v1'
+  reviewPairs = @(
+    [ordered]@{
+      targetId = 'target-a'
+      targetPath = 'Tooling/demo/A.vi'
+      comparison = [ordered]@{
+        index = 1
+        baseRef = 'base-1'
+        headRef = 'head-1'
+      }
+      sortKey = 'Tooling/demo/A.vi|0001'
+      surfaces = @(
+        [ordered]@{
+          surfaceKind = 'front-panel'
+          surfaceLabel = 'Front panel'
+          primaryReviewerRelativePath = 'history-pairs/001/index.html#front-panel'
+          debugReportHtmlRelativePath = 'targets/a/front-panel.html'
+          baseImageRelativePath = 'targets/a/fp-base.png'
+          headImageRelativePath = 'targets/a/fp-head.png'
+          baseByteLength = 4
+          headByteLength = 4
+          baseImageSha256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          headImageSha256 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+          sortKey = 'a|front-panel'
+        }
+      )
+      reviewerSummary = [ordered]@{
+        label = 'Reviewer summary'
+        overallSeverity = 'medium'
+        headline = 'Bundle headline 1'
+        signalCount = 1
+        omittedSignalCount = 0
+        signals = @(
+          [ordered]@{
+            signalKey = 'signal-1'
+            label = 'Signal 1'
+            severity = 'medium'
+            detailCount = 1
+            sectionCount = 1
+            summary = 'Signal 1 summary'
+            primaryReviewerRelativePath = 'history-pairs/001/index.html#signal-1'
+            primaryDebugReportHtmlRelativePath = 'targets/a/debug-signal-1.html'
+            sectionLinks = @()
+          }
+        )
+      }
+      changeDetails = [ordered]@{
+        label = 'Change details'
+        sourceMode = 'attributes'
+        primaryReviewerRelativePath = 'history-pairs/001/index.html#change-details'
+        debugReportHtmlRelativePath = 'targets/a/change-details.html'
+        includedCategories = @('VI Attribute')
+        groupCount = 1
+        omittedGroupCount = 0
+        sectionCount = 1
+        detailCount = 1
+        groups = @()
+      }
+    },
+    [ordered]@{
+      targetId = 'target-a'
+      targetPath = 'Tooling/demo/A.vi'
+      comparison = [ordered]@{
+        index = 2
+        baseRef = 'base-2'
+        headRef = 'head-2'
+      }
+      sortKey = 'Tooling/demo/A.vi|0002'
+      surfaces = @(
+        [ordered]@{
+          surfaceKind = 'front-panel'
+          surfaceLabel = 'Front panel'
+          primaryReviewerRelativePath = 'history-pairs/002/index.html#front-panel'
+          debugReportHtmlRelativePath = 'targets/a/front-panel-2.html'
+          baseImageRelativePath = 'targets/a/fp2-base.png'
+          headImageRelativePath = 'targets/a/fp2-head.png'
+          baseByteLength = 4
+          headByteLength = 4
+          baseImageSha256 = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+          headImageSha256 = 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+          sortKey = 'b|front-panel'
+        }
+      )
+      reviewerSummary = [ordered]@{
+        label = 'Reviewer summary'
+        overallSeverity = 'low'
+        headline = 'Bundle headline 2'
+        signalCount = 1
+        omittedSignalCount = 0
+        signals = @()
+      }
+      changeDetails = $null
+    }
+  )
+}
+
+$allCards = @(Get-CompareVIHistoryReviewBundleCards -ReviewBundle $reviewBundle)
+if ($allCards.Count -ne 2 -or
+  [string]$allCards[0].reviewerSummary.headline -ne 'Bundle headline 1' -or
+  [string]$allCards[1].reviewerSummary.headline -ne 'Bundle headline 2') {
+  throw 'Expected review-bundle projection to return ordered review cards from the compiled bundle.'
+}
+
+$selectedPairs = @(
+  [ordered]@{
+    targetId = 'target-a'
+    comparison = [ordered]@{
+      index = 2
+    }
+  }
+)
+$selectedCards = @(Get-CompareVIHistoryReviewBundleCards -ReviewBundle $reviewBundle -SelectedPreviewPairs $selectedPairs -UseSelectedPreviewPairs)
+if ($selectedCards.Count -ne 1 -or
+  [int]$selectedCards[0].comparison.index -ne 2 -or
+  [string]$selectedCards[0].surfaces[0].reportHtmlRelativePath -ne 'history-pairs/002/index.html#front-panel') {
+  throw 'Expected selection-driven projection to resolve review cards from review-bundle identities.'
+}
+
+$missingThrew = $false
+try {
+  [void](Get-CompareVIHistoryReviewBundleCards -ReviewBundle $reviewBundle -SelectedPreviewPairs @(
+        [ordered]@{
+          targetId = 'missing-target'
+          comparison = [ordered]@{ index = 9 }
+        }
+      ) -UseSelectedPreviewPairs)
+} catch {
+  if ([string]$_.Exception.Message -match 'missing review pairs') {
+    $missingThrew = $true
+  } else {
+    throw
+  }
+}
+
+if (-not $missingThrew) {
+  throw 'Expected missing selected review pairs to fail closed.'
+}

--- a/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
+++ b/scripts/Write-CompareVIHistoryAutomaticPullRequestRun.ps1
@@ -13,6 +13,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot 'CompareVIHistoryReviewBundleProjection.psm1') -Force
+
 $stickyMarker = '<!-- comparevi-history:pull-request-diagnostics -->'
 
 function Write-ActionOutput {
@@ -1847,6 +1849,7 @@ $totalProcessed = 0
 $totalDiffs = 0
 $previewManifest = $null
 $previewManifestPathResolved = $null
+$reviewBundle = $null
 $rawPreviewPairCount = 0
 $reviewerPreviewPairCount = 0
 $commentPreviewPairCount = 0
@@ -1882,6 +1885,14 @@ if ($null -ne $targetManifest) {
   if ([string]$previewManifest.schema -ne 'comparevi-history/pr-preview-manifest@v1') {
     throw "Unsupported preview manifest schema in '$previewManifestPathResolved': $($previewManifest.schema)"
   }
+  $reviewBundlePathResolved = Join-Path $resultsDirResolved 'review-bundle.json'
+  if (-not (Test-Path -LiteralPath $reviewBundlePathResolved -PathType Leaf)) {
+    throw "Compiled review bundle was missing from '$resultsDirResolved'."
+  }
+  $reviewBundle = Read-JsonFile -Path $reviewBundlePathResolved
+  if ([string]$reviewBundle.schema -ne 'comparevi-history/review-bundle@v1') {
+    throw "Unsupported review bundle schema in '$reviewBundlePathResolved': $($reviewBundle.schema)"
+  }
   $rawPreviewPairCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'rawPreviewPairCount') -Default $previewManifest.summary.previewPairCount)
   $reviewerPreviewPairCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'reviewerPreviewPairCount') -Default $previewManifest.summary.previewPairCount)
   $commentPreviewPairCap = [int]$previewManifest.summary.commentPreviewPairCap
@@ -1892,14 +1903,14 @@ if ($null -ne $targetManifest) {
   $indexPreviewPairCount = [int]$previewManifest.summary.indexPreviewPairCount
   $indexPreviewPairOmittedCount = [int]$previewManifest.summary.indexPreviewPairOmittedCount
   $indexPreviewCardCount = [int](Get-NestedValue -Object $previewManifest -Path @('summary', 'indexPreviewCardCount') -Default 0)
-  $indexPreviewCards = @(New-ReviewerPreviewCards `
+  $indexPreviewCards = @(Get-CompareVIHistoryReviewBundleCards `
+      -ReviewBundle $reviewBundle `
       -SelectedPreviewPairs @($previewManifest.indexPreviewPairs | ForEach-Object { $_ }) `
-      -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
-      -ExistingCards @($previewManifest.indexPreviewCards | ForEach-Object { $_ }))
-  $commentPreviewCards = @(New-ReviewerPreviewCards `
+      -UseSelectedPreviewPairs)
+  $commentPreviewCards = @(Get-CompareVIHistoryReviewBundleCards `
+      -ReviewBundle $reviewBundle `
       -SelectedPreviewPairs @($previewManifest.commentPreviewPairs | ForEach-Object { $_ }) `
-      -AllPreviewPairs @($previewManifest.previewPairs | ForEach-Object { $_ }) `
-      -ExistingCards @($previewManifest.commentPreviewCards | ForEach-Object { $_ }))
+      -UseSelectedPreviewPairs)
   $indexPreviewCards = @(New-WorkspacePrimaryPreviewCards -PreviewCards $indexPreviewCards)
   $commentPreviewCards = @(New-WorkspacePrimaryPreviewCards -PreviewCards $commentPreviewCards)
   Write-WorkspacePairPages -PreviewCards $indexPreviewCards -Targets $targets -ResultsRoot $resultsDirResolved


### PR DESCRIPTION
## Summary
- route automatic PR workspace rendering through the compiled review bundle
- route PR comment publication through the compiled review bundle instead of trusting preview-manifest cards
- add shared bundle-projection coverage and a poisoned-manifest publication regression for #162

## Testing
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryReviewBundleProjection.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestPreviewManifest.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPullRequestCommentPublication.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAgentCanaryEvaluation.ps1
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1
- git diff --check
