### PR TITLE
test: align public-run proof with pinned backend ref

### DIFF
--- a/scripts/Test-CompareVIHistoryPublicRun.ps1
+++ b/scripts/Test-CompareVIHistoryPublicRun.ps1
@@ -2,10 +2,16 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $scriptPath = Join-Path $PSScriptRoot 'Write-CompareVIHistoryPublicRun.ps1'
+$compareviRefPath = Join-Path $PSScriptRoot '..' 'comparevi-backend-ref.txt'
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("comparevi-history-public-run-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
 
 try {
+  $compareviRef = (Get-Content -LiteralPath $compareviRefPath -Raw).Trim()
+  if ([string]::IsNullOrWhiteSpace($compareviRef)) {
+    throw "comparevi-backend-ref.txt must contain the repo-pinned backend release tag."
+  }
+
   $repoRoot = Join-Path $tempRoot 'consumer'
   $resultsRoot = Join-Path $repoRoot 'tests/results/ref-compare/history'
   $publicRoot = Join-Path $resultsRoot 'public'
@@ -158,7 +164,7 @@ $lines -join "`n"
     -RequestPath (Join-Path $publicRoot 'request.json') `
     -ToolingRoot $toolingRoot `
     -CompareviRepository 'LabVIEW-Community-CI-CD/compare-vi-cli-action' `
-    -CompareviRef 'v0.6.11' `
+    -CompareviRef $compareviRef `
     -ToolingSource 'bundle' `
     -ActionRef 'LabVIEW-Community-CI-CD/comparevi-history@v1' `
     -HistorySummaryJson (Join-Path $resultsRoot 'history-summary.json') `
@@ -230,7 +236,7 @@ $lines -join "`n"
     -RequestPath (Join-Path $publicRoot 'request.json') `
     -ToolingRoot $toolingRoot `
     -CompareviRepository 'LabVIEW-Community-CI-CD/compare-vi-cli-action' `
-    -CompareviRef 'v0.6.11' `
+    -CompareviRef $compareviRef `
     -ToolingSource 'bundle' `
     -ModeSummaryJsonPath $modeSummaryJsonPath `
     -ModeSummaryPath $modeSummaryPath `


### PR DESCRIPTION
## Summary
- make the public-run proof fixture read the repo-pinned backend ref from comparevi-backend-ref.txt
- remove the hard-coded v0.6.11 backend tag from the success and failure test invocations
- keep the released facade test aligned with future backend repins instead of requiring manual tag edits

## Validation
- pwsh -NoLogo -NoProfile -File scripts/Test-CompareVIHistoryPublicRun.ps1
- git diff --check

## Why
The CompareVI system design benchmark promoted baseline-1 on the released comparevi-history v1.3.27 / compare-vi-cli-action v0.6.12 pair, but it recorded one remaining internal drift: comparevi-backend-ref.txt pins v0.6.12 while this proof fixture still invoked v0.6.11. This change removes that mismatch at the source.