### PR TITLE
#181 Wire local review onto operator-session facade

### DIFF
--- a/docs/schemas/comparevi-history-local-review-v1.schema.json
+++ b/docs/schemas/comparevi-history-local-review-v1.schema.json
@@ -10,6 +10,7 @@
     "consumer",
     "invocation",
     "runtime",
+    "operatorSession",
     "timings",
     "compiler",
     "projections",
@@ -115,6 +116,42 @@
         "cacheReuseState": { "type": ["string", "null"] },
         "coldWarmClass": { "type": ["string", "null"] },
         "warmRuntimeDir": { "type": ["string", "null"] }
+      }
+    },
+    "operatorSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "facadeSchema",
+        "toolingRoot",
+        "toolingSource",
+        "toolingRef",
+        "sessionPaths",
+        "localRefinementReceiptPaths",
+        "benchmarkPaths",
+        "reviewReceiptPaths"
+      ],
+      "properties": {
+        "facadeSchema": { "type": ["string", "null"] },
+        "toolingRoot": { "type": ["string", "null"] },
+        "toolingSource": { "type": ["string", "null"] },
+        "toolingRef": { "type": ["string", "null"] },
+        "sessionPaths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "localRefinementReceiptPaths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "benchmarkPaths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "reviewReceiptPaths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       }
     },
     "timings": {

--- a/scripts/Invoke-CompareVIHistoryLocalReview.ps1
+++ b/scripts/Invoke-CompareVIHistoryLocalReview.ps1
@@ -155,6 +155,43 @@ function Get-OptionalPropertyValue {
   return $property.Value
 }
 
+function Get-NestedValue {
+  param(
+    [AllowNull()]$Object,
+    [Parameter(Mandatory = $true)][string[]]$Path,
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
 function Invoke-GitCapture {
   param(
     [Parameter(Mandatory = $true)]
@@ -566,6 +603,109 @@ function Resolve-PublishedCompiler {
   }
 }
 
+function Resolve-ToolingMetadata {
+  param([Parameter(Mandatory = $true)][string]$ToolingRootPath)
+
+  $metadataPath = Join-Path $ToolingRootPath 'comparevi-tools-release.json'
+  if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+    return $null
+  }
+
+  return Read-JsonFile -Path $metadataPath
+}
+
+function Resolve-CompareVIToolsModulePath {
+  param([Parameter(Mandatory = $true)][string]$ToolingRootPath)
+
+  $modulePath = Join-Path $ToolingRootPath 'tools' 'CompareVI.Tools' 'CompareVI.Tools.psd1'
+  if (-not (Test-Path -LiteralPath $modulePath -PathType Leaf)) {
+    throw "CompareVI.Tools module manifest was not found under the resolved tooling root: $modulePath"
+  }
+
+  return $modulePath
+}
+
+function Resolve-CompareVITooling {
+  param(
+    [AllowNull()]
+    [string]$ProvidedToolingRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+    [AllowNull()]
+    [string]$RequestedRef,
+    [Parameter(Mandatory = $true)]
+    [string]$DefaultRefPath,
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationPath,
+    [AllowNull()]
+    [string]$Token
+  )
+
+  $toolingRootResolved = $null
+  $toolingSource = $null
+  $effectiveCompareviRef = $null
+  $hostedRunnerDefaultImage = $null
+
+  if (-not [string]::IsNullOrWhiteSpace($ProvidedToolingRoot)) {
+    $toolingRootResolved = Resolve-AbsolutePath -Path $ProvidedToolingRoot -BasePath (Get-Location).Path
+    if (-not (Test-Path -LiteralPath $toolingRootResolved -PathType Container)) {
+      throw "Tooling root not found: $toolingRootResolved"
+    }
+    $toolingSource = 'provided-tooling-root'
+    $effectiveCompareviRef = if ([string]::IsNullOrWhiteSpace($RequestedRef)) { 'provided-tooling-root' } else { $RequestedRef.Trim() }
+  } else {
+    $resolveOutputPath = Join-Path $DestinationPath 'resolve-backend.out'
+    & (Join-Path $repoRoot 'scripts' 'Resolve-CompareVIHistoryBackend.ps1') `
+      -Repository $Repository `
+      -RequestedRef $RequestedRef `
+      -DefaultRefPath $DefaultRefPath `
+      -ActionRef 'local-review' `
+      -ToolingPath (Join-Path $DestinationPath '.comparevi-history-tools') `
+      -AllowSourceFallback `
+      -GitHubToken $Token `
+      -GitHubOutputPath $resolveOutputPath | Out-Null
+
+    $backendValues = Read-KeyValueFile -Path $resolveOutputPath
+    $toolingSource = [string]$backendValues['tooling-source']
+    $effectiveCompareviRef = [string]$backendValues['comparevi-ref']
+    if ([string]::IsNullOrWhiteSpace($toolingSource)) {
+      throw 'Failed to resolve CompareVI.Tools backend tooling for local review.'
+    }
+
+    if ($toolingSource -eq 'bundle') {
+      $acquireOutputPath = Join-Path $DestinationPath 'acquire-backend.out'
+      & (Join-Path $repoRoot 'scripts' 'Acquire-CompareVIToolsBundle.ps1') `
+        -Repository $Repository `
+        -ReleaseTag ([string]$backendValues['release-tag']) `
+        -BundleAssetName ([string]$backendValues['bundle-asset-name']) `
+        -BundleAssetUrl ([string]$backendValues['bundle-asset-url']) `
+        -BundleAssetDigest ([string]$backendValues['bundle-asset-digest']) `
+        -DestinationPath ([string]$backendValues['tooling-path']) `
+        -GitHubToken $Token `
+        -GitHubOutputPath $acquireOutputPath | Out-Null
+
+      $acquireValues = Read-KeyValueFile -Path $acquireOutputPath
+      $toolingRootResolved = Resolve-AbsolutePath -Path ([string]$acquireValues['tooling-path']) -BasePath (Get-Location).Path
+      $hostedRunnerDefaultImage = Get-OptionalString -Value $acquireValues['hosted-runner-default-image']
+    } else {
+      throw 'Local review requires a released CompareVI.Tools bundle by default. Supply -ToolingRoot explicitly for unreleased backend work.'
+    }
+  }
+
+  $metadata = Resolve-ToolingMetadata -ToolingRootPath $toolingRootResolved
+  if ([string]::IsNullOrWhiteSpace($hostedRunnerDefaultImage) -and $null -ne $metadata) {
+    $hostedRunnerDefaultImage = Get-OptionalString -Value (Get-NestedValue -Object $metadata -Path @('consumerContract', 'hostedNiLinuxRunner', 'defaultImage'))
+  }
+
+  return [ordered]@{
+    root = $toolingRootResolved
+    source = $toolingSource
+    compareviRef = $effectiveCompareviRef
+    hostedRunnerDefaultImage = $hostedRunnerDefaultImage
+    modulePath = Resolve-CompareVIToolsModulePath -ToolingRootPath $toolingRootResolved
+  }
+}
+
 function Resolve-ExplicitChanges {
   param(
     [Parameter(Mandatory = $true)]
@@ -862,93 +1002,120 @@ $compilerInfo = if ($null -ne $resolvedCompilerExecutable) {
 
 $targetManifestPath = $null
 $manifestTargets = New-Object System.Collections.Generic.List[object]
-$runtimeReceipts = New-Object System.Collections.Generic.List[object]
-$effectiveToolingRoot = if ([string]::IsNullOrWhiteSpace($ToolingRoot)) { $null } else { (Resolve-AbsolutePath -Path $ToolingRoot -BasePath (Get-Location).Path) }
-$invocationScriptPath = if ([string]::IsNullOrWhiteSpace($InvokeScriptPath)) { $null } else { (Resolve-AbsolutePath -Path $InvokeScriptPath -BasePath $consumerRootResolved) }
+$operatorSessionReceipts = New-Object System.Collections.Generic.List[object]
+$compareVITooling = $null
+$effectiveCompareviRef = $null
+$toolingSource = $null
+$localReviewHookPath = Join-Path $repoRoot 'scripts' 'Invoke-CompareVIHistoryLocalReviewHook.ps1'
 
 if ($discoveryStatus -eq 'ready') {
+  $compareVITooling = Resolve-CompareVITooling `
+    -ProvidedToolingRoot $ToolingRoot `
+    -Repository $CompareviRepository `
+    -RequestedRef $CompareviRef `
+    -DefaultRefPath (Join-Path $repoRoot 'comparevi-backend-ref.txt') `
+    -DestinationPath $resultsDirResolved `
+    -Token $resolvedGitHubToken
+  $effectiveCompareviRef = [string]$compareVITooling.compareviRef
+  $toolingSource = [string]$compareVITooling.source
+
+  foreach ($loadedModule in @(Get-Module -Name 'CompareVI.Tools' -All)) {
+    Remove-Module -ModuleInfo $loadedModule -Force -ErrorAction SilentlyContinue
+  }
+  Import-Module -Name ([string]$compareVITooling.modulePath) -Force | Out-Null
+
   $targetOrdinal = 0
   foreach ($selectedTarget in @($selectedTargets | ForEach-Object { $_ })) {
     $targetOrdinal += 1
     $targetResultsDir = Join-Path $resultsDirResolved ('targets/{0:D3}-{1}' -f $targetOrdinal, [string]$selectedTarget.targetId)
-    $localFastLoopPath = Join-Path $targetResultsDir 'local-fast-loop.json'
-    $localFastLoopReceipt = $null
+    $operatorSessionPath = Join-Path $targetResultsDir 'local-operator-session.json'
+    $reviewProjectionReceiptPath = Join-Path $targetResultsDir 'local-target-review.json'
+    $operatorSessionReceipt = $null
+    $reviewProjectionReceipt = $null
     $caughtException = $null
     try {
-      $fastLoopArgs = @{
-        ConsumerRepositoryRoot = $consumerRootResolved
-        ViPath = [string]$selectedTarget.targetPath
-        RuntimeProfile = $Profile
-        ConsumerRef = $headSha
-        SourceBranchRef = $sourceBranchRef
-        ConsumerRepository = $consumerRepositorySlug
-        ResultsDir = $targetResultsDir
-        Mode = ($requestedModes -join ',')
-        NoisePolicy = $NoisePolicy
-        IncludeMergeParents = $IncludeMergeParents.IsPresent
-        CompareviRepository = $CompareviRepository
-        GitHubToken = $resolvedGitHubToken
+      $reviewCommandArguments = New-Object System.Collections.Generic.List[string]
+      foreach ($argument in @(
+          $consumerRootResolved,
+          [string]$selectedTarget.targetId,
+          [string]$selectedTarget.targetPath,
+          $(if ([string]::IsNullOrWhiteSpace($sourceBranchRef)) { '' } else { $sourceBranchRef }),
+          $consumerRepositorySlug,
+          $headSha,
+          ([string]::Join(',', @($selectedTarget.requestedModes | ForEach-Object { [string]$_ }))),
+          [string]$selectedTarget.requestedModeSource,
+          [string]$selectedTarget.targetSource,
+          [string]$selectedTarget.currentPath,
+          $(if ([string]::IsNullOrWhiteSpace([string]$selectedTarget.previousPath)) { '' } else { [string]$selectedTarget.previousPath }),
+          [string]$selectedTarget.changeStatus,
+          ([string][bool]$selectedTarget.keepArtifactsOnNoDiff)
+        )) {
+        $reviewCommandArguments.Add([string]$argument) | Out-Null
       }
-      if ($null -ne $CompareTimeoutSeconds) {
-        $fastLoopArgs.CompareTimeoutSeconds = [int]$CompareTimeoutSeconds
+
+      $operatorSessionArgs = @{
+        Profile = $Profile
+        RepoRoot = $consumerRootResolved
+        ResultsRoot = $targetResultsDir
+        HistoryTargetPath = [string]$selectedTarget.targetPath
+        HistoryBranchRef = $headSha
+        HistoryBaselineRef = $sourceBranchRef
+        ReviewCommandPath = $localReviewHookPath
+        ReviewCommandArguments = @($reviewCommandArguments | ForEach-Object { $_ })
+        ReviewWorkingDirectory = $repoRoot
+        ReviewReceiptPath = $reviewProjectionReceiptPath
+        SessionManifestPath = $operatorSessionPath
       }
       if (-not [string]::IsNullOrWhiteSpace($WarmRuntimeDir)) {
-        $fastLoopArgs.WarmRuntimeDir = $WarmRuntimeDir
+        $operatorSessionArgs.WarmRuntimeDir = $WarmRuntimeDir
       }
-      if ($null -ne $effectiveToolingRoot) {
-        $fastLoopArgs.ToolingRoot = $effectiveToolingRoot
-      }
-      if (-not [string]::IsNullOrWhiteSpace($CompareviRef)) {
-        $fastLoopArgs.CompareviRef = $CompareviRef
+      $selectedTargetMaxCommitCount = Get-NestedValue -Object $selectedTarget -Path @('history', 'branchBudget', 'maxCommitCount')
+      if ($null -ne $selectedTargetMaxCommitCount) {
+        $operatorSessionArgs.HistoryMaxCommitCount = [int]$selectedTargetMaxCommitCount
       }
       if (-not [string]::IsNullOrWhiteSpace($ContainerImage)) {
-        $fastLoopArgs.ContainerImage = $ContainerImage
-      }
-      if ($targetOrdinal -gt 1 -or $SkipImagePull.IsPresent) {
-        $fastLoopArgs.SkipImagePull = $true
+        if ($Profile -eq 'proof') {
+          $operatorSessionArgs.ProofImage = $ContainerImage.Trim()
+        } else {
+          $operatorSessionArgs.DevImage = $ContainerImage.Trim()
+        }
+      } elseif ($Profile -eq 'proof' -and -not [string]::IsNullOrWhiteSpace([string]$compareVITooling.hostedRunnerDefaultImage)) {
+        $operatorSessionArgs.ProofImage = [string]$compareVITooling.hostedRunnerDefaultImage
       }
       if ($SkipDevImageBuild.IsPresent) {
-        $fastLoopArgs.SkipDevImageBuild = $true
-      }
-      if (-not [string]::IsNullOrWhiteSpace($invocationScriptPath)) {
-        $fastLoopArgs.InvokeScriptPath = $invocationScriptPath
+        $operatorSessionArgs.SkipDevImageBuild = $true
       }
 
-      & (Join-Path $repoRoot 'scripts' 'Invoke-CompareVIHistoryManualExplorationFastLoop.ps1') @fastLoopArgs | Out-Null
-      if (-not (Test-Path -LiteralPath $localFastLoopPath -PathType Leaf)) {
-        throw "Local fast-loop receipt was not written: $localFastLoopPath"
-      }
-      $localFastLoopReceipt = Read-JsonFile -Path $localFastLoopPath
+      $operatorSessionReceipt = Invoke-CompareVIHistoryLocalOperatorSessionFacade @operatorSessionArgs
     } catch {
       $caughtException = $_
-      if (Test-Path -LiteralPath $localFastLoopPath -PathType Leaf) {
-        $localFastLoopReceipt = Read-JsonFile -Path $localFastLoopPath
+      if (Test-Path -LiteralPath $operatorSessionPath -PathType Leaf) {
+        $operatorSessionReceipt = Read-JsonFile -Path $operatorSessionPath
       }
     }
 
-    if ($null -ne $localFastLoopReceipt -and -not [string]::IsNullOrWhiteSpace([string]$localFastLoopReceipt.tooling.root)) {
-      $effectiveToolingRoot = [string]$localFastLoopReceipt.tooling.root
-    }
-    if ($null -ne $localFastLoopReceipt) {
-      $runtimeReceipts.Add($localFastLoopReceipt) | Out-Null
+    if ($null -ne $operatorSessionReceipt) {
+      $operatorSessionReceipts.Add($operatorSessionReceipt) | Out-Null
     }
 
-    $publicRunReceipt = $null
-    $publicRunPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.publicRunPath })
-    if (-not [string]::IsNullOrWhiteSpace($publicRunPath) -and (Test-Path -LiteralPath $publicRunPath -PathType Leaf)) {
-      $publicRunReceipt = Read-JsonFile -Path $publicRunPath
+    $resolvedReviewReceiptPath = Get-OptionalString -Value (Get-NestedValue -Object $operatorSessionReceipt -Path @('review', 'outputs', 'receiptPath'))
+    if ([string]::IsNullOrWhiteSpace($resolvedReviewReceiptPath) -and (Test-Path -LiteralPath $reviewProjectionReceiptPath -PathType Leaf)) {
+      $resolvedReviewReceiptPath = $reviewProjectionReceiptPath
+    }
+    if (-not [string]::IsNullOrWhiteSpace($resolvedReviewReceiptPath) -and (Test-Path -LiteralPath $resolvedReviewReceiptPath -PathType Leaf)) {
+      $reviewProjectionReceipt = Read-JsonFile -Path $resolvedReviewReceiptPath
     }
 
-    $targetFinalStatus = if ($null -ne $localFastLoopReceipt) { Get-OptionalString -Value $localFastLoopReceipt.summary.finalStatus } else { 'failed' }
+    $targetFinalStatus = if ($null -ne $reviewProjectionReceipt) { Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'finalStatus')) } else { Get-OptionalString -Value (Get-NestedValue -Object $operatorSessionReceipt -Path @('finalStatus')) }
     if ([string]::IsNullOrWhiteSpace($targetFinalStatus)) {
-      $targetFinalStatus = if ($null -ne $publicRunReceipt) { [string]$publicRunReceipt.summary.finalStatus } else { 'failed' }
+      $targetFinalStatus = 'failed'
     }
-    $targetFinalReason = if ($null -ne $localFastLoopReceipt) { Get-OptionalString -Value $localFastLoopReceipt.summary.finalReason } else { 'local-fast-loop-failed' }
+    $targetFinalReason = if ($null -ne $reviewProjectionReceipt) { Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'finalReason')) } else { Get-OptionalString -Value (Get-NestedValue -Object $operatorSessionReceipt -Path @('failure', 'stage')) }
     if ([string]::IsNullOrWhiteSpace($targetFinalReason)) {
-      $targetFinalReason = if ($null -ne $publicRunReceipt) { [string]$publicRunReceipt.summary.finalReason } else { 'local-fast-loop-failed' }
+      $targetFinalReason = 'local-operator-session-failed'
     }
     if ($null -ne $caughtException -and [string]::IsNullOrWhiteSpace($targetFinalReason)) {
-      $targetFinalReason = 'local-fast-loop-failed'
+      $targetFinalReason = 'local-operator-session-failed'
     }
 
     $manifestTargets.Add([ordered]@{
@@ -964,17 +1131,17 @@ if ($discoveryStatus -eq 'ready') {
         changeStatus = [string]$selectedTarget.changeStatus
         finalStatus = $targetFinalStatus
         finalReason = $targetFinalReason
-        requestPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.requestPath })
-        publicRunPath = $publicRunPath
-        sharedEvidencePath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.sharedEvidencePath })
-        historySummaryJsonPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.historySummaryJson })
-        manifestPath = Get-OptionalString -Value $(if ($null -eq $publicRunReceipt) { $null } else { $publicRunReceipt.outputs.manifestPath })
-        historyReportMdPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.historyReportMd })
-        historyReportHtmlPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.historyReportHtml })
-        modeSummaryJsonPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.modeSummaryJsonPath })
-        modeSummaryPath = Get-OptionalString -Value $(if ($null -eq $localFastLoopReceipt) { $null } else { $localFastLoopReceipt.outputs.modeSummaryPath })
-        totalProcessed = if ($null -eq $publicRunReceipt -or $null -eq $publicRunReceipt.summary.totalProcessed) { $null } else { [int]$publicRunReceipt.summary.totalProcessed }
-        totalDiffs = if ($null -eq $publicRunReceipt -or $null -eq $publicRunReceipt.summary.totalDiffs) { $null } else { [int]$publicRunReceipt.summary.totalDiffs }
+        requestPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'requestPath'))
+        publicRunPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'publicRunPath'))
+        sharedEvidencePath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'sharedEvidencePath'))
+        historySummaryJsonPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'historySummaryJsonPath'))
+        manifestPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'manifestPath'))
+        historyReportMdPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'historyReportMdPath'))
+        historyReportHtmlPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'historyReportHtmlPath'))
+        modeSummaryJsonPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'modeSummaryJsonPath'))
+        modeSummaryPath = Get-OptionalString -Value (Get-NestedValue -Object $reviewProjectionReceipt -Path @('projections', 'modeSummaryPath'))
+        totalProcessed = $(if ($null -eq (Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'totalProcessed'))) { $null } else { [int](Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'totalProcessed')) })
+        totalDiffs = $(if ($null -eq (Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'totalDiffs'))) { $null } else { [int](Get-NestedValue -Object $reviewProjectionReceipt -Path @('summary', 'totalDiffs')) })
       }) | Out-Null
   }
 
