### PR TITLE
chore: stamp comparevi-history published templates for v1.3.28

### DIFF
--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -191,4 +191,3 @@ Consumer repositories should not contain:
 7. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
    comments on a trusted hosted runner.
 8. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
-

--- a/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
+++ b/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md
@@ -132,7 +132,7 @@ Consumer repositories should not contain:
   `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/pull-request-diagnostics-canary-evaluate.yml@v1`. It
   exists so a same-repo `workflow_run` can evaluate the publication artifact, confirm the PR is an `agent-canary`
   draft lane, and fail closed without re-running execution or checking out candidate PR code.
-- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.27`. That is the right default when
+- The comment-gated template uses `LabVIEW-Community-CI-CD/comparevi-history@v1.3.28`. That is the right default when
   you want the public PR diagnostics surface frozen to a known immutable release. The release workflow updates that
   immutable pin as part of publish so the published example stays aligned to the latest reviewed immutable tag.
 - The automatic changed-VI execution template keeps the checked-in PR policy and hosted NI Linux adapter on the pull
@@ -191,3 +191,4 @@ Consumer repositories should not contain:
 7. Add the comment-gated template only after you are comfortable letting maintainers trigger diagnostics from PR
    comments on a trusted hosted runner.
 8. If you need stricter reproducibility, replace `@v1` with the latest immutable tag after each reviewed release.
+

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -23,7 +23,7 @@ jobs:
       DEFAULT_COMPARE_MODES: attributes,front-panel,block-diagram
       DEFAULT_MAX_PAIRS: '5'
       DEFAULT_MAX_SIGNAL_PAIRS: '5'
-      FACADE_REF: v1.3.27
+      FACADE_REF: v1.3.28
       COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.27
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.3.28
         with:
           target_spec_path: .github/comparevi-history-targets.json
           target_id: ${{ steps.request.outputs['target-id'] }}
@@ -146,7 +146,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.27
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.3.28
           COMMENT_PATH: ${{ steps.history.outputs['public-comment-path'] }}
         run: |
           Set-StrictMode -Version Latest
@@ -187,3 +187,4 @@ jobs:
               ('- PR comment publication: `skipped` ({0})' -f $warning)
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
+

--- a/docs/examples/comparevi-history-comment-gated.yml
+++ b/docs/examples/comparevi-history-comment-gated.yml
@@ -71,7 +71,6 @@ jobs:
             'User-Agent' = 'comparevi-history-template'
             'X-GitHub-Api-Version' = '2022-11-28'
           }
-
           $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/pulls/$env:ISSUE_NUMBER"
           $pr = Invoke-RestMethod -Uri $uri -Headers $headers
           if ($pr.state -ne 'open') {
@@ -187,4 +186,3 @@ jobs:
               ('- PR comment publication: `skipped` ({0})' -f $warning)
             ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
-


### PR DESCRIPTION
## Summary
- stamp the published comment-gated template refs for 
- align the immutable template docs with the next facade release

## Validation
- 
- 
- {
  "schema": "comparevi-history/release-publish-readiness@v1",
  "generatedAtUtc": "2026-04-01T17:48:08.1261499Z",
  "repoRoot": "/tmp/comparevi-history",
  "backendTag": "v0.6.12",
  "immutableTag": "v1.3.28",
  "currentBackendRef": "v0.6.12",
  "releaseContentReady": true,
  "preparationRequired": false,
  "changedFileCount": 0,
  "changedFiles": [],
  "preparationHint": null
}
- 