### PR TITLE
Honor docker override in local VI history fast loop

### DIFF
--- a/scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1
+++ b/scripts/Invoke-CompareVIHistoryManualExplorationFastLoop.ps1
@@ -142,12 +142,62 @@ function Resolve-ToolingMetadata {
   return Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json -Depth 32
 }
 
+function Resolve-DockerCommandSource {
+  $override = $env:DOCKER_COMMAND_OVERRIDE
+  if (-not [string]::IsNullOrWhiteSpace($override) -and (Test-Path -LiteralPath $override -PathType Leaf)) {
+    return [System.IO.Path]::GetFullPath($override)
+  }
+
+  $pathSeparator = [System.IO.Path]::PathSeparator
+  $pathEntries = @($env:PATH -split [regex]::Escape([string]$pathSeparator))
+  $candidates = if ($IsWindows) {
+    @('docker.exe', 'docker.cmd', 'docker.ps1', 'docker.bat', 'docker')
+  } else {
+    @('docker', 'docker.sh', 'docker.exe', 'docker.ps1', 'docker.cmd')
+  }
+
+  foreach ($entry in $pathEntries) {
+    if ([string]::IsNullOrWhiteSpace($entry)) { continue }
+    foreach ($name in $candidates) {
+      $candidatePath = Join-Path $entry $name
+      if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+        return [System.IO.Path]::GetFullPath($candidatePath)
+      }
+    }
+  }
+
+  $command = Get-Command -Name 'docker' -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($null -eq $command -or [string]::IsNullOrWhiteSpace([string]$command.Source)) {
+    return $null
+  }
+
+  return [System.IO.Path]::GetFullPath([string]$command.Source)
+}
+
+function Invoke-DockerCommand {
+  param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+  $dockerCommandSource = Resolve-DockerCommandSource
+  if ([string]::IsNullOrWhiteSpace($dockerCommandSource)) {
+    throw 'docker was not found on PATH and DOCKER_COMMAND_OVERRIDE is not set.'
+  }
+
+  $dockerCommandExtension = [System.IO.Path]::GetExtension($dockerCommandSource)
+  if ([System.StringComparer]::OrdinalIgnoreCase.Equals($dockerCommandExtension, '.ps1')) {
+    & pwsh -NoLogo -NoProfile -File $dockerCommandSource @Arguments | Out-Null
+  } else {
+    & $dockerCommandSource @Arguments | Out-Null
+  }
+
+  return $LASTEXITCODE
+}
+
 function Test-DockerImageExists {
   param([Parameter(Mandatory = $true)][string]$ImageName)
 
   try {
-    & docker image inspect $ImageName *> $null
-    return ($LASTEXITCODE -eq 0)
+    $exitCode = Invoke-DockerCommand -Arguments @('image', 'inspect', $ImageName)
+    return ($exitCode -eq 0)
   } catch {
     return $false
   }
@@ -156,13 +206,8 @@ function Test-DockerImageExists {
 function Invoke-DockerPull {
   param([Parameter(Mandatory = $true)][string]$Image)
 
-  $dockerCommand = Get-Command docker -ErrorAction SilentlyContinue
-  if ($null -eq $dockerCommand) {
-    throw "docker was not found on PATH, but the local fast loop requires it to pre-pull '$Image'."
-  }
-
-  & $dockerCommand.Source pull $Image
-  if ($LASTEXITCODE -ne 0) {
+  $exitCode = Invoke-DockerCommand -Arguments @('pull', $Image)
+  if ($exitCode -ne 0) {
     throw "docker pull failed for image '$Image'."
   }
 }

--- a/scripts/Test-CompareVIHistoryManualExplorationFastLoop.ps1
+++ b/scripts/Test-CompareVIHistoryManualExplorationFastLoop.ps1
@@ -278,6 +278,86 @@ $ErrorActionPreference = 'Stop'
     throw 'Local fast loop must surface capture/image metadata.'
   }
 
+  $dockerStubDir = Join-Path $tempRoot 'docker-stub'
+  $dockerStubLog = Join-Path $dockerStubDir 'docker-log.ndjson'
+  $dockerStubPullMarker = Join-Path $dockerStubDir 'pulled.txt'
+  New-Item -ItemType Directory -Path $dockerStubDir -Force | Out-Null
+  @'
+param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+$logPath = [System.Environment]::GetEnvironmentVariable('DOCKER_STUB_LOG', 'Process')
+if (-not [string]::IsNullOrWhiteSpace($logPath)) {
+  ([ordered]@{ args = @($Args) } | ConvertTo-Json -Compress) | Add-Content -LiteralPath $logPath -Encoding utf8
+}
+
+$pullMarker = [System.Environment]::GetEnvironmentVariable('DOCKER_STUB_PULL_MARKER', 'Process')
+if ($Args.Count -ge 2 -and $Args[0] -eq 'pull') {
+  if (-not [string]::IsNullOrWhiteSpace($pullMarker)) {
+    'pulled' | Set-Content -LiteralPath $pullMarker -Encoding utf8
+  }
+  Write-Output $Args[1]
+  exit 0
+}
+
+if ($Args.Count -ge 3 -and $Args[0] -eq 'image' -and $Args[1] -eq 'inspect') {
+  if (-not [string]::IsNullOrWhiteSpace($pullMarker) -and (Test-Path -LiteralPath $pullMarker -PathType Leaf)) {
+    Write-Output '[]'
+    exit 0
+  }
+  exit 1
+}
+
+exit 0
+'@ | Set-Content -LiteralPath (Join-Path $dockerStubDir 'docker-override.ps1') -Encoding utf8
+
+  $savedDockerOverride = $env:DOCKER_COMMAND_OVERRIDE
+  $savedDockerStubLog = $env:DOCKER_STUB_LOG
+  $savedDockerStubPullMarker = $env:DOCKER_STUB_PULL_MARKER
+  try {
+    Set-Item Env:DOCKER_COMMAND_OVERRIDE (Join-Path $dockerStubDir 'docker-override.ps1')
+    Set-Item Env:DOCKER_STUB_LOG $dockerStubLog
+    Set-Item Env:DOCKER_STUB_PULL_MARKER $dockerStubPullMarker
+
+    $proofResultsDir = Join-Path $tempRoot 'results-proof-override'
+    $proofReceiptJson = & $scriptPath `
+      -ConsumerRepositoryRoot $consumerRoot `
+      -ViPath 'Tooling/deployment/VIP_Pre-Install Custom Action.vi' `
+      -ConsumerRef 'HEAD' `
+      -ResultsDir $proofResultsDir `
+      -ToolingRoot $toolingRoot
+
+    $proofReceipt = $proofReceiptJson | ConvertFrom-Json -Depth 20
+    if (-not $proofReceipt.tooling.imagePulled) {
+      throw 'Proof-profile local fast loop must report imagePulled when using the docker override path.'
+    }
+    if (-not (Test-Path -LiteralPath $dockerStubPullMarker -PathType Leaf)) {
+      throw 'Docker override pull marker was not written.'
+    }
+    $dockerLogLines = @(Get-Content -LiteralPath $dockerStubLog | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($dockerLogLines.Count -eq 0) {
+      throw 'Docker override log is empty.'
+    }
+    $dockerCalls = @($dockerLogLines | ForEach-Object { $_ | ConvertFrom-Json })
+    if (@($dockerCalls | Where-Object { $_.args[0] -eq 'pull' }).Count -lt 1) {
+      throw 'Local fast loop did not pre-pull through DOCKER_COMMAND_OVERRIDE.'
+    }
+  } finally {
+    if ([string]::IsNullOrWhiteSpace($savedDockerOverride)) {
+      Remove-Item Env:DOCKER_COMMAND_OVERRIDE -ErrorAction SilentlyContinue
+    } else {
+      Set-Item Env:DOCKER_COMMAND_OVERRIDE $savedDockerOverride
+    }
+    if ([string]::IsNullOrWhiteSpace($savedDockerStubLog)) {
+      Remove-Item Env:DOCKER_STUB_LOG -ErrorAction SilentlyContinue
+    } else {
+      Set-Item Env:DOCKER_STUB_LOG $savedDockerStubLog
+    }
+    if ([string]::IsNullOrWhiteSpace($savedDockerStubPullMarker)) {
+      Remove-Item Env:DOCKER_STUB_PULL_MARKER -ErrorAction SilentlyContinue
+    } else {
+      Set-Item Env:DOCKER_STUB_PULL_MARKER $savedDockerStubPullMarker
+    }
+  }
+
   $devFastResultsDir = Join-Path $tempRoot 'results-dev-fast'
   $devFastReceiptJson = & $scriptPath `
     -ConsumerRepositoryRoot $consumerRoot `


### PR DESCRIPTION
## Summary
- honor `DOCKER_COMMAND_OVERRIDE` for proof-profile image inspect and pull in the local fast loop
- add a regression that proves image pre-pull goes through the override path
- keep the canonical `VIP_Pre-Install Custom Action.vi` proof runnable on this machine without relying on raw `docker` lookup

## Validation
- `pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryManualExplorationFastLoop.ps1`
- local canonical proof succeeded for `Tooling/deployment/VIP_Pre-Install Custom Action.vi`