@@ -1035,16 +1202,25 @@ $publicStepSummaryPathValue = Get-OptionalString -Value $prRunReceipt.outputs.pu
 $indexMarkdownPathValue = Get-OptionalString -Value $prRunReceipt.outputs.indexMarkdownPath
 $indexHtmlPathValue = Get-OptionalString -Value $prRunReceipt.outputs.indexHtmlPath
 $reviewBundlePathValue = Join-Path $resultsDirResolved 'review-bundle.json'
-$normalizedRuntimeReceipts = @(
-  $runtimeReceipts |
+$normalizedOperatorSessionReceipts = @(
+  $operatorSessionReceipts |
     ForEach-Object { ConvertTo-ObjectArray -Value $_ } |
     ForEach-Object { $_ }
 )
-$runtimeImages = @($normalizedRuntimeReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'runtime') -PropertyName 'image') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$runtimeToolSources = @($normalizedRuntimeReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'runtime') -PropertyName 'toolSource') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$runtimeReuseStates = @($normalizedRuntimeReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'runtime') -PropertyName 'cacheReuseState') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$runtimeTemperatureClasses = @($normalizedRuntimeReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'runtime') -PropertyName 'coldWarmClass') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
-$runtimeWarmDirs = @($normalizedRuntimeReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'runtime') -PropertyName 'warmRuntimeDir') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$normalizedLocalRefinementReceipts = @(
+  $normalizedOperatorSessionReceipts |
+    ForEach-Object { Get-OptionalPropertyValue -InputObject $_ -PropertyName 'localRefinement' } |
+    Where-Object { $null -ne $_ }
+)
+$runtimeImages = @($normalizedLocalRefinementReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'image') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$runtimeToolSources = @($normalizedLocalRefinementReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'toolSource') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$runtimeReuseStates = @($normalizedLocalRefinementReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'cacheReuseState') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$runtimeTemperatureClasses = @($normalizedLocalRefinementReceipts | ForEach-Object { Get-OptionalString -Value (Get-OptionalPropertyValue -InputObject $_ -PropertyName 'coldWarmClass') } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$operatorSessionPaths = @($normalizedOperatorSessionReceipts | ForEach-Object { Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('artifacts', 'sessionPath')) } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$localRefinementReceiptPaths = @($normalizedOperatorSessionReceipts | ForEach-Object { Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('artifacts', 'localRefinementPath')) } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$benchmarkPaths = @($normalizedOperatorSessionReceipts | ForEach-Object { Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('artifacts', 'benchmarkPath')) } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$reviewReceiptPaths = @($normalizedOperatorSessionReceipts | ForEach-Object { Get-OptionalString -Value (Get-NestedValue -Object $_ -Path @('artifacts', 'reviewReceiptPath')) } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
+$runtimeWarmDirs = @()
 
 $consumerReceipt = [ordered]@{
   repositoryRoot = $consumerRootResolved
@@ -1087,6 +1263,17 @@ $outputReceipt = [ordered]@{
   indexHtmlPath = $indexHtmlPathValue
 }
 
+$operatorSessionReceipt = [ordered]@{
+  facadeSchema = if ($normalizedOperatorSessionReceipts.Count -eq 0) { $null } else { 'comparevi-tools/local-operator-session-facade@v1' }
+  toolingRoot = if ($null -eq $compareVITooling) { $null } else { [string]$compareVITooling.root }
+  toolingSource = $toolingSource
+  toolingRef = $effectiveCompareviRef
+  sessionPaths = @($operatorSessionPaths)
+  localRefinementReceiptPaths = @($localRefinementReceiptPaths)
+  benchmarkPaths = @($benchmarkPaths)
+  reviewReceiptPaths = @($reviewReceiptPaths)
+}
+
 $summaryReceipt = [ordered]@{
   changedViCount = $changedViFiles.Count
   selectedTargetCount = $selectedTargets.Count
@@ -1116,6 +1303,7 @@ $localReceipt = [ordered]@{
   consumer = $consumerReceipt
   invocation = $invocationReceipt
   runtime = $runtimeReceipt
+  operatorSession = $operatorSessionReceipt
   timings = $timingsReceipt
   compiler = $compilerInfo
   projections = $projectionReceipt
@@ -1138,6 +1326,9 @@ $localReceipt = [ordered]@{
   ('- Runtime image: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$runtimeReceipt.image)) { 'n/a' } else { [string]$runtimeReceipt.image }))
   ('- Runtime cache reuse: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$runtimeReceipt.cacheReuseState)) { 'n/a' } else { [string]$runtimeReceipt.cacheReuseState }))
   ('- Runtime cold/warm class: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$runtimeReceipt.coldWarmClass)) { 'n/a' } else { [string]$runtimeReceipt.coldWarmClass }))
+  ('- Operator session tooling root: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$operatorSessionReceipt.toolingRoot)) { 'n/a' } else { [string]$operatorSessionReceipt.toolingRoot }))
+  ('- Operator session tooling source: `{0}`' -f $(if ([string]::IsNullOrWhiteSpace([string]$operatorSessionReceipt.toolingSource)) { 'n/a' } else { [string]$operatorSessionReceipt.toolingSource }))
+  ('- Operator session receipts: `{0}`' -f $operatorSessionReceipt.sessionPaths.Count)
   ('- Elapsed seconds: `{0}`' -f [string]$timingsReceipt.elapsedSeconds)
   ('- Compiler source: `{0}`' -f [string]$compilerInfo.source)
   ('- Compiler executable: `{0}`' -f [string]$compilerInfo.executablePath)

--- a/scripts/Invoke-CompareVIHistoryLocalReviewHook.ps1
+++ b/scripts/Invoke-CompareVIHistoryLocalReviewHook.ps1
@@ -1,0 +1,482 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$ConsumerRepositoryRoot,
+  [Parameter(Mandatory = $true, Position = 1)]
+  [string]$TargetId,
+  [Parameter(Mandatory = $true, Position = 2)]
+  [string]$TargetPath,
+  [Parameter(Position = 3)]
+  [string]$SourceBranchRef,
+  [Parameter(Mandatory = $true, Position = 4)]
+  [string]$ConsumerRepository,
+  [Parameter(Mandatory = $true, Position = 5)]
+  [string]$ConsumerRef,
+  [Parameter(Mandatory = $true, Position = 6)]
+  [string]$RequestedModes,
+  [Parameter(Position = 7)]
+  [string]$RequestedModeSource = 'pr-policy',
+  [Parameter(Position = 8)]
+  [string]$TargetSource = 'dynamic-path',
+  [Parameter(Position = 9)]
+  [string]$CurrentPath,
+  [Parameter(Position = 10)]
+  [string]$PreviousPath,
+  [Parameter(Position = 11)]
+  [string]$ChangeStatus = 'modified',
+  [Parameter(Position = 12)]
+  [AllowNull()]$KeepArtifactsOnNoDiff = $false
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Get-OptionalString {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return $stringValue.Trim()
+}
+
+function ConvertTo-NormalizedModeList {
+  param([Parameter(Mandatory = $true)][string]$Value)
+
+  $modes = New-Object System.Collections.Generic.List[string]
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($segment in @($Value -split '[,;]')) {
+    $trimmed = Get-OptionalString -Value $segment
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+      continue
+    }
+
+    $normalized = $trimmed.ToLowerInvariant()
+    if ($seen.Add($normalized)) {
+      $modes.Add($normalized) | Out-Null
+    }
+  }
+
+  if ($modes.Count -eq 0) {
+    throw 'RequestedModes must resolve to at least one explicit public mode.'
+  }
+
+  return @($modes | ForEach-Object { $_ })
+}
+
+function Read-JsonFile {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $raw = Get-Content -LiteralPath $Path -Raw
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    throw "JSON file was empty: $Path"
+  }
+
+  return $raw | ConvertFrom-Json -Depth 100
+}
+
+function Get-OptionalPropertyValue {
+  param(
+    [AllowNull()]$InputObject,
+    [Parameter(Mandatory = $true)][string]$PropertyName,
+    $Default = $null
+  )
+
+  if ($null -eq $InputObject) {
+    return $Default
+  }
+
+  $property = $InputObject.PSObject.Properties[$PropertyName]
+  if ($null -eq $property) {
+    return $Default
+  }
+
+  return $property.Value
+}
+
+function Get-NestedValue {
+  param(
+    [AllowNull()]$Object,
+    [Parameter(Mandatory = $true)][string[]]$Path,
+    $Default = $null
+  )
+
+  $current = $Object
+  foreach ($segment in $Path) {
+    if ($null -eq $current) {
+      return $Default
+    }
+
+    if ($current -is [System.Collections.IDictionary]) {
+      if (-not $current.Contains($segment)) {
+        return $Default
+      }
+
+      $current = $current[$segment]
+      continue
+    }
+
+    $property = $current.PSObject.Properties[$segment]
+    if ($null -eq $property) {
+      return $Default
+    }
+
+    $current = $property.Value
+  }
+
+  if ($null -eq $current) {
+    return $Default
+  }
+
+  return $current
+}
+
+function Resolve-FirstExistingFile {
+  param([Parameter(Mandatory = $true)][string[]]$Candidates)
+
+  foreach ($candidate in $Candidates) {
+    if (-not [string]::IsNullOrWhiteSpace($candidate) -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+      return [System.IO.Path]::GetFullPath($candidate)
+    }
+  }
+
+  return $null
+}
+
+function Get-OptionalInt {
+  param([AllowNull()]$Value)
+
+  if ($null -eq $Value) {
+    return $null
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $null
+  }
+
+  return [int]$stringValue
+}
+
+function ConvertTo-NormalizedBoolean {
+  param(
+    [AllowNull()]$Value,
+    [bool]$Default = $false
+  )
+
+  if ($null -eq $Value) {
+    return $Default
+  }
+
+  if ($Value -is [bool]) {
+    return [bool]$Value
+  }
+
+  $stringValue = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($stringValue)) {
+    return $Default
+  }
+
+  switch ($stringValue.Trim().ToLowerInvariant()) {
+    'true' { return $true }
+    'false' { return $false }
+    '1' { return $true }
+    '0' { return $false }
+    'yes' { return $true }
+    'no' { return $false }
+    default { throw "Unsupported boolean value '$stringValue'." }
+  }
+}
+
+function Get-HistoryMetric {
+  param(
+    [AllowNull()]$HistorySummary,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  foreach ($path in @(
+      @('summary', $Name),
+      @('totals', $Name),
+      @($Name)
+    )) {
+    $value = Get-NestedValue -Object $HistorySummary -Path $path
+    $intValue = Get-OptionalInt -Value $value
+    if ($null -ne $intValue) {
+      return $intValue
+    }
+  }
+
+  return $null
+}
+
+$consumerRootResolved = Resolve-AbsolutePath -Path $ConsumerRepositoryRoot -BasePath (Get-Location).Path
+$localRefinementReceiptPath = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_RECEIPT_PATH
+if ([string]::IsNullOrWhiteSpace($localRefinementReceiptPath) -or -not (Test-Path -LiteralPath $localRefinementReceiptPath -PathType Leaf)) {
+  throw 'COMPAREVI_LOCAL_REFINEMENT_RECEIPT_PATH must point to a valid comparevi/local-refinement@v1 receipt.'
+}
+
+$localRefinementReceipt = Read-JsonFile -Path $localRefinementReceiptPath
+if ([string]$localRefinementReceipt.schema -ne 'comparevi/local-refinement@v1') {
+  throw "Unsupported local refinement receipt schema in '$localRefinementReceiptPath': $($localRefinementReceipt.schema)"
+}
+
+$localRefinementResultsRoot = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_RESULTS_ROOT
+if ([string]::IsNullOrWhiteSpace($localRefinementResultsRoot)) {
+  $localRefinementResultsRoot = Get-OptionalString -Value $localRefinementReceipt.resultsRoot
+}
+if ([string]::IsNullOrWhiteSpace($localRefinementResultsRoot)) {
+  throw 'Local review hook could not resolve the local refinement results root.'
+}
+$localRefinementResultsRoot = Resolve-AbsolutePath -Path $localRefinementResultsRoot -BasePath (Get-Location).Path
+
+$reviewReceiptPath = Get-OptionalString -Value $env:COMPAREVI_REVIEW_RECEIPT_PATH
+if ([string]::IsNullOrWhiteSpace($reviewReceiptPath)) {
+  $reviewReceiptPath = Join-Path $localRefinementResultsRoot 'local-target-review.json'
+} else {
+  $reviewReceiptPath = Resolve-AbsolutePath -Path $reviewReceiptPath -BasePath (Get-Location).Path
+}
+$reviewReceiptParent = Split-Path -Parent $reviewReceiptPath
+if (-not [string]::IsNullOrWhiteSpace($reviewReceiptParent)) {
+  New-Item -ItemType Directory -Path $reviewReceiptParent -Force | Out-Null
+}
+
+$requestedModeList = ConvertTo-NormalizedModeList -Value $RequestedModes
+$keepArtifactsOnNoDiffValue = ConvertTo-NormalizedBoolean -Value $KeepArtifactsOnNoDiff
+$historyArtifactsRoot = $null
+foreach ($candidateRoot in @(
+    (Join-Path $localRefinementResultsRoot 'vi-history-report' 'results'),
+    (Join-Path $localRefinementResultsRoot 'results'),
+    $localRefinementResultsRoot
+  )) {
+  if (Test-Path -LiteralPath $candidateRoot -PathType Container) {
+    $historyArtifactsRoot = [System.IO.Path]::GetFullPath($candidateRoot)
+    break
+  }
+}
+
+if ($null -eq $historyArtifactsRoot) {
+  throw "Local review hook could not find history artifacts under '$localRefinementResultsRoot'."
+}
+
+$suiteManifestPath = Resolve-FirstExistingFile -Candidates @(
+  (Join-Path $historyArtifactsRoot 'suite-manifest.json'),
+  (Join-Path $historyArtifactsRoot 'manifest.json')
+)
+if ([string]::IsNullOrWhiteSpace($suiteManifestPath)) {
+  throw "Local review hook could not find suite-manifest.json under '$historyArtifactsRoot'."
+}
+
+$historySummaryJsonPath = Resolve-FirstExistingFile -Candidates @(
+  (Join-Path $historyArtifactsRoot 'history-summary.json')
+)
+$historyReportMdPath = Resolve-FirstExistingFile -Candidates @(
+  (Join-Path $historyArtifactsRoot 'history-report.md')
+)
+$historyReportHtmlPath = Resolve-FirstExistingFile -Candidates @(
+  (Join-Path $historyArtifactsRoot 'history-report.html')
+)
+
+$historySummary = $null
+if (-not [string]::IsNullOrWhiteSpace($historySummaryJsonPath)) {
+  try {
+    $historySummary = Read-JsonFile -Path $historySummaryJsonPath
+  } catch {
+    $historySummary = $null
+  }
+}
+
+$suiteManifest = Read-JsonFile -Path $suiteManifestPath
+$modeCount = $requestedModeList.Count
+$totalProcessed = Get-HistoryMetric -HistorySummary $historySummary -Name 'totalProcessed'
+$totalDiffs = Get-HistoryMetric -HistorySummary $historySummary -Name 'totalDiffs'
+if ($null -eq $totalProcessed -or $null -eq $totalDiffs) {
+  $firstModeEntry = @(Get-NestedValue -Object $suiteManifest -Path @('modes') -Default @()) | Select-Object -First 1
+  $firstModeManifestPath = if ($null -eq $firstModeEntry) { $null } else { Get-OptionalString -Value $firstModeEntry.manifestPath }
+  if (-not [string]::IsNullOrWhiteSpace($firstModeManifestPath)) {
+    $firstModeManifestPath = Resolve-AbsolutePath -Path $firstModeManifestPath -BasePath (Split-Path -Parent $suiteManifestPath)
+    if (Test-Path -LiteralPath $firstModeManifestPath -PathType Leaf) {
+      $firstModeManifest = Read-JsonFile -Path $firstModeManifestPath
+      $comparisonCount = @($firstModeManifest.comparisons).Count
+      if ($null -eq $totalProcessed) {
+        $totalProcessed = $comparisonCount
+      }
+      if ($null -eq $totalDiffs) {
+        $totalDiffs = $comparisonCount
+      }
+    }
+  }
+}
+
+$finalStatus = Get-OptionalString -Value $localRefinementReceipt.finalStatus
+if ([string]::IsNullOrWhiteSpace($finalStatus)) {
+  $finalStatus = 'succeeded'
+}
+$finalReason = if ($finalStatus -eq 'succeeded') { 'completed' } else { 'local-refinement-failed' }
+
+$publicRoot = Join-Path $localRefinementResultsRoot 'public'
+New-Item -ItemType Directory -Path $publicRoot -Force | Out-Null
+$requestPath = Join-Path $publicRoot 'request.json'
+$publicRunPath = Join-Path $publicRoot 'public-run.json'
+$publicCommentPath = Join-Path $publicRoot 'comment.md'
+$publicStepSummaryPath = Join-Path $publicRoot 'step-summary.md'
+$operatorSessionPath = Get-OptionalString -Value $env:COMPAREVI_LOCAL_OPERATOR_SESSION_PATH
+
+$request = [ordered]@{
+  schema = 'comparevi-history/request@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  consumer = [ordered]@{
+    repository = $ConsumerRepository
+    ref = $ConsumerRef
+    repositoryRoot = $consumerRootResolved
+  }
+  targetSpec = $null
+  target = [ordered]@{
+    id = $TargetId
+    path = $TargetPath
+    requestedModes = @($requestedModeList)
+    publicModes = @($requestedModeList)
+  }
+  history = [ordered]@{
+    startRef = $ConsumerRef
+    endRef = $null
+    sourceBranchRef = $SourceBranchRef
+    maxBranchCommits = $null
+    maxPairs = $null
+    maxSignalPairs = $null
+    noisePolicy = 'include'
+    resultsDir = $historyArtifactsRoot
+    renderReport = $true
+    reportFormat = 'html'
+    failFast = $false
+    failOnDiff = $false
+    quiet = $false
+    detailed = $true
+    keepArtifactsOnNoDiff = $keepArtifactsOnNoDiffValue
+    includeMergeParents = $false
+    compareTimeoutSeconds = $null
+  }
+  reviewerSurface = [ordered]@{
+    kind = 'none'
+    issueNumber = $null
+    pullRequestNumber = $null
+    isFork = $null
+    containerImage = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_IMAGE
+  }
+  results = [ordered]@{
+    resultsDir = $historyArtifactsRoot
+    publicRoot = $publicRoot
+    requestPath = $requestPath
+    publicRunPath = $publicRunPath
+    publicCommentPath = $publicCommentPath
+    publicStepSummaryPath = $publicStepSummaryPath
+  }
+}
+$request | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $requestPath -Encoding utf8
+
+$publicRun = [ordered]@{
+  schema = 'comparevi-history/public-run@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  requestPath = $requestPath
+  request = $request
+  backend = [ordered]@{
+    repository = $null
+    ref = $null
+    toolingPath = $null
+    toolingSource = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_TOOL_SOURCE
+    historyFacadeSchema = 'comparevi-tools/history-facade@v1'
+    localRefinementSchema = [string]$localRefinementReceipt.schema
+    localOperatorSessionPath = $operatorSessionPath
+    historySummaryPath = $historySummaryJsonPath
+    diagnosticsRendererPath = $null
+  }
+  outputs = [ordered]@{
+    resultsDir = $historyArtifactsRoot
+    manifestPath = $suiteManifestPath
+    historySummaryJson = $historySummaryJsonPath
+    historyReportMd = $historyReportMdPath
+    historyReportHtml = $historyReportHtmlPath
+    modeSummaryPath = $null
+    modeSummaryJsonPath = $null
+    publicCommentPath = $null
+    publicStepSummaryPath = $null
+  }
+  summary = [ordered]@{
+    modeCount = $modeCount
+    requestedModes = @($requestedModeList)
+    executedModes = @($requestedModeList)
+    totalProcessed = $totalProcessed
+    totalDiffs = $totalDiffs
+    stopReason = 'completed'
+    finalStatus = $finalStatus
+    finalReason = $finalReason
+  }
+  replay = [ordered]@{
+    status = if ($null -ne $historySummary) { 'ready' } else { 'not-available' }
+    reason = if ($null -ne $historySummary) { 'history-summary-present' } else { 'history-summary-missing' }
+  }
+}
+$publicRun | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $publicRunPath -Encoding utf8
+
+$reviewReceipt = [ordered]@{
+  schema = 'comparevi-history/local-target-review@v1'
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  target = [ordered]@{
+    targetId = $TargetId
+    targetSource = $TargetSource
+    targetPath = $TargetPath
+    requestedModes = @($requestedModeList)
+    requestedModeSource = $RequestedModeSource
+    sourceBranchRef = $SourceBranchRef
+    keepArtifactsOnNoDiff = $keepArtifactsOnNoDiffValue
+    currentPath = Get-OptionalString -Value $CurrentPath
+    previousPath = Get-OptionalString -Value $PreviousPath
+    changeStatus = $ChangeStatus
+  }
+  runtime = [ordered]@{
+    profile = Get-OptionalString -Value $env:COMPAREVI_RUNTIME_PROFILE
+    image = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_IMAGE
+    toolSource = Get-OptionalString -Value $env:COMPAREVI_LOCAL_REFINEMENT_TOOL_SOURCE
+    localRefinementReceiptPath = $localRefinementReceiptPath
+    localRefinementResultsRoot = $localRefinementResultsRoot
+    operatorSessionPath = $operatorSessionPath
+  }
+  projections = [ordered]@{
+    requestPath = $requestPath
+    publicRunPath = $publicRunPath
+    sharedEvidencePath = $null
+    historySummaryJsonPath = $historySummaryJsonPath
+    manifestPath = $suiteManifestPath
+    historyReportMdPath = $historyReportMdPath
+    historyReportHtmlPath = $historyReportHtmlPath
+    modeSummaryJsonPath = $null
+    modeSummaryPath = $null
+  }
+  summary = [ordered]@{
+    modeCount = $modeCount
+    totalProcessed = $totalProcessed
+    totalDiffs = $totalDiffs
+    finalStatus = $finalStatus
+    finalReason = $finalReason
+  }
+}
+$reviewReceipt | ConvertTo-Json -Depth 32 | Set-Content -LiteralPath $reviewReceiptPath -Encoding utf8

--- a/scripts/Test-CompareVIHistoryLocalReview.ps1
+++ b/scripts/Test-CompareVIHistoryLocalReview.ps1
@@ -27,19 +27,27 @@ function Write-FakeCompareHistoryTooling {
   param([Parameter(Mandatory = $true)][string]$DestinationRoot)
 
   $toolsDir = Join-Path $DestinationRoot 'tools'
-  New-Item -ItemType Directory -Path $toolsDir -Force | Out-Null
-  @'
-param(
-  [string]$TargetPath,
-  [string]$StartRef,
-  [string]$ResultsDir,
-  [string]$Mode,
-  [string]$InvokeScriptPath,
-  [string]$GitHubOutputPath
-)
+  $moduleDir = Join-Path $toolsDir 'CompareVI.Tools'
+  New-Item -ItemType Directory -Path $moduleDir -Force | Out-Null
 
+  @'
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$BasePath
+  )
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return [System.IO.Path]::GetFullPath($Path)
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
 
 function New-ReportFixture {
   param(
@@ -130,145 +138,297 @@ $attributeDetails
   }
 }
 
-if ([string]::IsNullOrWhiteSpace($InvokeScriptPath) -or -not (Test-Path -LiteralPath $InvokeScriptPath -PathType Leaf)) {
-  throw 'InvokeScriptPath must point to an existing adapter script.'
-}
-
-New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
-$suiteManifestPath = Join-Path $ResultsDir 'manifest.json'
-$historySummaryPath = Join-Path $ResultsDir 'history-summary.json'
-$historyReportMd = Join-Path $ResultsDir 'history-report.md'
-$historyReportHtml = Join-Path $ResultsDir 'history-report.html'
-
-$modeEntries = New-Object System.Collections.Generic.List[object]
-$requestedModes = @($Mode -split '[,;\s]+' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-foreach ($modeName in $requestedModes) {
-  $modeRoot = Join-Path $ResultsDir $modeName
-  New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
-  $modeManifestPath = Join-Path $modeRoot 'manifest.json'
-  $comparisons = @(
-    (New-ReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 1),
-    (New-ReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 2)
+function Write-HistoryFixture {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResultsRoot,
+    [Parameter(Mandatory = $true)]
+    [string[]]$RequestedModes,
+    [Parameter(Mandatory = $true)]
+    [string]$TargetPath,
+    [Parameter(Mandatory = $true)]
+    [string]$StartRef
   )
 
-  ([ordered]@{
-      schema = 'vi-compare/history@v1'
-      generatedAt = '2026-03-18T00:00:00Z'
-      mode = $modeName
-      comparisons = $comparisons
-      stats = [ordered]@{
-        categoryCounts = [ordered]@{ attributes = 2 }
-        bucketCounts = [ordered]@{ 'metadata-rich' = 1; 'logic-motion' = 1 }
-      }
-    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
+  $historyResultsRoot = Join-Path $ResultsRoot 'vi-history-report' 'results'
+  New-Item -ItemType Directory -Path $historyResultsRoot -Force | Out-Null
+  $suiteManifestPath = Join-Path $historyResultsRoot 'suite-manifest.json'
+  $historySummaryPath = Join-Path $historyResultsRoot 'history-summary.json'
+  $historyReportMd = Join-Path $historyResultsRoot 'history-report.md'
+  $historyReportHtml = Join-Path $historyResultsRoot 'history-report.html'
 
-  $modeEntries.Add([ordered]@{
-      name = $modeName
-      manifestPath = $modeManifestPath
-      processed = 2
-      diffs = 2
-      signalDiffs = 2
-      noiseCollapsed = 0
-      errors = 0
-      status = 'ok'
-      stopReason = 'completed'
-      flags = @()
-      categoryCounts = [ordered]@{ attributes = 2 }
-      bucketCounts = [ordered]@{ 'metadata-rich' = 1; 'logic-motion' = 1 }
-    }) | Out-Null
-}
+  $modeEntries = New-Object System.Collections.Generic.List[object]
+  foreach ($modeName in $RequestedModes) {
+    $modeRoot = Join-Path $historyResultsRoot $modeName
+    New-Item -ItemType Directory -Path $modeRoot -Force | Out-Null
+    $modeManifestPath = Join-Path $modeRoot 'manifest.json'
+    $comparisons = @(
+      (New-ReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 1),
+      (New-ReportFixture -ModeRoot $modeRoot -ModeName $modeName -ComparisonIndex 2)
+    )
 
-([ordered]@{
-    schema = 'vi-compare/history-suite@v1'
-    generatedAt = '2026-03-18T00:00:00Z'
-    modes = @($modeEntries | ForEach-Object {
-        [ordered]@{
-          name = $_.name
-          manifestPath = $_.manifestPath
+    ([ordered]@{
+        schema = 'vi-compare/history@v1'
+        generatedAt = '2026-03-18T00:00:00Z'
+        mode = $modeName
+        comparisons = $comparisons
+        stats = [ordered]@{
+          categoryCounts = [ordered]@{ attributes = 2 }
+          bucketCounts = [ordered]@{ 'metadata-rich' = 1; 'logic-motion' = 1 }
         }
-      })
-  } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $suiteManifestPath -Encoding utf8
+      } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $modeManifestPath -Encoding utf8
 
-([ordered]@{
-    schema = 'comparevi-tools/history-facade@v1'
-    targetPath = $TargetPath
-    startRef = $StartRef
-    invokeScriptPath = $InvokeScriptPath
-  } | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $historySummaryPath -Encoding utf8
-'# local history report' | Set-Content -LiteralPath $historyReportMd -Encoding utf8
-'<html><body>local history report</body></html>' | Set-Content -LiteralPath $historyReportHtml -Encoding utf8
-
-@(
-  "target-path=$TargetPath"
-  "manifest-path=$suiteManifestPath"
-  "results-dir=$ResultsDir"
-  "history-summary-json=$historySummaryPath"
-  "history-report-md=$historyReportMd"
-  "history-report-html=$historyReportHtml"
-  "mode-count=$($requestedModes.Count)"
-  'total-processed=2'
-  'total-diffs=2'
-  'stop-reason=completed'
-  'category-counts-json={}'
-  'bucket-counts-json={}'
-  ("mode-manifests-json={0}" -f (($modeEntries.ToArray() | ConvertTo-Json -Depth 16 -Compress)))
-  ("requested-mode-list={0}" -f ($requestedModes -join ','))
-  ("executed-mode-list={0}" -f ($requestedModes -join ','))
-  ("mode-list={0}" -f ($requestedModes -join ','))
-  'flag-list='
-) | Set-Content -LiteralPath $GitHubOutputPath -Encoding utf8
-'@ | Set-Content -LiteralPath (Join-Path $toolsDir 'Compare-VIHistory.ps1') -Encoding utf8
-
-@'
-param([string]$Tag = 'comparevi-vi-history-dev:local')
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-@{
-  tag = $Tag
-  status = 'built'
-} | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path (Split-Path -Parent $PSCommandPath) 'build-vi-history-dev-image.json') -Encoding utf8
-'@ | Set-Content -LiteralPath (Join-Path $toolsDir 'Build-VIHistoryDevImage.ps1') -Encoding utf8
-
-@'
-param(
-  [string]$Action = 'status',
-  [string]$RepoRoot,
-  [string]$ResultsRoot,
-  [string]$RuntimeDir,
-  [string]$Image = 'comparevi-vi-history-dev:local'
-)
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-
-$payload = [ordered]@{
-  schema = 'comparevi/local-runtime-state@v1'
-  generatedAt = '2026-03-19T00:00:00Z'
-  action = $Action
-  outcome = 'reused'
-  image = $Image
-  container = [ordered]@{
-    name = 'comparevi-history-test-runtime'
+    $modeEntries.Add([ordered]@{
+        name = $modeName
+        manifestPath = $modeManifestPath
+      }) | Out-Null
   }
-  mounts = [ordered]@{
-    repoHostPath = $RepoRoot
-    repoContainerPath = '/opt/comparevi/source'
-    resultsHostPath = $ResultsRoot
-    resultsContainerPath = '/opt/comparevi/vi-history/results'
+
+  ([ordered]@{
+      schema = 'vi-compare/history-suite@v1'
+      generatedAt = '2026-03-18T00:00:00Z'
+      modes = @($modeEntries | ForEach-Object {
+          [ordered]@{
+            name = $_.name
+            manifestPath = $_.manifestPath
+          }
+        })
+    } | ConvertTo-Json -Depth 64) | Set-Content -LiteralPath $suiteManifestPath -Encoding utf8
+
+  ([ordered]@{
+      schema = 'comparevi-tools/history-facade@v1'
+      targetPath = $TargetPath
+      startRef = $StartRef
+      summary = [ordered]@{
+        totalProcessed = 2
+        totalDiffs = 2
+      }
+    } | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $historySummaryPath -Encoding utf8
+  '# local history report' | Set-Content -LiteralPath $historyReportMd -Encoding utf8
+  '<html><body>local history report</body></html>' | Set-Content -LiteralPath $historyReportHtml -Encoding utf8
+
+  return [ordered]@{
+    resultsRoot = $historyResultsRoot
+    manifestPath = $suiteManifestPath
+    historySummaryJsonPath = $historySummaryPath
+    historyReportMdPath = $historyReportMd
+    historyReportHtmlPath = $historyReportHtml
   }
-  runtimeDir = $RuntimeDir
 }
-$payload | ConvertTo-Json -Depth 16
-'@ | Set-Content -LiteralPath (Join-Path $toolsDir 'Manage-VIHistoryRuntimeInDocker.ps1') -Encoding utf8
 
-([ordered]@{
-    schema = 'comparevi-tools-release-manifest@v1'
+function Invoke-CompareVIHistoryLocalOperatorSessionFacade {
+  [CmdletBinding()]
+  param(
+    [ValidateSet('proof', 'dev-fast', 'warm-dev')]
+    [string]$Profile = 'dev-fast',
+    [string]$RepoRoot = '',
+    [string]$HistoryTargetPath = 'fixtures/vi-attr/Head.vi',
+    [string]$HistoryBranchRef = 'HEAD',
+    [string]$HistoryBaselineRef = '',
+    [string]$ResultsRoot = '',
+    [string]$WarmRuntimeDir = '',
+    [string]$ProofImage = 'nationalinstruments/labview:2026q1-linux',
+    [string]$DevImage = 'comparevi-vi-history-dev:local',
+    [string]$ReviewCommandPath = '',
+    [string[]]$ReviewCommandArguments = @(),
+    [string]$ReviewWorkingDirectory = '',
+    [string]$ReviewReceiptPath = '',
+    [string]$SessionManifestPath = '',
+    [switch]$SkipDevImageBuild
+  )
+
+  $resolvedRepoRoot = if ([string]::IsNullOrWhiteSpace($RepoRoot)) { (Get-Location).Path } else { $RepoRoot }
+  $resolvedResultsRoot = if ([string]::IsNullOrWhiteSpace($ResultsRoot)) {
+    Join-Path $resolvedRepoRoot ('tests/results/local-vi-history/{0}' -f $Profile)
+  } else {
+    $ResultsRoot
+  }
+  New-Item -ItemType Directory -Path $resolvedResultsRoot -Force | Out-Null
+
+  $requestedModeLine = $ReviewCommandArguments | Where-Object { $_ -like 'attributes*' -or $_ -like 'front-panel*' -or $_ -like 'block-diagram*' } | Select-Object -First 1
+  $requestedModes = if ([string]::IsNullOrWhiteSpace($requestedModeLine)) {
+    @('attributes', 'front-panel', 'block-diagram')
+  } else {
+    @($requestedModeLine -split '[,;]' | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  }
+
+  $historyFixture = Write-HistoryFixture -ResultsRoot $resolvedResultsRoot -RequestedModes $requestedModes -TargetPath $HistoryTargetPath -StartRef $HistoryBranchRef
+  [ordered]@{
+    schema = 'comparevi-review-suite-summary@v1'
     generatedAt = '2026-03-19T00:00:00Z'
-    consumerContract = [ordered]@{
-      hostedNiLinuxRunner = [ordered]@{
-        defaultImage = 'nationalinstruments/labview:2026q1-linux'
+    image = $(if ($Profile -eq 'proof') { $ProofImage } else { $DevImage })
+    scenarios = @(
+      [ordered]@{
+        name = 'vi-history-report'
+        historySummaryPath = $historyFixture.historySummaryJsonPath
+      }
+    )
+  } | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath (Join-Path $resolvedResultsRoot 'review-suite-summary.json') -Encoding utf8
+
+  $cacheReuseState = switch ($Profile) {
+    'proof' { 'canonical-proof-image' }
+    'warm-dev' { 'warm-runtime-reused' }
+    default { 'existing-local-image' }
+  }
+  $coldWarmClass = switch ($Profile) {
+    'proof' { 'cold' }
+    'warm-dev' { 'warm' }
+    default { 'warm' }
+  }
+  $imageUsed = if ($Profile -eq 'proof') { $ProofImage } else { $DevImage }
+  $toolSource = if ($Profile -eq 'proof') { 'canonical-proof-image' } else { 'local-dev-image' }
+  $localRefinementReceiptPath = Join-Path $resolvedResultsRoot 'local-refinement.json'
+  $benchmarkPath = Join-Path $resolvedResultsRoot 'local-refinement-benchmark.json'
+  $sessionPath = if ([string]::IsNullOrWhiteSpace($SessionManifestPath)) {
+    Join-Path $resolvedResultsRoot 'local-operator-session.json'
+  } else {
+    $SessionManifestPath
+  }
+  $reviewReceiptResolved = if ([string]::IsNullOrWhiteSpace($ReviewReceiptPath)) {
+    Join-Path $resolvedResultsRoot 'local-target-review.json'
+  } else {
+    $ReviewReceiptPath
+  }
+
+  ([ordered]@{
+      schema = 'comparevi/local-refinement@v1'
+      generatedAt = '2026-03-19T00:00:00Z'
+      runtimeProfile = $Profile
+      image = $imageUsed
+      toolSource = $toolSource
+      cacheReuseState = $cacheReuseState
+      coldWarmClass = $coldWarmClass
+      benchmarkSampleKind = if ($Profile -eq 'warm-dev') { 'warm-dev-repeat' } elseif ($Profile -eq 'proof') { 'proof-cold' } else { 'dev-fast-repeat' }
+      repoRoot = $resolvedRepoRoot
+      resultsRoot = $resolvedResultsRoot
+      timings = [ordered]@{
+        elapsedMilliseconds = 1200
+        elapsedSeconds = 1.2
+      }
+      finalStatus = 'succeeded'
+    } | ConvertTo-Json -Depth 16) | Set-Content -LiteralPath $localRefinementReceiptPath -Encoding utf8
+
+  ([ordered]@{
+      schema = 'comparevi/local-refinement-benchmark@v1'
+      generatedAt = '2026-03-19T00:00:01Z'
+      latest = [ordered]@{}
+      selectedSamples = [ordered]@{}
+      comparisons = [ordered]@{}
+    } | ConvertTo-Json -Depth 16) | Set-Content -LiteralPath $benchmarkPath -Encoding utf8
+
+  $reviewStatus = 'not-requested'
+  if (-not [string]::IsNullOrWhiteSpace($ReviewCommandPath)) {
+    $reviewWorkingDirectoryResolved = if ([string]::IsNullOrWhiteSpace($ReviewWorkingDirectory)) { $resolvedRepoRoot } else { $ReviewWorkingDirectory }
+    $envState = @{}
+    foreach ($name in @(
+        'COMPAREVI_RUNTIME_PROFILE',
+        'COMPAREVI_LOCAL_REFINEMENT_RECEIPT_PATH',
+        'COMPAREVI_LOCAL_REFINEMENT_BENCHMARK_PATH',
+        'COMPAREVI_LOCAL_REFINEMENT_RESULTS_ROOT',
+        'COMPAREVI_LOCAL_OPERATOR_SESSION_PATH',
+        'COMPAREVI_LOCAL_REFINEMENT_IMAGE',
+        'COMPAREVI_LOCAL_REFINEMENT_TOOL_SOURCE',
+        'COMPAREVI_REVIEW_RECEIPT_PATH'
+      )) {
+      $existingItem = Get-Item ("Env:{0}" -f $name) -ErrorAction SilentlyContinue
+      $envState[$name] = if ($null -eq $existingItem) { $null } else { $existingItem.Value }
+    }
+
+    try {
+      $env:COMPAREVI_RUNTIME_PROFILE = $Profile
+      $env:COMPAREVI_LOCAL_REFINEMENT_RECEIPT_PATH = $localRefinementReceiptPath
+      $env:COMPAREVI_LOCAL_REFINEMENT_BENCHMARK_PATH = $benchmarkPath
+      $env:COMPAREVI_LOCAL_REFINEMENT_RESULTS_ROOT = $resolvedResultsRoot
+      $env:COMPAREVI_LOCAL_OPERATOR_SESSION_PATH = $sessionPath
+      $env:COMPAREVI_LOCAL_REFINEMENT_IMAGE = $imageUsed
+      $env:COMPAREVI_LOCAL_REFINEMENT_TOOL_SOURCE = $toolSource
+      $env:COMPAREVI_REVIEW_RECEIPT_PATH = $reviewReceiptResolved
+      Push-Location $reviewWorkingDirectoryResolved
+      try {
+        & $ReviewCommandPath @ReviewCommandArguments
+        if ($LASTEXITCODE -ne 0) {
+          throw ("Review hook failed with exit code {0}." -f $LASTEXITCODE)
+        }
+      } finally {
+        Pop-Location | Out-Null
+      }
+      $reviewStatus = 'succeeded'
+    } finally {
+      foreach ($entry in $envState.GetEnumerator()) {
+        if ($null -eq $entry.Value) {
+          Remove-Item ("Env:{0}" -f $entry.Key) -ErrorAction SilentlyContinue
+        } else {
+          Set-Item ("Env:{0}" -f $entry.Key) -Value $entry.Value
+        }
       }
     }
-  } | ConvertTo-Json -Depth 16) | Set-Content -LiteralPath (Join-Path $DestinationRoot 'comparevi-tools-release.json') -Encoding utf8
+  }
+
+  $receipt = [ordered]@{
+    schema = 'comparevi-tools/local-operator-session-facade@v1'
+    generatedAtUtc = '2026-03-19T00:00:02Z'
+    backendReceiptSchema = 'comparevi/local-operator-session@v1'
+    runtimeProfile = $Profile
+    repoRoot = $resolvedRepoRoot
+    resultsRoot = $resolvedResultsRoot
+    localRefinement = [ordered]@{
+      schema = 'comparevi/local-refinement@v1'
+      receiptPath = $localRefinementReceiptPath
+      benchmarkPath = $benchmarkPath
+      image = $imageUsed
+      toolSource = $toolSource
+      cacheReuseState = $cacheReuseState
+      coldWarmClass = $coldWarmClass
+      finalStatus = 'succeeded'
+    }
+    review = [ordered]@{
+      status = $reviewStatus
+      commandPath = $ReviewCommandPath
+      workingDirectory = if ([string]::IsNullOrWhiteSpace($ReviewWorkingDirectory)) { $resolvedRepoRoot } else { $ReviewWorkingDirectory }
+      outputs = [ordered]@{
+        receiptPath = $reviewReceiptResolved
+        reviewBundlePath = $null
+        workspaceHtmlPath = $null
+        workspaceMarkdownPath = $null
+        previewManifestPath = $null
+        runPath = $null
+      }
+    }
+    artifacts = [ordered]@{
+      sessionPath = $sessionPath
+      localRefinementPath = $localRefinementReceiptPath
+      benchmarkPath = $benchmarkPath
+      reviewReceiptPath = $reviewReceiptResolved
+    }
+    finalStatus = 'succeeded'
+  }
+
+  $receipt | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $sessionPath -Encoding utf8
+  return [pscustomobject]$receipt
+}
+
+Export-ModuleMember -Function Invoke-CompareVIHistoryLocalOperatorSessionFacade
+'@ | Set-Content -LiteralPath (Join-Path $moduleDir 'CompareVI.Tools.psm1') -Encoding utf8
+
+  @'
+@{
+  RootModule = 'CompareVI.Tools.psm1'
+  ModuleVersion = '9.9.9'
+  GUID = '9e64db64-9484-4b9d-96df-3aa1b44d90d0'
+  PowerShellVersion = '7.0'
+  FunctionsToExport = @('Invoke-CompareVIHistoryLocalOperatorSessionFacade')
+}
+'@ | Set-Content -LiteralPath (Join-Path $moduleDir 'CompareVI.Tools.psd1') -Encoding utf8
+
+  ([ordered]@{
+      schema = 'comparevi-tools-release-manifest@v1'
+      generatedAt = '2026-03-19T00:00:00Z'
+      consumerContract = [ordered]@{
+        hostedNiLinuxRunner = [ordered]@{
+          defaultImage = 'nationalinstruments/labview:2026q1-linux'
+        }
+      }
+    } | ConvertTo-Json -Depth 16) | Set-Content -LiteralPath (Join-Path $DestinationRoot 'comparevi-tools-release.json') -Encoding utf8
 }
 
 try {
@@ -336,6 +496,18 @@ try {
   if ([string]$explicitReceipt.invocation.containerImage -ne 'comparevi-vi-history-dev:local') {
     throw 'Explicit local-review should preserve the selected accelerated container image.'
   }
+  if ([string]$explicitReceipt.operatorSession.facadeSchema -ne 'comparevi-tools/local-operator-session-facade@v1') {
+    throw 'Explicit local-review should record the operator-session facade schema.'
+  }
+  if ([string]$explicitReceipt.operatorSession.toolingSource -ne 'provided-tooling-root') {
+    throw 'Explicit local-review should record the provided tooling root source.'
+  }
+  if ([string]$explicitReceipt.operatorSession.toolingRoot -ne $toolingRoot) {
+    throw 'Explicit local-review should record the resolved tooling root.'
+  }
+  if (@($explicitReceipt.operatorSession.sessionPaths).Count -ne 1 -or @($explicitReceipt.operatorSession.reviewReceiptPaths).Count -ne 1) {
+    throw 'Explicit local-review should record one operator-session receipt and one review-hook receipt.'
+  }
   if ([string]$explicitReceipt.runtime.image -ne 'comparevi-vi-history-dev:local') {
     throw 'Explicit local-review should use the selected accelerated dev image.'
   }
@@ -396,6 +568,9 @@ try {
 
   if ([string]$changedReceipt.consumer.selectionMode -ne 'git-diff') {
     throw 'Changed local-review selection mode mismatch.'
+  }
+  if ([string]$changedReceipt.operatorSession.facadeSchema -ne 'comparevi-tools/local-operator-session-facade@v1') {
+    throw 'Changed local-review should record the operator-session facade schema.'
   }
   if ([string]$changedReceipt.invocation.runtimeProfile -ne 'warm-dev' -or
     [string]$changedReceipt.runtime.profile -ne 'warm-dev') {


### PR DESCRIPTION
## Summary
- wire `Invoke-CompareVIHistoryLocalReview.ps1` onto the CompareVI.Tools operator-session facade
- add a local review hook that projects operator-session history outputs into comparevi-history review inputs
- extend the local-review contract and focused tests to cover operator-session receipts and review hook projection

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryLocalReview.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryLocalProof.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryAutomaticPullRequestRun.ps1`
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryTemplateContracts.ps1`
- `git diff --check`

Closes #181
